### PR TITLE
removed redundant log-statement

### DIFF
--- a/src/main/java/com/hivemq/throttling/ioc/GlobalTrafficShapingProvider.java
+++ b/src/main/java/com/hivemq/throttling/ioc/GlobalTrafficShapingProvider.java
@@ -65,7 +65,6 @@ public class GlobalTrafficShapingProvider implements Provider<GlobalTrafficShapi
         registry.add(shutdownHook);
 
         final long incomingLimit = restrictionsConfigurationService.incomingLimit();
-        log.debug("Throttling incoming traffic to {} B/s", incomingLimit);
 
         final long outgoinglimit = InternalConfigurations.OUTGOING_BANDWIDTH_THROTTLING_DEFAULT;
         log.debug("Throttling outgoing traffic to {} B/s", outgoinglimit);


### PR DESCRIPTION
**Motivation**
HiveMQ logs while starting the configuration for bandwidth throttling twice.

**Changes**
Removed the redundant log-statement. 