### PR TITLE
Bugfix/hivemq folder fails with whitespaces

### DIFF
--- a/src/packaging/bin/diagnostics.sh
+++ b/src/packaging/bin/diagnostics.sh
@@ -77,12 +77,9 @@ if hash java 2>/dev/null; then
                 echo "ERROR! HiveMQ JAR not found."
                 echo $HIVEMQ_FOLDER;
             else
-                HIVEMQ_FOLDER=$(echo "$HIVEMQ_FOLDER" | sed 's/ /\\ /g')
                 JAVA_OPTS="$JAVA_OPTS -XX:+CrashOnOutOfMemoryError"
                 JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-
                 HEAPDUMP_PATH_OPT="-XX:HeapDumpPath=\"$HIVEMQ_FOLDER/heap-dump.hprof\""
-
 
                 echo "-------------------------------------------------------------------------"
                 echo ""

--- a/src/packaging/bin/diagnostics.sh
+++ b/src/packaging/bin/diagnostics.sh
@@ -66,20 +66,23 @@ if hash java 2>/dev/null; then
     fi
 
     if [ ! -d "$HIVEMQ_FOLDER" ]; then
-        echo ERROR! HiveMQ Home Folder not found.
+        echo "ERROR! HiveMQ Home Folder not found."
     else
 
         if [ ! -w "$HIVEMQ_FOLDER" ]; then
-            echo ERROR! HiveMQ Home Folder Permissions not correct.
+            echo "ERROR! HiveMQ Home Folder Permissions not correct."
         else
 
             if [ ! -f "$HIVEMQ_FOLDER/bin/hivemq.jar" ]; then
-                echo ERROR! HiveMQ JAR not found.
+                echo "ERROR! HiveMQ JAR not found."
                 echo $HIVEMQ_FOLDER;
             else
                 HIVEMQ_FOLDER=$(echo "$HIVEMQ_FOLDER" | sed 's/ /\\ /g')
                 JAVA_OPTS="$JAVA_OPTS -XX:+CrashOnOutOfMemoryError"
-                JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$HIVEMQ_FOLDER/heap-dump.hprof"
+                JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+
+                HEAPDUMP_PATH_OPT="-XX:HeapDumpPath=\"$HIVEMQ_FOLDER/heap-dump.hprof\""
+
 
                 echo "-------------------------------------------------------------------------"
                 echo ""
@@ -93,11 +96,11 @@ if hash java 2>/dev/null; then
                 echo ""
                 # Run HiveMQ
                 JAR_PATH="$HIVEMQ_FOLDER/bin/hivemq.jar"
-                exec "java" ${HOME_OPT} ${JAVA_OPTS} -jar ${JAR_PATH}
+                exec "java" "${HOME_OPT}" "${HEAPDUMP_PATH_OPT}" ${JAVA_OPTS} -jar "${JAR_PATH}"
             fi
         fi
     fi
 
 else
-    echo You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again.
+  echo "ERROR! You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again."
 fi

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -25,37 +25,37 @@ echo "-------------------------------------------------------------------------"
 echo ""
 echo "  HiveMQ Start Script for Linux/Unix v1.10"
 echo ""
-
+​
 if hash java 2>/dev/null; then
-
+​
     java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/\..*//')
-
+​
     if [[ "$((java_version))" -lt 11 ]]; then
         echo "HiveMQ 4 requires at least Java version 11"
         exit 1
     fi
-
+​
     ############## VARIABLES
     JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
     JAVA_OPTS="$JAVA_OPTS -noverify"
-
+​
     JAVA_OPTS="$JAVA_OPTS --add-opens java.base/java.lang=ALL-UNNAMED"
     JAVA_OPTS="$JAVA_OPTS --add-opens java.base/java.nio=ALL-UNNAMED"
     JAVA_OPTS="$JAVA_OPTS --add-opens java.base/sun.nio.ch=ALL-UNNAMED"
     JAVA_OPTS="$JAVA_OPTS --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
     JAVA_OPTS="$JAVA_OPTS --add-exports java.base/jdk.internal.misc=ALL-UNNAMED"
-
+​
     if [ -c "/dev/urandom" ]; then
         # Use /dev/urandom as standard source for secure randomness if it exists
         JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/./urandom"
     fi
-
+​
     # JMX Monitoring
     JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
-
+​
     # Uncomment for enabling Diagnostic Mode
     #JAVA_OPTS="$JAVA_OPTS -DdiagnosticMode=true"
-
+​
     if [ -z "$HIVEMQ_HOME" ]; then
         HIVEMQ_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
         HOME_OPT="-Dhivemq.home=$HIVEMQ_FOLDER"
@@ -63,26 +63,23 @@ if hash java 2>/dev/null; then
         HIVEMQ_FOLDER=$HIVEMQ_HOME
         HOME_OPT=""
     fi
-
+​
     if [ ! -d "$HIVEMQ_FOLDER" ]; then
-        echo ERROR! HiveMQ Home Folder not found.
+        echo "ERROR! HiveMQ Home Folder not found."
     else
-
+​
         if [ ! -w "$HIVEMQ_FOLDER" ]; then
-            echo ERROR! HiveMQ Home Folder Permissions not correct.
+            echo "ERROR! HiveMQ Home Folder Permissions not correct."
         else
-
+​
             if [ ! -f "$HIVEMQ_FOLDER/bin/hivemq.jar" ]; then
-                echo ERROR! HiveMQ JAR not found.
+                echo "ERROR! HiveMQ JAR not found."
                 echo $HIVEMQ_FOLDER;
             else
-                # shellcheck disable=SC2001
-#                HIVEMQ_FOLDER="$(echo $HIVEMQ_FOLDER | sed 's/ /\\ /g')"
                 JAVA_OPTS="$JAVA_OPTS -XX:+CrashOnOutOfMemoryError"
                 JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-                HEAPDUMP_PATH="$HIVEMQ_FOLDER/heap-dump.hprof"
-                JAVA_OPTS="${JAVA_OPTS} -XX:HeapDumpPath=${HEAPDUMP_PATH}"
-
+                HEAPDUMP_PATH_OPT="-XX:HeapDumpPath=\"$HIVEMQ_FOLDER/heap-dump.hprof\""
+​
                 echo "-------------------------------------------------------------------------"
                 echo ""
                 echo "  HIVEMQ_HOME: $HIVEMQ_FOLDER"
@@ -95,12 +92,12 @@ if hash java 2>/dev/null; then
                 echo ""
                 # Run HiveMQ
                 JAR_PATH="$HIVEMQ_FOLDER/bin/hivemq.jar"
-                exec "java" "${HOME_OPT}" ${JAVA_OPTS} -jar "${JAR_PATH}"
+                exec "java" "${HOME_OPT}" "${HEAPDUMP_PATH_OPT}" ${JAVA_OPTS} -jar "${JAR_PATH}"
             fi
         fi
     fi
-
+​
 else
-    echo You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again.
+    echo "ERROR! You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again."
     exit 1
 fi

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -25,6 +25,7 @@ echo "-------------------------------------------------------------------------"
 echo ""
 echo "  HiveMQ Start Script for Linux/Unix v1.10"
 echo ""
+set -o xtrace
 
 if hash java 2>/dev/null; then
 
@@ -76,9 +77,12 @@ if hash java 2>/dev/null; then
                 echo ERROR! HiveMQ JAR not found.
                 echo $HIVEMQ_FOLDER;
             else
-                HIVEMQ_FOLDER=$(echo "$HIVEMQ_FOLDER" | sed 's/ /\\ /g')
+                # shellcheck disable=SC2001
+#                HIVEMQ_FOLDER="$(echo $HIVEMQ_FOLDER | sed 's/ /\\ /g')"
                 JAVA_OPTS="$JAVA_OPTS -XX:+CrashOnOutOfMemoryError"
-                JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$HIVEMQ_FOLDER/heap-dump.hprof"
+                JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+                HEAPDUMP_PATH="$HIVEMQ_FOLDER/heap-dump.hprof"
+                JAVA_OPTS="${JAVA_OPTS} -XX:HeapDumpPath=${HEAPDUMP_PATH}"
 
                 echo "-------------------------------------------------------------------------"
                 echo ""
@@ -92,7 +96,7 @@ if hash java 2>/dev/null; then
                 echo ""
                 # Run HiveMQ
                 JAR_PATH="$HIVEMQ_FOLDER/bin/hivemq.jar"
-                exec "java" ${HOME_OPT} ${JAVA_OPTS} -jar ${JAR_PATH}
+                exec "java" "${HOME_OPT}" ${JAVA_OPTS} -jar "${JAR_PATH}"
             fi
         fi
     fi

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -25,7 +25,6 @@ echo "-------------------------------------------------------------------------"
 echo ""
 echo "  HiveMQ Start Script for Linux/Unix v1.10"
 echo ""
-set -o xtrace
 
 if hash java 2>/dev/null; then
 

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -25,37 +25,37 @@ echo "-------------------------------------------------------------------------"
 echo ""
 echo "  HiveMQ Start Script for Linux/Unix v1.10"
 echo ""
-​
+
 if hash java 2>/dev/null; then
-​
+
     java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/\..*//')
-​
+
     if [[ "$((java_version))" -lt 11 ]]; then
         echo "HiveMQ 4 requires at least Java version 11"
         exit 1
     fi
-​
+
     ############## VARIABLES
     JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
     JAVA_OPTS="$JAVA_OPTS -noverify"
-​
+
     JAVA_OPTS="$JAVA_OPTS --add-opens java.base/java.lang=ALL-UNNAMED"
     JAVA_OPTS="$JAVA_OPTS --add-opens java.base/java.nio=ALL-UNNAMED"
     JAVA_OPTS="$JAVA_OPTS --add-opens java.base/sun.nio.ch=ALL-UNNAMED"
     JAVA_OPTS="$JAVA_OPTS --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
     JAVA_OPTS="$JAVA_OPTS --add-exports java.base/jdk.internal.misc=ALL-UNNAMED"
-​
+
     if [ -c "/dev/urandom" ]; then
         # Use /dev/urandom as standard source for secure randomness if it exists
         JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/./urandom"
     fi
-​
+
     # JMX Monitoring
     JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
-​
+
     # Uncomment for enabling Diagnostic Mode
     #JAVA_OPTS="$JAVA_OPTS -DdiagnosticMode=true"
-​
+
     if [ -z "$HIVEMQ_HOME" ]; then
         HIVEMQ_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
         HOME_OPT="-Dhivemq.home=$HIVEMQ_FOLDER"
@@ -63,15 +63,15 @@ if hash java 2>/dev/null; then
         HIVEMQ_FOLDER=$HIVEMQ_HOME
         HOME_OPT=""
     fi
-​
+
     if [ ! -d "$HIVEMQ_FOLDER" ]; then
         echo "ERROR! HiveMQ Home Folder not found."
     else
-​
+
         if [ ! -w "$HIVEMQ_FOLDER" ]; then
             echo "ERROR! HiveMQ Home Folder Permissions not correct."
         else
-​
+
             if [ ! -f "$HIVEMQ_FOLDER/bin/hivemq.jar" ]; then
                 echo "ERROR! HiveMQ JAR not found."
                 echo $HIVEMQ_FOLDER;
@@ -79,7 +79,7 @@ if hash java 2>/dev/null; then
                 JAVA_OPTS="$JAVA_OPTS -XX:+CrashOnOutOfMemoryError"
                 JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
                 HEAPDUMP_PATH_OPT="-XX:HeapDumpPath=\"$HIVEMQ_FOLDER/heap-dump.hprof\""
-​
+
                 echo "-------------------------------------------------------------------------"
                 echo ""
                 echo "  HIVEMQ_HOME: $HIVEMQ_FOLDER"
@@ -96,7 +96,7 @@ if hash java 2>/dev/null; then
             fi
         fi
     fi
-​
+
 else
     echo "ERROR! You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptopenjdk.net/?variant=openjdk11 and try again."
     exit 1


### PR DESCRIPTION
**Motivation**

HiveMQ did not work if the parent folder name contained whitespaces.

**Changes**

Added additional parenthesis to parts of the run.sh script to make it safe to use whitespaces in the folder name.
