### PR TITLE
improve topic tree performance on add

### DIFF
--- a/src/main/java/com/hivemq/mqtt/topic/tree/NodeUtils.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/NodeUtils.java
@@ -143,9 +143,9 @@ public class NodeUtils {
     public static int getChildrenCount(final @NotNull Node node) {
         checkNotNull(node, "Node must not be null");
 
-        //If the node has a children index, we don't need to count
-        if (node.childrenIndex != null) {
-            return node.childrenIndex.size();
+        //If the node has a children map instead of the array, we don't need to count
+        if (node.childrenMap != null) {
+            return node.childrenMap.size();
         }
 
         final Node[] children = node.getChildren();

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestRemoveSubscriberFromTopicInTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestRemoveSubscriberFromTopicInTopicTreeImpl.java
@@ -280,13 +280,13 @@ public class TestRemoveSubscriberFromTopicInTopicTreeImpl {
         topicTree.addTopic("subscriber3", new Topic("topic/topic2", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber4", new Topic("topic/topic3", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        assertEquals(3, topicTree.segments.get("topic").childrenIndex.size());
+        assertEquals(3, topicTree.segments.get("topic").getChildrenMap().size());
         topicTree.removeSubscriber("subscriber1", "topic/topic1", null);
-        assertEquals(3, topicTree.segments.get("topic").childrenIndex.size());
+        assertEquals(3, topicTree.segments.get("topic").getChildrenMap().size());
         topicTree.removeSubscriber("subscriber2", "topic/topic1", null);
-        assertEquals(2, topicTree.segments.get("topic").childrenIndex.size());
+        assertEquals(2, topicTree.segments.get("topic").getChildrenMap().size());
         topicTree.removeSubscriber("subscriber3", "topic/topic2", null);
-        assertEquals(1, topicTree.segments.get("topic").childrenIndex.size());
+        assertEquals(1, topicTree.segments.get("topic").getChildrenMap().size());
         topicTree.removeSubscriber("subscriber4", "topic/topic3", null);
         assertEquals(0, topicTree.segments.size());
     }
@@ -298,13 +298,13 @@ public class TestRemoveSubscriberFromTopicInTopicTreeImpl {
         topicTree.addTopic("subscriber3", new Topic("topic/topic1/part2", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber4", new Topic("topic/topic1/part3", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        assertEquals(3, topicTree.segments.get("topic").children[0].childrenIndex.size());
+        assertEquals(3, topicTree.segments.get("topic").children[0].getChildrenMap().size());
         topicTree.removeSubscriber("subscriber1", "topic/topic1/part1", null);
-        assertEquals(3, topicTree.segments.get("topic").children[0].childrenIndex.size());
+        assertEquals(3, topicTree.segments.get("topic").children[0].getChildrenMap().size());
         topicTree.removeSubscriber("subscriber2", "topic/topic1/part1", null);
-        assertEquals(2, topicTree.segments.get("topic").children[0].childrenIndex.size());
+        assertEquals(2, topicTree.segments.get("topic").children[0].getChildrenMap().size());
         topicTree.removeSubscriber("subscriber3", "topic/topic1/part2", null);
-        assertEquals(1, topicTree.segments.get("topic").children[0].childrenIndex.size());
+        assertEquals(1, topicTree.segments.get("topic").children[0].getChildrenMap().size());
         topicTree.removeSubscriber("subscriber4", "topic/topic1/part3", null);
         assertEquals(0, topicTree.segments.size());
     }


### PR DESCRIPTION
**Motivation**
Improve topic tree performance on subscription add when many topic filters start with the same prefix.

**Changes**
Repurpose the already existing index map of a topic tree node as children map. 