### PR TITLE
improve SSL Context handling for TLS 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         jcenter()
-        maven { url 'https://repo.eclipse.org/content/repositories/paho-releases/' }
         maven { url 'https://oss.sonatype.org/content/groups/public' } // for snapshot artifacts
     }
 }
@@ -52,7 +51,7 @@ project.ext {
     // Project Dependency Versions
     bouncycastlesVersion = '1.60'
     jacksonVersion = '2.9.8'
-    nettyVersion = '4.1.34.Final'
+    nettyVersion = '4.1.38.Final'
     xodusVersion = '1.2.3'
     guiceVersion = '4.2.2'
     metricsVersion = '4.0.3'

--- a/src/main/java/com/hivemq/security/ssl/SslContextFactoryImpl.java
+++ b/src/main/java/com/hivemq/security/ssl/SslContextFactoryImpl.java
@@ -40,7 +40,7 @@ public class SslContextFactoryImpl implements SslContextFactory {
     public SslContext createSslContext(@NotNull final Tls tls) throws SSLException {
         final KeyManagerFactory kmf = sslUtil.getKeyManagerFactory(tls);
         final TrustManagerFactory tmFactory = sslUtil.getTrustManagerFactory(tls);
-        return sslUtil.createSslServerContext(kmf, tmFactory, tls.getCipherSuites());
+        return sslUtil.createSslServerContext(kmf, tmFactory, tls.getCipherSuites(), tls.getProtocols());
     }
 
 

--- a/src/main/java/com/hivemq/security/ssl/SslContextStore.java
+++ b/src/main/java/com/hivemq/security/ssl/SslContextStore.java
@@ -214,7 +214,7 @@ public class SslContextStore {
                         tmf = null;
                     }
 
-                    final SslContext context = sslUtil.createSslServerContext(kmf, tmf, tls.getCipherSuites());
+                    final SslContext context = sslUtil.createSslServerContext(kmf, tmf, tls.getCipherSuites(), tls.getProtocols());
                     sslContextMap.put(tls, context);
                     checksumMap.put(tls, hash);
                     log.info("Successfully updated changed SSL Context");

--- a/src/main/java/com/hivemq/security/ssl/SslExceptionHandler.java
+++ b/src/main/java/com/hivemq/security/ssl/SslExceptionHandler.java
@@ -69,7 +69,7 @@ public class SslExceptionHandler extends ChannelHandlerAdapter {
 
             } else if (cause.getCause() instanceof SSLException) {
                 logSSLException(ctx, cause);
-                eventLog.clientWasDisconnected(ctx.channel(), "SSL handshake failed");
+                eventLog.clientWasDisconnected(ctx.channel(), "SSL message transmission failed");
                 ctx.close();
                 return;
             }

--- a/src/main/java/com/hivemq/security/ssl/SslUtil.java
+++ b/src/main/java/com/hivemq/security/ssl/SslUtil.java
@@ -97,11 +97,15 @@ public class SslUtil {
     }
 
     @NotNull
-    public SslContext createSslServerContext(@NotNull final KeyManagerFactory kmf, @Nullable final TrustManagerFactory tmFactory, @Nullable final List<String> cipherSuites) throws SSLException {
+    public SslContext createSslServerContext(@NotNull final KeyManagerFactory kmf, @Nullable final TrustManagerFactory tmFactory, @Nullable final List<String> cipherSuites, @Nullable final List<String> protocols) throws SSLException {
 
         final SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(kmf);
 
         sslContextBuilder.sslProvider(SslProvider.JDK).trustManager(tmFactory);
+
+        if (protocols != null && !protocols.isEmpty()) {
+            sslContextBuilder.protocols(protocols.toArray(new String[0]));
+        }
 
         //set chosen cipher suites if available
         if (cipherSuites != null && cipherSuites.size() > 0) {


### PR DESCRIPTION
**Motivation**
Allow to select TLSv1.3 cipher suites the same way as for TLSv1.2 or TLSv1.1

Resolves #27

**Changes**
Change how the selected protocols and cipher suites are passed to the creation of the SSL/TLS Server Context.