### PR TITLE
Feature/puback inbound interceptor

### DIFF
--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
@@ -20,6 +20,7 @@ import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.puback.PubackInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.puback.PubackOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
@@ -68,6 +69,15 @@ public interface ClientContext {
      * @throws NullPointerException If the interceptor is null.
      */
     void addPubackOutboundInterceptor(@NotNull PubackOutboundInterceptor pubackOutboundInterceptor);
+
+    /**
+     * Adds an {@link PubackInboundInterceptor} for this client. <br> Subsequent adding of the same interceptor will be
+     * ignored.
+     *
+     * @param pubackInboundInterceptor The implementation of an PubackOutboundInterceptor.
+     * @throws NullPointerException If the interceptor is null.
+     */
+    void addPubackInboundInterceptor(@NotNull PubackInboundInterceptor pubackInboundInterceptor);
 
     /**
      * Adds an {@link SubscribeInboundInterceptor} for this client. <br>
@@ -120,6 +130,15 @@ public interface ClientContext {
     void removePubackOutboundInterceptor(@NotNull PubackOutboundInterceptor pubackOutboundInterceptor);
 
     /**
+     * Removes an {@link PubackInboundInterceptor} for this client. <br> Nothing happens if the interceptor that should
+     * be removed, has not been added in the first place.
+     *
+     * @param pubackInboundInterceptor The implementation of an PubackOutboundInterceptor.
+     * @throws NullPointerException If the interceptor is null.
+     */
+    void removePubackInboundInterceptor(@NotNull PubackInboundInterceptor pubackInboundInterceptor);
+
+    /**
      * Returns all {@link Interceptor} which are registered for this client.
      *
      * @return List of Interceptors for this client.
@@ -162,6 +181,14 @@ public interface ClientContext {
      */
     @Immutable
     @NotNull List<@NotNull PubackOutboundInterceptor> getPubackOutboundInterceptors();
+
+    /**
+     * Returns all {@link PubackInboundInterceptor} which are registered for this client by this extension.
+     *
+     * @return List of {@link PubackInboundInterceptor} for this client.
+     */
+    @Immutable
+    @NotNull List<@NotNull PubackInboundInterceptor> getPubackInboundInterceptors();
 
     /**
      * The default permissions for this client. Default permissions are automatically applied by HiveMQ for every

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/PubackInboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/PubackInboundInterceptor.java
@@ -1,0 +1,39 @@
+package com.hivemq.extension.sdk.api.interceptor.puback;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.async.TimeoutFallback;
+import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.puback.parameter.PubackInboundInput;
+import com.hivemq.extension.sdk.api.interceptor.puback.parameter.PubackInboundOutput;
+import com.hivemq.extension.sdk.api.interceptor.puback.parameter.PubackOutboundInput;
+import com.hivemq.extension.sdk.api.interceptor.puback.parameter.PubackOutboundOutput;
+
+import java.time.Duration;
+
+/**
+ * Interface for the inbound PUBACK interception.
+ * <p>
+ * Interceptors are always called by the same Thread for all messages from the same client.
+ * <p>
+ * If the same instance is shared between multiple clients it can be called in different Threads and must therefore be
+ * thread-safe.
+ * <p>
+ * When the method {@link #onInboundPuback(PubackInboundInput, PubackInboundOutput)} throws an exception or a call
+ * to {@link PubackInboundOutput#async(Duration)} times out with {@link TimeoutFallback#FAILURE},
+ * then the connection will be closed by the broker without another packet being sent to the client.
+ *
+ * @author Yannick Weber
+ */
+public interface PubackInboundInterceptor extends Interceptor {
+
+    /**
+     * When a {@link PubackInboundInterceptor} is set through any extension,
+     * this method gets called for every inbound PUBACK packet from any MQTT client.
+     *
+     * @param pubackInboundInput  The {@link PubackInboundInput} parameter.
+     * @param pubackInboundOutput The {@link PubackInboundOutput} parameter.
+     */
+    void onInboundPuback(
+            @NotNull PubackInboundInput pubackInboundInput, @NotNull PubackInboundOutput pubackInboundOutput);
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackInboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackInboundInput.java
@@ -1,0 +1,24 @@
+package com.hivemq.extension.sdk.api.interceptor.puback.parameter;
+
+import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.puback.PubackInboundInterceptor;
+import com.hivemq.extension.sdk.api.packets.puback.PubackPacket;
+import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
+
+/**
+ * This is the input parameter for any {@link PubackInboundInterceptor}
+ * providing PUBACK information.
+ *
+ * @author Yannick Weber
+ */
+public interface PubackInboundInput extends ClientBasedInput {
+
+    /**
+     * The unmodifiable PUBACK packet that was intercepted.
+     *
+     * @return An unmodifiable {@link PubackPacket}.
+     */
+    @NotNull @Immutable PubackPacket getPubackPacket();
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackInboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackInboundInput.java
@@ -1,5 +1,6 @@
 package com.hivemq.extension.sdk.api.interceptor.puback.parameter;
 
+import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.puback.PubackInboundInterceptor;
@@ -12,6 +13,7 @@ import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
  *
  * @author Yannick Weber
  */
+@DoNotImplement
 public interface PubackInboundInput extends ClientBasedInput {
 
     /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackInboundOutput.java
@@ -1,5 +1,6 @@
 package com.hivemq.extension.sdk.api.interceptor.puback.parameter;
 
+import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.async.Async;
@@ -16,6 +17,7 @@ import java.time.Duration;
  *
  * @author Yannick Weber
  */
+@DoNotImplement
 public interface PubackInboundOutput extends AsyncOutput<PubackInboundOutput> {
 
     /**
@@ -45,7 +47,7 @@ public interface PubackInboundOutput extends AsyncOutput<PubackInboundOutput> {
 
     /**
      * If the timeout is expired before {@link Async#resume()} is called then the outcome is handled as failed.
-     * This means that the outcome results in closed connection without a PUBACK sent to the client.
+     * This means that the outcome results an unmodified PUBACK is sent to the client.
      * <p>
      * Do not call this method more than once. If an async method is called multiple times an exception is thrown.
      *

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackInboundOutput.java
@@ -1,0 +1,57 @@
+package com.hivemq.extension.sdk.api.interceptor.puback.parameter;
+
+import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.async.Async;
+import com.hivemq.extension.sdk.api.async.AsyncOutput;
+import com.hivemq.extension.sdk.api.async.TimeoutFallback;
+import com.hivemq.extension.sdk.api.interceptor.puback.PubackInboundInterceptor;
+import com.hivemq.extension.sdk.api.packets.puback.ModifiablePubackPacket;
+import com.hivemq.extension.sdk.api.packets.puback.PubackPacket;
+
+import java.time.Duration;
+
+/**
+ * This is the output parameter of any {@link PubackInboundInterceptor}
+ *
+ * @author Yannick Weber
+ */
+public interface PubackInboundOutput extends AsyncOutput<PubackInboundOutput> {
+
+    /**
+     * Use this object to make any changes to the PUBACK message.
+     *
+     * @return An modifiable {@link PubackPacket}
+     */
+    @Immutable
+    @NotNull ModifiablePubackPacket getPubackPacket();
+
+    /**
+     * If the timeout is expired before {@link Async#resume()} is called then the outcome is
+     * handled either as failed or successful, depending on the specified fallback.
+     * <p>
+     * Do not call this method more than once. If an async method is called multiple times an exception is thrown.
+     * <p>
+     * {@link TimeoutFallback#FAILURE} results in closed connection without a PUBACK sent to the client.
+     * <p>
+     * {@link TimeoutFallback#SUCCESS} will proceed the PUBACK.
+     *
+     * @param timeout  Timeout that HiveMQ waits for the result of the async operation.
+     * @param fallback Fallback behaviour if a timeout occurs.
+     * @throws UnsupportedOperationException If async is called more than once.
+     */
+    @Override
+    @NotNull Async<PubackInboundOutput> async(@NotNull Duration timeout, @NotNull TimeoutFallback fallback);
+
+    /**
+     * If the timeout is expired before {@link Async#resume()} is called then the outcome is handled as failed.
+     * This means that the outcome results in closed connection without a PUBACK sent to the client.
+     * <p>
+     * Do not call this method more than once. If an async method is called multiple times an exception is thrown.
+     *
+     * @param timeout Timeout that HiveMQ waits for the result of the async operation.
+     * @throws UnsupportedOperationException If async is called more than once.
+     */
+    @Override
+    @NotNull Async<PubackInboundOutput> async(@NotNull Duration timeout);
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackOutboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackOutboundInput.java
@@ -1,5 +1,6 @@
 package com.hivemq.extension.sdk.api.interceptor.puback.parameter;
 
+import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.puback.PubackOutboundInterceptor;
@@ -12,6 +13,7 @@ import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
  *
  * @author Yannick Weber
  */
+@DoNotImplement
 public interface PubackOutboundInput extends ClientBasedInput {
 
     /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackOutboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/puback/parameter/PubackOutboundOutput.java
@@ -1,5 +1,6 @@
 package com.hivemq.extension.sdk.api.interceptor.puback.parameter;
 
+import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.async.Async;
@@ -16,6 +17,7 @@ import java.time.Duration;
  *
  * @author Yannick Weber
  */
+@DoNotImplement
 public interface PubackOutboundOutput extends AsyncOutput<PubackOutboundOutput> {
 
     /**

--- a/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
@@ -19,6 +19,7 @@ package com.hivemq.extensions.client;
 import com.hivemq.annotations.Immutable;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.puback.PubackInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.puback.PubackOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
@@ -67,6 +68,10 @@ public class ClientContextImpl {
     }
 
     public void addPubackOutboundInterceptor(final @NotNull PubackOutboundInterceptor interceptor) {
+        addInterceptor(interceptor);
+    }
+
+    public void addPubackInboundInterceptor(final @NotNull PubackInboundInterceptor interceptor) {
         addInterceptor(interceptor);
     }
 
@@ -187,6 +192,23 @@ public class ClientContextImpl {
                 .filter(this::hasPluginForClassloader)
                 .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
                 .map(interceptor -> (PubackOutboundInterceptor) interceptor)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public @NotNull @Immutable List<PubackInboundInterceptor> getPubackInboundInterceptorsForPlugin(final @NotNull IsolatedPluginClassloader pluginClassloader) {
+        return interceptorList.stream()
+                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
+                .filter(interceptor -> interceptor instanceof PubackInboundInterceptor)
+                .map(interceptor -> (PubackInboundInterceptor) interceptor)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public @NotNull @Immutable List<PubackInboundInterceptor> getPubackInboundInterceptors() {
+        return interceptorList.stream()
+                .filter(interceptor -> interceptor instanceof PubackInboundInterceptor)
+                .filter(this::hasPluginForClassloader)
+                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
+                .map(interceptor -> (PubackInboundInterceptor) interceptor)
                 .collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
@@ -20,6 +20,7 @@ import com.hivemq.annotations.Immutable;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.extension.sdk.api.client.ClientContext;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.puback.PubackInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.puback.PubackOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
@@ -71,6 +72,11 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     }
 
     @Override
+    public void addPubackInboundInterceptor(final @NotNull PubackInboundInterceptor interceptor) {
+        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+    }
+
+    @Override
     public void removePublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
         clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
@@ -88,6 +94,11 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     @Override
     public void removePubackOutboundInterceptor(final @NotNull PubackOutboundInterceptor pubackOutboundInterceptor) {
         clientContext.removeInterceptor(checkNotNull(pubackOutboundInterceptor, "The interceptor must never be null"));
+    }
+
+    @Override
+    public void removePubackInboundInterceptor(final @NotNull PubackInboundInterceptor pubackInboundInterceptor) {
+        clientContext.removeInterceptor(checkNotNull(pubackInboundInterceptor, "The interceptor must never be null"));
     }
 
     @NotNull
@@ -121,6 +132,12 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     @Override
     public @Immutable @NotNull List<@NotNull PubackOutboundInterceptor> getPubackOutboundInterceptors() {
         return clientContext.getPubackOutboundInterceptorsForPlugin(pluginClassloader);
+    }
+
+    @Override
+    public @Immutable
+    @NotNull List<@NotNull PubackInboundInterceptor> getPubackInboundInterceptors() {
+        return clientContext.getPubackInboundInterceptorsForPlugin(pluginClassloader);
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/handler/PubackInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/PubackInboundInterceptorHandler.java
@@ -1,0 +1,225 @@
+package com.hivemq.extensions.handler;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import com.hivemq.annotations.NotNull;
+import com.hivemq.annotations.Nullable;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.interceptor.puback.PubackInboundInterceptor;
+import com.hivemq.extensions.HiveMQExtension;
+import com.hivemq.extensions.HiveMQExtensions;
+import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
+import com.hivemq.extensions.client.ClientContextImpl;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.task.PluginInOutTask;
+import com.hivemq.extensions.executor.task.PluginInOutTaskContext;
+import com.hivemq.extensions.interceptor.puback.PubackInboundInputImpl;
+import com.hivemq.extensions.interceptor.puback.PubackInboundOutputImpl;
+import com.hivemq.extensions.packets.puback.PubackPacketImpl;
+import com.hivemq.mqtt.message.puback.PUBACK;
+import com.hivemq.util.ChannelAttributes;
+import com.hivemq.util.Exceptions;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PubackInboundInterceptorHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(PubackInboundInterceptorHandler.class);
+
+    @NotNull
+    private final FullConfigurationService configurationService;
+
+    @NotNull
+    private final PluginOutPutAsyncer asyncer;
+
+    @NotNull
+    private final HiveMQExtensions hiveMQExtensions;
+
+    @NotNull
+    private final PluginTaskExecutorService pluginTaskExecutorService;
+
+
+    @Inject
+    public PubackInboundInterceptorHandler(@NotNull final FullConfigurationService configurationService,
+            @NotNull final PluginOutPutAsyncer asyncer,
+            @NotNull final HiveMQExtensions hiveMQExtensions,
+            @NotNull final PluginTaskExecutorService pluginTaskExecutorService) {
+        this.configurationService = configurationService;
+        this.asyncer = asyncer;
+        this.hiveMQExtensions = hiveMQExtensions;
+        this.pluginTaskExecutorService = pluginTaskExecutorService;
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
+        if (!(msg instanceof PUBACK)) {
+            super.channelRead(ctx, msg);
+            return;
+        }
+
+        final PUBACK puback = (PUBACK) msg;
+
+        final Channel channel = ctx.channel();
+        if (!channel.isActive()) {
+            return;
+        }
+
+        final String clientId = channel.attr(ChannelAttributes.CLIENT_ID).get();
+        if (clientId == null) {
+            return;
+        }
+
+        final ClientContextImpl clientContext = channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).get();
+        if (clientContext == null || clientContext.getPubackInboundInterceptors().isEmpty()) {
+            super.channelRead(ctx, msg);
+            return;
+        }
+        final List<PubackInboundInterceptor> pubackInboundInterceptors = clientContext.getPubackInboundInterceptors();
+
+        final PubackInboundOutputImpl output = new PubackInboundOutputImpl(configurationService, asyncer, puback);
+        final PubackInboundInputImpl
+                input = new PubackInboundInputImpl(new PubackPacketImpl(puback), clientId, channel);
+        final SettableFuture<Void> interceptorFuture = SettableFuture.create();
+        final PubackInterceptorContext interceptorContext = new PubackInterceptorContext(
+                PubackInterceptorTask.class, clientId, input, interceptorFuture, pubackInboundInterceptors.size());
+
+        for (final PubackInboundInterceptor interceptor : pubackInboundInterceptors) {
+
+            if (interceptorFuture.isDone()) {
+                // The future is set in case an async interceptor timeout failed
+                break;
+            }
+
+            final HiveMQExtension plugin = hiveMQExtensions.getExtensionForClassloader((IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
+
+            //disabled extension would be null
+            if (plugin == null) {
+                interceptorContext.increment();
+                continue;
+            }
+            final PubackInterceptorTask interceptorTask =
+                    new PubackInterceptorTask(interceptor, interceptorFuture, plugin.getId());
+
+            pluginTaskExecutorService.handlePluginInOutTaskExecution(interceptorContext, input, output, interceptorTask);
+        }
+
+        final InterceptorFutureCallback callback =
+                new InterceptorFutureCallback(output, puback, ctx);
+        Futures.addCallback(interceptorFuture, callback, ctx.executor());
+    }
+
+    private static class InterceptorFutureCallback implements FutureCallback<Void> {
+
+        private final @NotNull PubackInboundOutputImpl output;
+        private final @NotNull PUBACK puback;
+        private final @NotNull ChannelHandlerContext ctx;
+
+        InterceptorFutureCallback(final @NotNull PubackInboundOutputImpl output,
+                final @NotNull PUBACK puback,
+                final @NotNull ChannelHandlerContext ctx) {
+            this.output = output;
+            this.puback = puback;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void onSuccess(final @Nullable Void result) {
+            try {
+                final PUBACK finalPuback = PUBACK.constructPUBACK(output.getPubackPacket());
+                ctx.fireChannelRead(finalPuback);
+            } catch (final Exception e) {
+                log.error("Exception while modifying an intercepted PUBACK message.", e);
+                ctx.fireChannelRead(puback);
+            }
+        }
+
+        @Override
+        public void onFailure(final @NotNull Throwable t) {
+            //should never happen, since the settable future never sets an exception
+            ctx.channel().close();
+        }
+    }
+
+    private static class PubackInterceptorContext extends PluginInOutTaskContext<PubackInboundOutputImpl> {
+
+        private final @NotNull PubackInboundInputImpl input;
+        private final @NotNull SettableFuture<Void> interceptorFuture;
+        private final int interceptorCount;
+        private final @NotNull AtomicInteger counter;
+
+
+        PubackInterceptorContext(final @NotNull Class<?> taskClazz,
+                final @NotNull String clientId,
+                final @NotNull PubackInboundInputImpl input,
+                final @NotNull SettableFuture<Void> interceptorFuture,
+                final int interceptorCount) {
+            super(taskClazz, clientId);
+            this.input = input;
+            this.interceptorFuture = interceptorFuture;
+            this.interceptorCount = interceptorCount;
+            this.counter = new AtomicInteger(0);
+        }
+
+        @Override
+        public void pluginPost(@NotNull final PubackInboundOutputImpl pluginOutput) {
+            if (pluginOutput.getPubackPacket().isModified()) {
+                input.updatePuback(pluginOutput.getPubackPacket());
+            }
+            increment();
+        }
+
+        public void increment() {
+            //we must set the future when no more interceptors are registered
+            if (counter.incrementAndGet() == interceptorCount) {
+                interceptorFuture.set(null);
+            }
+        }
+    }
+
+    private static class PubackInterceptorTask implements
+            PluginInOutTask<PubackInboundInputImpl, PubackInboundOutputImpl> {
+
+        private final @NotNull PubackInboundInterceptor interceptor;
+        private final @NotNull SettableFuture<Void> interceptorFuture;
+        private final @NotNull String pluginId;
+
+        private PubackInterceptorTask(final @NotNull PubackInboundInterceptor interceptor,
+                final @NotNull SettableFuture<Void> interceptorFuture,
+                final @NotNull String pluginId) {
+            this.interceptor = interceptor;
+            this.interceptorFuture = interceptorFuture;
+            this.pluginId = pluginId;
+        }
+
+        @Override
+        public @NotNull PubackInboundOutputImpl apply(final @NotNull PubackInboundInputImpl input, final @NotNull PubackInboundOutputImpl output) {
+            try {
+                if (!interceptorFuture.isDone()) {
+                    interceptor.onInboundPuback(input, output);
+                }
+            } catch (final Throwable e) {
+                log.warn(
+                        "Uncaught exception was thrown from extension with id \"{}\" on puback interception. The exception should be handled by the extension.",
+                        pluginId);
+                log.debug("Original exception:", e);
+                Exceptions.rethrowError(e);
+            }
+            return output;
+        }
+
+        @Override
+        public @NotNull ClassLoader getPluginClassLoader() {
+            return interceptor.getClass().getClassLoader();
+        }
+    }
+
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/puback/PubackInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/puback/PubackInboundInputImpl.java
@@ -1,0 +1,56 @@
+package com.hivemq.extensions.interceptor.puback;
+
+import com.hivemq.annotations.Immutable;
+import com.hivemq.annotations.NotNull;
+import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
+import com.hivemq.extension.sdk.api.client.parameter.ConnectionInformation;
+import com.hivemq.extension.sdk.api.interceptor.puback.parameter.PubackInboundInput;
+import com.hivemq.extension.sdk.api.packets.puback.PubackPacket;
+import com.hivemq.extensions.PluginInformationUtil;
+import com.hivemq.extensions.executor.task.PluginTaskInput;
+import com.hivemq.extensions.packets.puback.PubackPacketImpl;
+import io.netty.channel.Channel;
+
+import java.util.function.Supplier;
+
+public class PubackInboundInputImpl implements PubackInboundInput, Supplier<PubackInboundInputImpl>, PluginTaskInput {
+
+    private @NotNull PubackPacket pubackPacket;
+    private final @NotNull ClientInformation clientInformation;
+    private final @NotNull ConnectionInformation connectionInformation;
+
+    public PubackInboundInputImpl(
+            final @NotNull PubackPacket pubackPacket,
+            final @NotNull String clientId,
+            final @NotNull Channel channel) {
+
+        this.pubackPacket = pubackPacket;
+        clientInformation = PluginInformationUtil.getAndSetClientInformation(channel, clientId);
+        connectionInformation = PluginInformationUtil.getAndSetConnectionInformation(channel);
+    }
+
+    @Override
+    public @NotNull @Immutable
+    PubackPacket getPubackPacket() {
+        return pubackPacket;
+    }
+
+    @Override
+    public @NotNull ConnectionInformation getConnectionInformation() {
+        return connectionInformation;
+    }
+
+    @Override
+    public @NotNull ClientInformation getClientInformation() {
+        return clientInformation;
+    }
+
+    @Override
+    public PubackInboundInputImpl get() {
+        return this;
+    }
+
+    public void updatePuback(final @NotNull PubackPacket pubackPacket) {
+        this.pubackPacket = new PubackPacketImpl(pubackPacket);
+    }
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/puback/PubackInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/puback/PubackInboundOutputImpl.java
@@ -14,13 +14,15 @@ import java.util.function.Supplier;
 public class PubackInboundOutputImpl extends AbstractAsyncOutput<PubackInboundOutput>
         implements PubackInboundOutput, Supplier<PubackInboundOutputImpl> {
 
-    private final ModifiablePubackPacketImpl modifiablePubackPacket;
+    private final @NotNull FullConfigurationService configurationService;
+    private ModifiablePubackPacketImpl modifiablePubackPacket;
 
     public PubackInboundOutputImpl(final @NotNull FullConfigurationService configurationService,
             final @NotNull PluginOutPutAsyncer asyncer,
             final @NotNull PUBACK puback) {
         super(asyncer);
-        modifiablePubackPacket = new ModifiablePubackPacketImpl(configurationService, puback);
+        this.configurationService = configurationService;
+        modifiablePubackPacket = new ModifiablePubackPacketImpl(this.configurationService, puback);
     }
 
     @Override
@@ -32,5 +34,13 @@ public class PubackInboundOutputImpl extends AbstractAsyncOutput<PubackInboundOu
     @Override
     public PubackInboundOutputImpl get() {
         return this;
+    }
+
+    public void update(final @NotNull PUBACK puback) {
+        modifiablePubackPacket = new ModifiablePubackPacketImpl(configurationService, puback);
+    }
+
+    public void update(final @NotNull ModifiablePubackPacketImpl packet) {
+        this.modifiablePubackPacket = packet;
     }
 }

--- a/src/main/java/com/hivemq/extensions/interceptor/puback/PubackInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/puback/PubackInboundOutputImpl.java
@@ -1,0 +1,36 @@
+package com.hivemq.extensions.interceptor.puback;
+
+import com.hivemq.annotations.Immutable;
+import com.hivemq.annotations.NotNull;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.interceptor.puback.parameter.PubackInboundOutput;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.task.AbstractAsyncOutput;
+import com.hivemq.extensions.packets.puback.ModifiablePubackPacketImpl;
+import com.hivemq.mqtt.message.puback.PUBACK;
+
+import java.util.function.Supplier;
+
+public class PubackInboundOutputImpl extends AbstractAsyncOutput<PubackInboundOutput>
+        implements PubackInboundOutput, Supplier<PubackInboundOutputImpl> {
+
+    private final ModifiablePubackPacketImpl modifiablePubackPacket;
+
+    public PubackInboundOutputImpl(final @NotNull FullConfigurationService configurationService,
+            final @NotNull PluginOutPutAsyncer asyncer,
+            final @NotNull PUBACK puback) {
+        super(asyncer);
+        modifiablePubackPacket = new ModifiablePubackPacketImpl(configurationService, puback);
+    }
+
+    @Override
+    public @Immutable
+    @NotNull ModifiablePubackPacketImpl getPubackPacket() {
+        return modifiablePubackPacket;
+    }
+
+    @Override
+    public PubackInboundOutputImpl get() {
+        return this;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/puback/PubackInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/puback/PubackInboundOutputImpl.java
@@ -39,8 +39,4 @@ public class PubackInboundOutputImpl extends AbstractAsyncOutput<PubackInboundOu
     public void update(final @NotNull PUBACK puback) {
         modifiablePubackPacket = new ModifiablePubackPacketImpl(configurationService, puback);
     }
-
-    public void update(final @NotNull ModifiablePubackPacketImpl packet) {
-        this.modifiablePubackPacket = packet;
-    }
 }

--- a/src/test/java/com/hivemq/extensions/handler/PubackInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/PubackInboundInterceptorHandlerTest.java
@@ -1,0 +1,274 @@
+package com.hivemq.extensions.handler;
+
+import com.google.common.collect.ImmutableList;
+import com.hivemq.annotations.NotNull;
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.async.TimeoutFallback;
+import com.hivemq.extension.sdk.api.interceptor.puback.PubackInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.puback.parameter.PubackInboundInput;
+import com.hivemq.extension.sdk.api.interceptor.puback.parameter.PubackInboundOutput;
+import com.hivemq.extension.sdk.api.packets.puback.ModifiablePubackPacket;
+import com.hivemq.extensions.HiveMQExtension;
+import com.hivemq.extensions.HiveMQExtensions;
+import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
+import com.hivemq.extensions.client.ClientContextImpl;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginOutputAsyncerImpl;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.PluginTaskExecutorServiceImpl;
+import com.hivemq.extensions.executor.task.PluginTaskExecutor;
+import com.hivemq.mqtt.message.ProtocolVersion;
+import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
+import com.hivemq.mqtt.message.puback.PUBACK;
+import com.hivemq.mqtt.message.reason.Mqtt5PubAckReasonCode;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import util.TestConfigurationBootstrap;
+
+import java.io.File;
+import java.net.URL;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PubackInboundInterceptorHandlerTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private HiveMQExtensions hiveMQExtensions;
+
+    @Mock
+    private HiveMQExtension plugin;
+
+    @Mock
+    private ClientContextImpl clientContext;
+
+    private PluginOutPutAsyncer asyncer;
+
+    private FullConfigurationService configurationService;
+
+    private PluginTaskExecutor executor1;
+
+    private EmbeddedChannel channel;
+
+    private PluginTaskExecutorService pluginTaskExecutorService;
+
+    private PubackInboundInterceptorHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        executor1 = new PluginTaskExecutor(new AtomicLong());
+        executor1.postConstruct();
+
+        channel = new EmbeddedChannel();
+        channel.attr(ChannelAttributes.CLIENT_ID).set("client");
+        channel.attr(ChannelAttributes.REQUEST_RESPONSE_INFORMATION).set(true);
+        channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
+        when(plugin.getId()).thenReturn("plugin");
+
+        configurationService = new TestConfigurationBootstrap().getFullConfigurationService();
+        asyncer = new PluginOutputAsyncerImpl(mock(ShutdownHooks.class));
+        pluginTaskExecutorService = new PluginTaskExecutorServiceImpl(() -> executor1);
+
+        handler = new PubackInboundInterceptorHandler(configurationService, asyncer, hiveMQExtensions, pluginTaskExecutorService);
+        channel.pipeline().addFirst(handler);
+    }
+
+    @Test(timeout = 5000)
+    public void test_client_id_not_set() {
+
+        channel.attr(ChannelAttributes.CLIENT_ID).set(null);
+
+        channel.writeInbound(testPuback());
+        channel.runPendingTasks();
+
+        assertNull(channel.readInbound());
+    }
+
+    @Test(timeout = 5000)
+    public void test_channel_inactive() throws Exception {
+        final ChannelHandlerContext context = channel.pipeline().context(handler);
+
+        channel.close();
+
+        handler.channelRead(context, testPuback());
+
+        channel.runPendingTasks();
+
+        assertNull(channel.readInbound());
+    }
+
+    @Test(timeout = 5000)
+    public void test_no_interceptors() {
+
+        when(clientContext.getPubackInboundInterceptors()).thenReturn(ImmutableList.of());
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(plugin);
+
+        final PUBACK testPuback = testPuback();
+        channel.writeInbound(testPuback);
+        channel.runPendingTasks();
+        PUBACK puback = channel.readInbound();
+        while (puback == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            puback = channel.readInbound();
+        }
+        assertEquals(testPuback.getReasonCode(), puback.getReasonCode());
+    }
+
+
+    @Test(timeout = 5000)
+    public void test_modify() throws Exception {
+
+        final PubackInboundInterceptor interceptor = getInterceptor("TestModifyInboundInterceptor");
+        final List<PubackInboundInterceptor> list = ImmutableList.of(interceptor);
+
+        when(clientContext.getPubackInboundInterceptors()).thenReturn(list);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(plugin);
+
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        channel.writeInbound(testPuback());
+        channel.runPendingTasks();
+        PUBACK puback = channel.readInbound();
+        while (puback == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            puback = channel.readInbound();
+        }
+
+        assertEquals("modified", puback.getReasonString());
+    }
+
+    @Test(timeout = 5000)
+    public void test_plugin_null() throws Exception {
+
+        final PubackInboundInterceptor interceptor = getInterceptor("TestModifyInboundInterceptor");
+        final List<PubackInboundInterceptor> list = ImmutableList.of(interceptor);
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+        when(clientContext.getPubackInboundInterceptors()).thenReturn(list);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(null);
+
+        channel.writeInbound(testPuback());
+        channel.runPendingTasks();
+        PUBACK puback = channel.readInbound();
+        while (puback == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            puback = channel.readInbound();
+        }
+
+        assertEquals("reason", puback.getReasonString());
+    }
+
+    @Test(timeout = 10_000)
+    public void test_timeout_failed() throws Exception {
+
+        final PubackInboundInterceptor interceptor = getInterceptor("TestTimeoutFailedInboundInterceptor");
+        final List<PubackInboundInterceptor> list = ImmutableList.of(interceptor);
+
+        when(clientContext.getPubackInboundInterceptors()).thenReturn(list);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(plugin);
+
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        channel.writeInbound(testPuback());
+        channel.runPendingTasks();
+        channel.runScheduledPendingTasks();
+        Thread.sleep(10);
+
+        assertTrue(channel.isActive());
+    }
+
+    @Test(timeout = 5000)
+    public void test_exception() throws Exception {
+
+        final PubackInboundInterceptor interceptor = getInterceptor("TestExceptionInboundInterceptor");
+        final List<PubackInboundInterceptor> list = ImmutableList.of(interceptor);
+
+        when(clientContext.getPubackInboundInterceptors()).thenReturn(list);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(plugin);
+
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        channel.writeInbound(testPuback());
+        channel.runPendingTasks();
+        channel.runScheduledPendingTasks();
+        Thread.sleep(10);
+
+        assertTrue(channel.isActive());
+    }
+
+
+    @NotNull
+    private PUBACK testPuback() {
+        return new PUBACK(1, Mqtt5PubAckReasonCode.UNSPECIFIED_ERROR, "reason", Mqtt5UserProperties.NO_USER_PROPERTIES);
+    }
+
+    @NotNull
+    private PubackInboundInterceptor getInterceptor(@NotNull final String name) throws Exception {
+
+        final JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
+                .addClass("com.hivemq.extensions.handler.PubackInboundInterceptorHandlerTest$" + name);
+
+        final File jarFile = temporaryFolder.newFile();
+        javaArchive.as(ZipExporter.class).exportTo(jarFile, true);
+
+        //This classloader contains the classes from the jar file
+        final IsolatedPluginClassloader
+                cl = new IsolatedPluginClassloader(new URL[]{jarFile.toURI().toURL()}, this.getClass().getClassLoader());
+
+        final Class<?> interceptorClass = cl.loadClass("com.hivemq.extensions.handler.PubackInboundInterceptorHandlerTest$" + name);
+
+        return (PubackInboundInterceptor) interceptorClass.newInstance();
+    }
+
+    public static class TestModifyInboundInterceptor implements PubackInboundInterceptor {
+
+        @Override
+        public void onInboundPuback(@NotNull final PubackInboundInput pubackInboundInput, @NotNull final PubackInboundOutput pubackInboundOutput) {
+            @Immutable final ModifiablePubackPacket pubackPacket = pubackInboundOutput.getPubackPacket();
+            pubackPacket.setReasonString("modified");
+        }
+    }
+
+    public static class TestTimeoutFailedInboundInterceptor implements PubackInboundInterceptor {
+
+        @Override
+        public void onInboundPuback(@NotNull final PubackInboundInput pubackInboundInput, @NotNull final PubackInboundOutput pubackInboundOutput) {
+            pubackInboundOutput.async(Duration.ofMillis(10), TimeoutFallback.FAILURE);
+        }
+    }
+
+    public static class TestExceptionInboundInterceptor implements PubackInboundInterceptor {
+
+        @Override
+        public void onInboundPuback(@NotNull final PubackInboundInput pubackInboundInput, @NotNull final PubackInboundOutput pubackInboundOutput) {
+            throw new RuntimeException();
+        }
+    }
+
+}

--- a/src/test/java/com/hivemq/extensions/handler/PubackInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/PubackInboundInterceptorHandlerTest.java
@@ -100,7 +100,7 @@ public class PubackInboundInterceptorHandlerTest {
         channel.writeInbound(testPuback());
         channel.runPendingTasks();
 
-        assertNull(channel.readInbound());
+        assertNotNull(channel.readInbound());
     }
 
     @Test(timeout = 5000)
@@ -113,7 +113,7 @@ public class PubackInboundInterceptorHandlerTest {
 
         channel.runPendingTasks();
 
-        assertNull(channel.readInbound());
+        assertNotNull(channel.readInbound());
     }
 
     @Test(timeout = 5000)


### PR DESCRIPTION
Resolves #49 

**Motivation**
Resolves the absence of a possibility for extension developers to intercept inbound puback messages.

**Changes**
Implemented the puback-inbound interceptor.
An extension-developer is now able to intercept inbound PUBACK messages.
The developer can change the following parameters of the PUBACK message:
* AckReasonCode (changing from a successful to an unsuccessful  reason code is prohibited and vice versa)
* ReasonString (can only be set for an unsuccessful PUBACK message)
* when an exception is caught in the interceptor, the client is not disconnected
* when a timeout fails in the interceptor, the client is not disconnected

Exceptions / Timeouts are handled in the following way:
* when an exception is caught in the interceptor, the client is not disconnected
* when a timeout fails in the interceptor, the client is not disconnected
* when an exception is caught in the interceptor all changes to the PUBREC are ignored.