### PR TITLE
updated java download links in start scripts.

### DIFF
--- a/src/packaging/bin/diagnostics.bat
+++ b/src/packaging/bin/diagnostics.bat
@@ -116,7 +116,7 @@ fsutil dirty query %systemdrive% >nul
 exit /b
 
 :NOJAVA
-  echo You do not have the Java Runtime Environment installed, please install Java JRE from java.com/en/download and try again.
+  echo You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again.
 
 :EXIT
   pause

--- a/src/packaging/bin/diagnostics.sh
+++ b/src/packaging/bin/diagnostics.sh
@@ -99,5 +99,5 @@ if hash java 2>/dev/null; then
     fi
 
 else
-    echo You do not have the Java Runtime Environment installed, please install Java JRE from java.com/en/download and try again.
+    echo You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again.
 fi

--- a/src/packaging/bin/run.bat
+++ b/src/packaging/bin/run.bat
@@ -117,7 +117,7 @@ fsutil dirty query %systemdrive% >nul
 exit /b
 
 :NOJAVA
-  echo You do not have the Java Runtime Environment installed, please install Java JRE from java.com/en/download and try again.
+  echo You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again.
 
 :EXIT
   pause

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -98,6 +98,6 @@ if hash java 2>/dev/null; then
     fi
 
 else
-    echo You do not have the Java Runtime Environment installed, please install Java JRE from java.com/en/download and try again.
+    echo You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again.
     exit 1
 fi


### PR DESCRIPTION
**Motivation**
java download links in start scripts are outdated.
**Changes**
changed the links from java.com to adoptopenjdk.net.