### PR TITLE
Add feature to iterate subscribers from extension system

### DIFF
--- a/src/extensionApi/java/com/hivemq/extension/sdk/api/annotations/ThreadSafe.java
+++ b/src/extensionApi/java/com/hivemq/extension/sdk/api/annotations/ThreadSafe.java
@@ -18,6 +18,7 @@ package com.hivemq.extension.sdk.api.annotations;
 
 import java.lang.annotation.*;
 
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
@@ -29,7 +30,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  */
 @Documented
 @Retention(CLASS)
-@Target({TYPE})
+@Target({TYPE, METHOD})
 public @interface ThreadSafe {
     String value() default "";
 }

--- a/src/extensionApi/java/com/hivemq/extension/sdk/api/services/general/IterationCallback.java
+++ b/src/extensionApi/java/com/hivemq/extension/sdk/api/services/general/IterationCallback.java
@@ -1,0 +1,23 @@
+package com.hivemq.extension.sdk.api.services.general;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.services.subscription.SubscriptionStore;
+
+/**
+ * A callback that can be passed to methods in extension stores (e.g. {@link SubscriptionStore}) to lazily iterate over
+ * a potentially large result set.
+ *
+ * @author Christoph Schäbel
+ * @since 4.2.0
+ */
+@FunctionalInterface
+public interface IterationCallback<T> {
+
+    /**
+     * This method is called for every result that is part of the iteration.
+     *
+     * @param context an {@link} IterationContext that allows for interaction with the overlaying iteration mechanism.
+     * @param value   the value for this single iteration.
+     */
+    void iterate(@NotNull IterationContext context, @NotNull T value);
+}

--- a/src/extensionApi/java/com/hivemq/extension/sdk/api/services/general/IterationContext.java
+++ b/src/extensionApi/java/com/hivemq/extension/sdk/api/services/general/IterationContext.java
@@ -1,0 +1,17 @@
+package com.hivemq.extension.sdk.api.services.general;
+
+/**
+ * @author Christoph Schäbel
+ * @since 4.2.0
+ */
+public interface IterationContext {
+
+    /**
+     * Aborts the iteration at the current step of the iteration.
+     * <p>
+     * No further callbacks will be executed and the result future will complete successfully as soon as the current
+     * iteration callback returns
+     */
+    void abortIteration();
+
+}

--- a/src/extensionApi/java/com/hivemq/extension/sdk/api/services/subscription/SubscriberForTopicResult.java
+++ b/src/extensionApi/java/com/hivemq/extension/sdk/api/services/subscription/SubscriberForTopicResult.java
@@ -1,0 +1,16 @@
+package com.hivemq.extension.sdk.api.services.subscription;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+/**
+ * @author Christoph Schäbel
+ * @since 4.2.0
+ */
+public interface SubscriberForTopicResult {
+
+    /**
+     * @return the subscribers MQTT client identifier
+     */
+    @NotNull
+    String getClientId();
+}

--- a/src/extensionApi/java/com/hivemq/extension/sdk/api/services/subscription/SubscriberWithFilterResult.java
+++ b/src/extensionApi/java/com/hivemq/extension/sdk/api/services/subscription/SubscriberWithFilterResult.java
@@ -1,0 +1,16 @@
+package com.hivemq.extension.sdk.api.services.subscription;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+/**
+ * @author Christoph Schäbel
+ * @since 4.2.0
+ */
+public interface SubscriberWithFilterResult {
+
+    /**
+     * @return the subscribers MQTT client identifier
+     */
+    @NotNull
+    String getClientId();
+}

--- a/src/extensionApi/java/com/hivemq/extension/sdk/api/services/subscription/SubscriptionType.java
+++ b/src/extensionApi/java/com/hivemq/extension/sdk/api/services/subscription/SubscriptionType.java
@@ -1,0 +1,25 @@
+package com.hivemq.extension.sdk.api.services.subscription;
+
+/**
+ * Enum to filter the subscriptions by type.
+ *
+ * @author Christoph Schäbel
+ * @since 4.2.0
+ */
+public enum SubscriptionType {
+
+    /**
+     * Include individual and shared subscriptions
+     */
+    ALL,
+
+    /**
+     * Only include individual subscriptions
+     */
+    INDIVIDUAL,
+
+    /**
+     * Only include shared subscriptions
+     */
+    SHARED
+}

--- a/src/main/java/com/hivemq/extensions/services/general/IterationContextImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/general/IterationContextImpl.java
@@ -1,0 +1,22 @@
+package com.hivemq.extensions.services.general;
+
+import com.hivemq.extension.sdk.api.services.general.IterationContext;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author Christoph Schäbel
+ */
+public class IterationContextImpl implements IterationContext {
+
+    private final AtomicBoolean aborted = new AtomicBoolean(false);
+
+    @Override
+    public void abortIteration() {
+        aborted.set(true);
+    }
+
+    public boolean isAborted() {
+        return aborted.get();
+    }
+}

--- a/src/main/java/com/hivemq/extensions/services/subscription/SubscriberForTopicResultImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/subscription/SubscriberForTopicResultImpl.java
@@ -1,0 +1,25 @@
+package com.hivemq.extensions.services.subscription;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.services.subscription.SubscriberForTopicResult;
+
+/**
+ * @author Christoph Schäbel
+ */
+public class SubscriberForTopicResultImpl implements SubscriberForTopicResult {
+
+    @NotNull
+    private final String clientId;
+
+    public SubscriberForTopicResultImpl(@NotNull final String clientId) {
+        this.clientId = clientId;
+    }
+
+    /**
+     * @return the subscribers MQTT client identifier
+     */
+    @NotNull
+    public String getClientId() {
+        return clientId;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/services/subscription/SubscriberWithFilterResultImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/subscription/SubscriberWithFilterResultImpl.java
@@ -1,0 +1,25 @@
+package com.hivemq.extensions.services.subscription;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.services.subscription.SubscriberWithFilterResult;
+
+/**
+ * @author Christoph Schäbel
+ */
+public class SubscriberWithFilterResultImpl implements SubscriberWithFilterResult {
+
+    @NotNull
+    private final String clientId;
+
+    public SubscriberWithFilterResultImpl(@NotNull final String clientId) {
+        this.clientId = clientId;
+    }
+
+    /**
+     * @return the subscribers MQTT client identifier
+     */
+    @NotNull
+    public String getClientId() {
+        return clientId;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImpl.java
@@ -246,6 +246,10 @@ public class SubscriptionStoreImpl implements SubscriptionStore {
                 Topics.isValidTopicToPublish(topic),
                 "Topic must be a valid topic and cannot contain wildcard characters, got '" + topic + "'");
 
+        if (rateLimitService.rateLimitExceeded()) {
+            return CompletableFuture.failedFuture(PluginServiceRateLimitService.RATE_LIMIT_EXCEEDED_EXCEPTION);
+        }
+
         final ImmutableSet<String> subscribers = topicTree.getSubscribersForTopic(topic, new SubscriptionTypeItemFilter(subscriptionType), false);
 
         final CompletableFuture<Void> iterationFinishedFuture = new CompletableFuture<>();
@@ -312,6 +316,9 @@ public class SubscriptionStoreImpl implements SubscriptionStore {
         Preconditions.checkNotNull(subscriptionType, "SubscriptionType cannot be null");
         Preconditions.checkArgument(Topics.isValidToSubscribe(topicFilter), "Topic filter must be a valid MQTT topic filter, got '" + topicFilter + "'");
 
+        if (rateLimitService.rateLimitExceeded()) {
+            return CompletableFuture.failedFuture(PluginServiceRateLimitService.RATE_LIMIT_EXCEEDED_EXCEPTION);
+        }
 
         final ImmutableSet<String> subscribers =
                 topicTree.getSubscribersWithFilter(topicFilter, new SubscriptionTypeItemFilter(subscriptionType));

--- a/src/main/java/com/hivemq/mqtt/topic/tree/LocalTopicTree.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/LocalTopicTree.java
@@ -25,13 +25,40 @@ import com.hivemq.mqtt.topic.SubscriberWithQoS;
 
 /**
  * @author Lukas Brandl
+ * @author Christoph Schäbel
  */
 public interface LocalTopicTree {
 
     boolean addTopic(@NotNull String subscriber, @NotNull Topic topic, byte flags, @Nullable String sharedGroup);
 
+    /**
+     * All subscribers for a topic (PUBLISH)
+     *
+     * @param topic the topic to publish to (no wildcards)
+     * @return the subscribers interested in this topic with all their identifiers
+     */
     @NotNull
     ImmutableSet<SubscriberWithIdentifiers> getSubscribers(@NotNull String topic);
+
+    /**
+     * All subscribers that have subscribed to this exact topic filter
+     *
+     * @param topicFilter the topic filter (including wildcards)
+     * @return the subscribers with a subscription with this topic filter
+     */
+    @NotNull
+    ImmutableSet<String> getSubscribersWithFilter(@NotNull String topicFilter, @NotNull ItemFilter itemFilter);
+
+    /**
+     * All subscribers that have a subscription matching this topic
+     *
+     * @param topic the topic to match (no wildcards)
+     * @param itemFilter
+     * @param excludeRootLevelWildcard
+     * @return the subscribers with a subscription for this topic
+     */
+    @NotNull
+    ImmutableSet<String> getSubscribersForTopic(@NotNull String topic, @NotNull ItemFilter itemFilter, boolean excludeRootLevelWildcard);
 
     @NotNull
     ImmutableSet<SubscriberWithIdentifiers> getSubscribers(@NotNull String topic, boolean excludeRootLevelWildcard);
@@ -66,4 +93,15 @@ public interface LocalTopicTree {
      */
     @Nullable
     SubscriberWithIdentifiers getSubscriber(@NotNull String client, @NotNull String topic);
+
+
+    interface ItemFilter {
+        /**
+         * is called for each subscriber that matches the specified topic / topic filter
+         *
+         * @param subscriber the current subscriber
+         * @return true if the current subscriber should be added to the result set, false if not
+         */
+        boolean checkItem(@NotNull final SubscriberWithQoS subscriber);
+    }
 }

--- a/src/main/java/com/hivemq/mqtt/topic/tree/SubscriptionTypeItemFilter.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/SubscriptionTypeItemFilter.java
@@ -1,0 +1,29 @@
+package com.hivemq.mqtt.topic.tree;
+
+import com.hivemq.annotations.NotNull;
+import com.hivemq.extension.sdk.api.services.subscription.SubscriptionType;
+import com.hivemq.mqtt.topic.SubscriberWithQoS;
+
+public class SubscriptionTypeItemFilter implements LocalTopicTree.ItemFilter {
+
+    @NotNull
+    private final SubscriptionType subscriptionType;
+
+    public SubscriptionTypeItemFilter(@NotNull final SubscriptionType subscriptionType) {
+        this.subscriptionType = subscriptionType;
+    }
+
+    @Override
+    public boolean checkItem(@NotNull final SubscriberWithQoS subscriber) {
+        switch (subscriptionType) {
+            case ALL:
+                return true;
+            case INDIVIDUAL:
+                return !subscriber.isSharedSubscription();
+            case SHARED:
+                return subscriber.isSharedSubscription();
+        }
+        //to support potential new types
+        return false;
+    }
+}

--- a/src/test/java/com/hivemq/extensions/services/general/IterationContextImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/general/IterationContextImplTest.java
@@ -1,0 +1,25 @@
+package com.hivemq.extensions.services.general;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Christoph Schäbel
+ */
+public class IterationContextImplTest {
+
+    @Test
+    public void test_abort() {
+
+        final IterationContextImpl iterationContext = new IterationContextImpl();
+
+        assertFalse(iterationContext.isAborted());
+
+        iterationContext.abortIteration();
+
+        assertTrue(iterationContext.isAborted());
+    }
+
+}

--- a/src/test/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImplTest.java
@@ -28,6 +28,7 @@ import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.services.exception.DoNotImplementException;
 import com.hivemq.extension.sdk.api.services.exception.InvalidTopicException;
 import com.hivemq.extension.sdk.api.services.exception.NoSuchClientIdException;
+import com.hivemq.extension.sdk.api.services.exception.RateLimitExceededException;
 import com.hivemq.extension.sdk.api.services.subscription.SubscriptionStore;
 import com.hivemq.extension.sdk.api.services.subscription.TopicSubscription;
 import com.hivemq.extensions.services.PluginServiceRateLimitService;
@@ -689,6 +690,31 @@ public class SubscriptionStoreImplTest {
         //test checks if the future does return with an exception if an exception is thrown in the iterate callback
         future.get();
     }
+
+    @Test(timeout = 10000, expected = RateLimitExceededException.class)
+    public void test_iterate_topic_filter_rate_limit_exceeded() throws Throwable {
+        when(rateLimitService.rateLimitExceeded()).thenReturn(true);
+
+        try {
+            subscriptionStore.iterateAllSubscribersWithTopicFilter("topic/#", (context, value) -> {
+            }).get();
+        } catch (final ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test(timeout = 10000, expected = RateLimitExceededException.class)
+    public void test_iterate_topic_rate_limit_exceeded() throws Throwable {
+        when(rateLimitService.rateLimitExceeded()).thenReturn(true);
+
+        try {
+            subscriptionStore.iterateAllSubscribersForTopic("topic", (context, value) -> {
+            }).get();
+        } catch (final ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+
 
     private static class TestSubscriptionImpl implements TopicSubscription {
 

--- a/src/test/java/com/hivemq/mqtt/topic/tree/SubscriptionTypeItemFilterTest.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/SubscriptionTypeItemFilterTest.java
@@ -1,0 +1,49 @@
+package com.hivemq.mqtt.topic.tree;
+
+import com.hivemq.extension.sdk.api.services.subscription.SubscriptionType;
+import com.hivemq.mqtt.topic.SubscriberWithQoS;
+import com.hivemq.mqtt.topic.SubscriptionFlags;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SubscriptionTypeItemFilterTest {
+
+    @Test
+    public void test_mode_all() {
+
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+        final byte individualFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        final SubscriptionTypeItemFilter itemFilter = new SubscriptionTypeItemFilter(SubscriptionType.ALL);
+
+        assertTrue(itemFilter.checkItem(new SubscriberWithQoS("client", 0, individualFlag, 0)));
+        assertTrue(itemFilter.checkItem(new SubscriberWithQoS("client", 0, sharedFlag, 0)));
+    }
+
+    @Test
+    public void test_mode_individual() {
+
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+        final byte individualFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        final SubscriptionTypeItemFilter itemFilter = new SubscriptionTypeItemFilter(SubscriptionType.INDIVIDUAL);
+
+        assertTrue(itemFilter.checkItem(new SubscriberWithQoS("client", 0, individualFlag, 0)));
+        assertFalse(itemFilter.checkItem(new SubscriberWithQoS("client", 0, sharedFlag, 0)));
+    }
+
+    @Test
+    public void test_mode_shared() {
+
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+        final byte individualFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        final SubscriptionTypeItemFilter itemFilter = new SubscriptionTypeItemFilter(SubscriptionType.SHARED);
+
+        assertFalse(itemFilter.checkItem(new SubscriberWithQoS("client", 0, individualFlag, 0)));
+        assertTrue(itemFilter.checkItem(new SubscriberWithQoS("client", 0, sharedFlag, 0)));
+    }
+
+}

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersFromTopicWithFilterTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersFromTopicWithFilterTopicTreeImpl.java
@@ -1,0 +1,406 @@
+package com.hivemq.mqtt.topic.tree;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.hivemq.annotations.NotNull;
+import com.hivemq.metrics.MetricsHolder;
+import com.hivemq.mqtt.message.QoS;
+import com.hivemq.mqtt.message.subscribe.Topic;
+import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
+import com.hivemq.mqtt.topic.SubscriberWithQoS;
+import com.hivemq.mqtt.topic.SubscriptionFlags;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author  Christoph Schäbel
+ */
+public class TestGetSubscribersFromTopicWithFilterTopicTreeImpl {
+
+
+    private TopicTreeImpl topicTree;
+
+    private Counter subscriptionCounter;
+    private Counter staleSubscriptionsCounter;
+
+    @Before
+    public void setUp() {
+        subscriptionCounter = new Counter();
+        staleSubscriptionsCounter = new Counter();
+        topicTree = new TopicTreeImpl(new MetricsHolder(new MetricRegistry()));
+
+    }
+
+    @Test
+    public void test_empty_topic_tree_get_subscribers() throws Exception {
+
+        final Set<SubscriberWithIdentifiers> any = topicTree.getSubscribers("any");
+        assertEquals(true, any.isEmpty());
+    }
+
+    @Test
+    public void test_empty_no_subscriber_for_topic() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("anothertopic", getMatchAllFilter(), false);
+        assertEquals(true, subscribers.isEmpty());
+    }
+
+    @Test
+    public void test_get_single_subscriber_for_topic() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_get_single_subscriber_for_topic_with_flags() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE, true, true), (byte) 12, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_multiple_subscribers_for_topic() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(2, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber", "subscriber2"));
+    }
+
+    @Test
+    public void test_same_subscriber_two_times_for_same_topic() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_same_subscriber_two_times_for_same_topic_different_flags() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE, true, true), (byte) 12, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_same_subscriber_two_times_for_same_topic_with_different_qos() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_root_wildcard_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_root_level_wildcard_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("+", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_two_level_wildcard_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("+/+", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic/level", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_root_level_wildcard_subscriber_with_wildcard() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("+/#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic/level", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_root_level_wildcard_multiple_subscribers_with_wildcard() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(3, subscribers.size());
+    }
+
+    @Test
+    public void test_subscriber_add_and_delete() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.removeSubscriber("subscriber", "topic", null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(0, subscribers.size());
+    }
+
+    @Test
+    public void test_subscriber_add_and_delete_multiple_topics_per_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+        topicTree.removeSubscriber("subscriber", "topic", null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(0, subscribers.size());
+    }
+
+
+
+    @Test
+    public void test_qos_subscriptions_multiple_subscribers() throws Exception {
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(2, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber", "subscriber2"));
+    }
+
+    @Test
+    public void test_multiple_subscribers_for_sys_topic() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("$SYS/topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("$SYS/topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("$SYS/topic", getMatchAllFilter(), false);
+        assertEquals(2, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber", "subscriber2"));
+    }
+
+    @Test
+    public void test_sys_topic_wildcard_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("$SYS/+", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("$SYS/topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_same_subscriber_for_same_topic_with_subscriber_map() throws Exception {
+
+        topicTree = new TopicTreeImpl(new MetricsHolder(new MetricRegistry()));
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_root_level_wildcard_multiple_subscribers_with_wildcard_with_subscriber_map() throws Exception {
+
+        topicTree = new TopicTreeImpl(new MetricsHolder(new MetricRegistry()));
+
+        topicTree.addTopic("subscriber", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(3, subscribers.size());
+    }
+
+    @Test
+    public void test_get_subscriber_from_index_map() throws Exception {
+        topicTree.addTopic("subscriber1", new Topic("this/topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("this/topic2", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("this/topic3", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("this/topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertEquals("subscriber1", subscribers.iterator().next());
+    }
+
+    @Test
+    public void test_get_topc_level_subscriber_from_index_map() throws Exception {
+        topicTree.addTopic("subscriber1", new Topic("topic1", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("topic2", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("topic3", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic1", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertEquals("subscriber1", subscribers.iterator().next());
+
+        final Set<String> subscribers2 = topicTree.getSubscribersForTopic("topic2", getMatchAllFilter(), false);
+        assertEquals(1, subscribers2.size());
+        assertEquals("subscriber2", subscribers2.iterator().next());
+
+        final Set<String> subscribers3 = topicTree.getSubscribersForTopic("topic3", getMatchAllFilter(), false);
+        assertEquals(1, subscribers3.size());
+        assertEquals("subscriber3", subscribers3.iterator().next());
+    }
+
+    @Test
+    public void test_get_wildcard_subscriber_from_index_map() throws Exception {
+        topicTree.addTopic("subscriber1", new Topic("this/+", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("this/topic2", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("this/topic3", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("this/topic1", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+        assertEquals("subscriber1", subscribers.iterator().next());
+    }
+
+    @Test
+    public void test_get_root_level_wildcard_subscriber() throws Exception {
+        topicTree.addTopic("subscriber1", new Topic("+/test", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("+/+", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber4", new Topic("test/+", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("a/test", getMatchAllFilter(), false);
+        assertEquals(3, subscribers.size());
+    }
+
+
+    @Test
+    public void get_shared_subscriber() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        topicTree.addTopic("sub1", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        topicTree.addTopic("sub2", new Topic("topic", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        topicTree.addTopic("sub3", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "group2");
+        topicTree.addTopic("sub4", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+
+        final Set<String> subscribers1 = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(4, subscribers1.size());
+
+        final Set<String> subscribers2 = topicTree.getSubscribersForTopic("topic", getSharedSubFilter(), false);
+        assertEquals(3, subscribers2.size());
+
+        final Set<String> subscribers2i = topicTree.getSubscribersForTopic("topic", getIndividualSubFilter(), false);
+        assertEquals(1, subscribers2i.size());
+    }
+
+    @Test
+    public void get_shared_subscriber_overlapping() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        topicTree.addTopic("sub1", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group1");
+        topicTree.addTopic("sub2", new Topic("#", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        topicTree.addTopic("sub1", new Topic("#", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(2, subscribers.size());
+
+        final Set<String> subscribers2 = topicTree.getSubscribersForTopic("topic", getSharedSubFilter(), false);
+        assertEquals(1, subscribers2.size());
+
+        final Set<String> subscribers3 = topicTree.getSubscribersForTopic("topic", getIndividualSubFilter(), false);
+        assertEquals(2, subscribers3.size());
+    }
+
+    @Test
+    public void get_shared_subscriber_with_same_id() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+
+        topicTree.addTopic("client", new Topic("topic/a", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        topicTree.addTopic("client", new Topic("topic/+", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        topicTree.addTopic("client", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic", getMatchAllFilter(), false);
+        assertEquals(1, subscribers.size());
+    }
+
+    @Test
+    public void get_subscriber() {
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+
+        topicTree.addTopic("client1", new Topic("topic/a", QoS.AT_MOST_ONCE), notSharedFlag, null);
+        topicTree.addTopic("client2", new Topic("topic/+", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        topicTree.addTopic("client3", new Topic("#", QoS.EXACTLY_ONCE), notSharedFlag, null);
+        topicTree.addTopic("client4", new Topic("topic/a", QoS.AT_MOST_ONCE), sharedFlag, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersForTopic("topic/a", getMatchAllFilter(), false);
+        assertEquals(4, subscribers.size());
+    }
+
+    @NotNull
+    public LocalTopicTree.ItemFilter getMatchAllFilter() {
+        return new LocalTopicTree.ItemFilter() {
+            @Override
+            public boolean checkItem(@NotNull final SubscriberWithQoS subscriber) {
+                return true;
+            }
+        };
+    }
+
+    @NotNull
+    public LocalTopicTree.ItemFilter getSharedSubFilter() {
+        return new LocalTopicTree.ItemFilter() {
+            @Override
+            public boolean checkItem(@NotNull final SubscriberWithQoS subscriber) {
+                return subscriber.isSharedSubscription();
+            }
+        };
+    }
+
+    @NotNull
+    public LocalTopicTree.ItemFilter getIndividualSubFilter() {
+        return new LocalTopicTree.ItemFilter() {
+            @Override
+            public boolean checkItem(@NotNull final SubscriberWithQoS subscriber) {
+                return !subscriber.isSharedSubscription();
+            }
+        };
+    }
+}

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersWithFilterFromTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersWithFilterFromTopicTreeImpl.java
@@ -1,0 +1,533 @@
+package com.hivemq.mqtt.topic.tree;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableSet;
+import com.hivemq.annotations.NotNull;
+import com.hivemq.metrics.MetricsHolder;
+import com.hivemq.mqtt.message.QoS;
+import com.hivemq.mqtt.message.mqtt5.Mqtt5RetainHandling;
+import com.hivemq.mqtt.message.subscribe.Topic;
+import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
+import com.hivemq.mqtt.topic.SubscriberWithQoS;
+import com.hivemq.mqtt.topic.SubscriptionFlags;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.*;
+
+/**
+ * @author  Christoph Schäbel
+ */
+@SuppressWarnings("NullabilityAnnotations")
+public class TestGetSubscribersWithFilterFromTopicTreeImpl {
+
+
+    private TopicTreeImpl topicTree;
+
+    private Counter subscriptionCounter;
+    private Counter staleSubscriptionsCounter;
+
+    @Before
+    public void setUp() {
+        subscriptionCounter = new Counter();
+        staleSubscriptionsCounter = new Counter();
+        topicTree = new TopicTreeImpl(new MetricsHolder(new MetricRegistry()));
+
+    }
+
+    @Test
+    public void test_empty_topic_tree_get_subscribers() throws Exception {
+
+        final Set<String> any = topicTree.getSubscribersWithFilter("any", getMatchAllFilter());
+        assertEquals(true, any.isEmpty());
+    }
+
+    @Test
+    public void test_empty_topic_tree_get_subscribers_wildcard() throws Exception {
+
+        final Set<String> any = topicTree.getSubscribersWithFilter("topic/#", getMatchAllFilter());
+        assertEquals(true, any.isEmpty());
+    }
+
+    @Test
+    public void test_empty_topic_tree_get_subscribers_root_wildcard() throws Exception {
+
+        final Set<String> any = topicTree.getSubscribersWithFilter("#", getMatchAllFilter());
+        assertEquals(true, any.isEmpty());
+    }
+
+
+    @Test
+    public void test_empty_no_subscriber_for_topic_filter() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("anothertopic", getMatchAllFilter());
+        assertEquals(true, subscribers.isEmpty());
+    }
+
+
+
+    @Test
+    public void test_get_single_subscriber_for_topic_filter() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_get_single_subscriber_for_long_topic_filter() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic/1/2/3/4/5/6/7/8/9/0", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic/1/2/3/4/5/6/7/8/9/0", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_get_single_subscriber_for_long_topic_filter_wildcard() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic/1/2/3/4/5/6/7/8/9/0/#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic/1/2/3/4/5/6/7/8/9/0/#", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_get_single_subscriber_for_long_topic_filter_plus_wildcard() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic/1/2/3/4/+/6/7/8/9/0/#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic/1/2/3/4/+/6/7/8/9/0/#", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_get_single_subscriber_for_topic_filter_with_flags() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE, true, true), (byte) 12, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_multiple_subscribers_for_topic_filter() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(2, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber", "subscriber2"));
+    }
+
+    @Test
+    public void test_same_subscriber_two_times_for_same_topic() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_same_subscriber_two_times_for_same_topic_different_flags() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE, true, true), (byte) 12, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_same_subscriber_two_times_for_same_topic_with_different_qos() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_root_wildcard_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("#", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_root_level_wildcard_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("+", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("+", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_two_level_wildcard_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("+/+", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("+/+", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_root_level_wildcard_subscriber_with_wildcard() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("+/#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("+/#", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber"));
+    }
+
+    @Test
+    public void test_root_level_wildcard_multiple_subscribers_with_wildcard() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("#", getMatchAllFilter());
+        assertEquals(3, subscribers.size());
+    }
+
+    @Test
+    public void test_subscriber_add_and_delete() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.removeSubscriber("subscriber", "topic", null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(0, subscribers.size());
+    }
+
+    @Test
+    public void test_subscriber_add_and_delete_multiple_topics_per_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+        topicTree.removeSubscriber("subscriber", "topic", null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(0, subscribers.size());
+    }
+
+    @Test
+    public void test_qos_subscriptions_multiple_subscribers() throws Exception {
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(2, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber", "subscriber2"));
+    }
+
+    @Test
+    public void test_multiple_subscribers_for_sys_topic() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("$SYS/topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("$SYS/topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("$SYS/topic", getMatchAllFilter());
+        assertEquals(2, subscribers.size());
+        assertThat(subscribers, hasItems("subscriber", "subscriber2"));
+    }
+
+    @Test
+    public void test_sys_topic_wildcard_subscriber() throws Exception {
+
+        topicTree.addTopic("subscriber", new Topic("$SYS/+", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("$SYS/+", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_same_subscriber_for_same_topic_with_subscriber_map() throws Exception {
+
+        topicTree = new TopicTreeImpl(new MetricsHolder(new MetricRegistry()));
+
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber", new Topic("topic", QoS.EXACTLY_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertThat(subscribers, hasItem("subscriber"));
+    }
+
+    @Test
+    public void test_root_level_wildcard_multiple_subscribers_with_wildcard_with_subscriber_map() throws Exception {
+
+        topicTree = new TopicTreeImpl(new MetricsHolder(new MetricRegistry()));
+
+        topicTree.addTopic("subscriber", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("#", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("#", getMatchAllFilter());
+        assertEquals(3, subscribers.size());
+    }
+
+    @Test
+    public void test_get_subscriber_from_index_map() throws Exception {
+        topicTree.addTopic("subscriber1", new Topic("this/topic", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("this/topic2", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("this/topic3", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("this/topic", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertEquals("subscriber1", subscribers.iterator().next());
+    }
+
+    @Test
+    public void test_get_topc_level_subscriber_from_index_map() throws Exception {
+        topicTree.addTopic("subscriber1", new Topic("topic1", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("topic2", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("topic3", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("topic1", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertEquals("subscriber1", subscribers.iterator().next());
+    }
+
+    @Test
+    public void test_get_wildcard_subscriber_from_index_map() throws Exception {
+        topicTree.addTopic("subscriber1", new Topic("this/+", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber2", new Topic("this/topic2", QoS.AT_MOST_ONCE), (byte) 0, null);
+        topicTree.addTopic("subscriber3", new Topic("this/topic3", QoS.AT_MOST_ONCE), (byte) 0, null);
+
+        final Set<String> subscribers = topicTree.getSubscribersWithFilter("this/+", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+        assertEquals("subscriber1", subscribers.iterator().next());
+    }
+
+
+    @Test
+    public void get_shared_subscriber() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        topicTree.addTopic("sub1", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        topicTree.addTopic("sub2", new Topic("topic", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        topicTree.addTopic("sub3", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "group2");
+        topicTree.addTopic("sub4", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+
+        final ImmutableSet<String> subscribers1 = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(3, subscribers1.size());
+        assertThat(subscribers1, hasItems("sub1", "sub2", "sub3"));
+
+        final ImmutableSet<String> subscribers2 = topicTree.getSubscribersWithFilter("#", getMatchAllFilter());
+        assertEquals(1, subscribers2.size());
+        assertEquals("sub4", subscribers2.iterator().next());
+
+        topicTree.addTopic("sub5", new Topic("topic/#", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        final ImmutableSet<String> subscribers3 = topicTree.getSubscribersWithFilter("topic/#", getMatchAllFilter());
+        assertEquals(1, subscribers3.size());
+        assertEquals("sub5", subscribers3.iterator().next());
+
+        topicTree.addTopic("sub6", new Topic("topic/a", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        final ImmutableSet<String> subscribers5 = topicTree.getSubscribersWithFilter("topic/a", getMatchAllFilter());
+        assertEquals(1, subscribers5.size());
+        assertEquals("sub6", subscribers5.iterator().next());
+
+        topicTree.addTopic("sub7", new Topic("topic/+", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        final ImmutableSet<String> subscribers6 = topicTree.getSubscribersWithFilter("topic/+", getMatchAllFilter());
+        assertEquals(1, subscribers6.size());
+        assertEquals("sub7", subscribers6.iterator().next());
+
+        topicTree.addTopic("sub8", new Topic("topic/+/b", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        final ImmutableSet<String> subscribers7 = topicTree.getSubscribersWithFilter("topic/+/b", getMatchAllFilter());
+        assertEquals(1, subscribers7.size());
+        assertEquals("sub8", subscribers7.iterator().next());
+
+        final ImmutableSet<String> subscribers8 = topicTree.getSubscribersWithFilter("topic/a/b", getMatchAllFilter());
+        assertEquals(0, subscribers8.size());
+    }
+
+    @Test
+    public void get_shared_subscriber_overlapping() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+
+        topicTree.addTopic("sub1", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group1");
+        topicTree.addTopic("sub2", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group2");
+        topicTree.addTopic("sub3", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "group3");
+        topicTree.addTopic("sub4", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "group4");
+
+        final ImmutableSet<String> subscribers1 = topicTree.getSubscribersWithFilter("#", getMatchAllFilter());
+        assertEquals(2, subscribers1.size());
+
+        final ImmutableSet<String> subscribers3 = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(2, subscribers3.size());
+    }
+
+    @Test
+    public void get_shared_subscriber_with_same_id() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+
+        topicTree.addTopic("client", new Topic("topic/a", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        topicTree.addTopic("client", new Topic("topic/+", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+        topicTree.addTopic("client", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group");
+
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("topic/a");
+        assertEquals(3, subscribers.size());
+    }
+
+
+    @Test
+    public void get_subscriber_shared_overlapping() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+
+        topicTree.addTopic("client1", new Topic("topic/a", QoS.AT_MOST_ONCE, false, false, Mqtt5RetainHandling.SEND, 1), sharedFlag, null);
+        topicTree.addTopic("client1", new Topic("topic/+", QoS.AT_LEAST_ONCE, false, false, Mqtt5RetainHandling.SEND, 2), sharedFlag, "group");
+
+        final SubscriberWithIdentifiers subscribers = topicTree.getSubscriber("client1", "topic/a");
+
+        assertEquals(1, subscribers.getSubscriptionIdentifier().size());
+        assertTrue(subscribers.getSubscriptionIdentifier().contains(2));
+    }
+
+    @Test
+    public void get_subscriber_non_shared_overlapping() {
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        topicTree.addTopic("client1", new Topic("topic/a", QoS.AT_MOST_ONCE, false, false, Mqtt5RetainHandling.SEND, 1), notSharedFlag, null);
+        topicTree.addTopic("client1", new Topic("topic/+", QoS.AT_LEAST_ONCE, false, false, Mqtt5RetainHandling.SEND, 2), notSharedFlag, null);
+
+        final SubscriberWithIdentifiers subscribers = topicTree.getSubscriber("client1", "topic/a");
+
+        assertEquals(2, subscribers.getSubscriptionIdentifier().size());
+        assertTrue(subscribers.getSubscriptionIdentifier().contains(1));
+        assertTrue(subscribers.getSubscriptionIdentifier().contains(2));
+    }
+
+    @Test
+    public void get_subscriber_shared_and_non_shared_overlapping() {
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+
+        topicTree.addTopic("client1", new Topic("topic/a", QoS.AT_MOST_ONCE, false, false, Mqtt5RetainHandling.SEND, 1), notSharedFlag, null);
+        topicTree.addTopic("client1", new Topic("topic/+", QoS.AT_LEAST_ONCE, false, false, Mqtt5RetainHandling.SEND, 2), sharedFlag, "group");
+
+        final SubscriberWithIdentifiers subscribers = topicTree.getSubscriber("client1", "topic/a");
+
+        assertEquals(1, subscribers.getSubscriptionIdentifier().size());
+        assertEquals(1, subscribers.getSubscriptionIdentifier().get(0).intValue());
+    }
+
+
+    @Test
+    public void test_normal_and_shared_subscription() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        topicTree.addTopic("client", new Topic("topic", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        topicTree.addTopic("client", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "name");
+
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("topic");
+        assertEquals(2, subscribers.size());
+    }
+
+    @Test
+    public void test_normal_and_shared_subscription_with_map() {
+        topicTree = new TopicTreeImpl(new MetricsHolder(new MetricRegistry()));
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        topicTree.addTopic("client1", new Topic("topic", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        topicTree.addTopic("client1", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "name");
+        topicTree.addTopic("client2", new Topic("topic", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        topicTree.addTopic("client2", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "name");
+
+        final ImmutableSet<String> subscribers = topicTree.getSubscribersWithFilter("topic", getMatchAllFilter());
+        assertEquals(2, subscribers.size());
+
+
+    }
+
+    @Test
+    public void test_multiple_root_wildcards() {
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        for (int i = 0; i < 20; i++) {
+            topicTree.addTopic("client" + i, new Topic("#", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        }
+
+        final ImmutableSet<String> subscribers = topicTree.getSubscribersWithFilter("#", getMatchAllFilter());
+        assertEquals(20, subscribers.size());
+
+        new Random().nextInt();
+    }
+
+    @Test
+    public void test_multiple_wildcards() {
+        final byte notSharedFlag = SubscriptionFlags.getDefaultFlags(false, false, false);
+
+        for (int i = 0; i < 20; i++) {
+            topicTree.addTopic("client" + i, new Topic("topic/#", QoS.AT_LEAST_ONCE), notSharedFlag, null);
+        }
+
+        final ImmutableSet<String> subscribers = topicTree.getSubscribersWithFilter("topic/#", getMatchAllFilter());
+        assertEquals(20, subscribers.size());
+
+        new Random().nextInt();
+    }
+
+
+    @Test
+    public void test_add_shared_wildcard() {
+        final byte sharedFlag = SubscriptionFlags.getDefaultFlags(true, false, false);
+
+        topicTree.addTopic("client", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "name1");
+        topicTree.addTopic("client", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "name2");
+
+        final ImmutableSet<String> subscribers = topicTree.getSubscribersWithFilter("#", getMatchAllFilter());
+        assertEquals(1, subscribers.size());
+
+        new Random().nextInt();
+    }
+
+
+    @NotNull
+    public LocalTopicTree.ItemFilter getMatchAllFilter() {
+        return new LocalTopicTree.ItemFilter() {
+            @Override
+            public boolean checkItem(@NotNull final SubscriberWithQoS subscriber) {
+                return true;
+            }
+        };
+    }
+}


### PR DESCRIPTION
**Motivation**

Allow extensions to search and iterate all available subscribers for either a topic (as used in a MQTT PUBLISH message) or a topic filter (as used in a MQTT SUBSCRIBE message).



**Changes**

Add 2 new methods to the SubscriptionStore:
- iterateAllSubscribersForTopic
- iterateAllSubscribersWithTopicFilter