### PR TITLE
Feature/disconnect inbound outbound interceptors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ allprojects {
     sourceCompatibility = 10
     targetCompatibility = 10
 
+    compileJava.options.encoding = 'UTF-8'
+    compileTestJava.options.encoding = 'UTF-8'
+    javadoc.options.encoding = 'UTF-8'
+
     group 'com.hivemq'
 }
 
@@ -261,7 +265,7 @@ jar {
 }
 
 test {
-    jvmArgs += ["-noverify", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "jdk.management/com.sun.management.internal=ALL-UNNAMED", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED"]
+    jvmArgs += ["-Dfile.encoding=UTF-8", "-noverify", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "jdk.management/com.sun.management.internal=ALL-UNNAMED", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED"]
     minHeapSize = "128m"
     maxHeapSize = "2048m"
 
@@ -273,14 +277,8 @@ test {
         logger.lifecycle("Excluded " + lines.size() + " tests for this execution")
     }
 
-    beforeTest { descriptor ->
-        logger.lifecycle("Running test: " + descriptor)
-    }
-
-    testLogging {
-        events "failed"
-        exceptionFormat "short"
-    }
+    testLogging.events("failed")
+    testLogging.exceptionFormat("full")
 
     /* use tmpdir from gradle property or the same tmpdir as the runner */
     if (project.hasProperty("test_temp_dir")) {

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
@@ -44,7 +44,7 @@ public interface ClientContext {
      * Adds an {@link PublishInboundInterceptor} for this client. <br>
      * Subsequent adding of the same interceptor will be ignored.
      *
-     * @param publishInboundInterceptor The implementation of a PublishInboundInterceptor.
+     * @param publishInboundInterceptor The implementation of an PublishInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.0.0
      */
@@ -54,7 +54,7 @@ public interface ClientContext {
      * Adds an {@link PublishOutboundInterceptor} for this client. <br>
      * Subsequent adding of the same interceptor will be ignored.
      *
-     * @param publishOutboundInterceptor The implementation of a PublishOutboundInterceptor.
+     * @param publishOutboundInterceptor The implementation of an PublishOutboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.2.0
      */
@@ -64,7 +64,7 @@ public interface ClientContext {
      * Adds an {@link SubscribeInboundInterceptor} for this client. <br>
      * Subsequent adding of the same interceptor will be ignored.
      *
-     * @param subscribeInboundInterceptor The implementation of a SubscribeInboundInterceptor.
+     * @param subscribeInboundInterceptor The implementation of an SubscribeInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.2.0
      */
@@ -74,7 +74,7 @@ public interface ClientContext {
      * Ads an {@link DisconnectInboundInterceptor} for this client. <br> Subsequent adding of the same interceptor will
      * be ignored.
      *
-     * @param disconnectInboundInterceptor The implementation of a DisconnectInboundInterceptor.
+     * @param disconnectInboundInterceptor The implementation of an DisconnectInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      */
     void addDisconnectInboundInterceptor(@NotNull DisconnectInboundInterceptor disconnectInboundInterceptor);
@@ -83,7 +83,7 @@ public interface ClientContext {
      * Removes an {@link PublishInboundInterceptor} for this client. <br>
      * Nothing happens if the interceptor that should be removed, has not been added in the first place.
      *
-     * @param publishInboundInterceptor The implementation of a PublishInboundInterceptor.
+     * @param publishInboundInterceptor The implementation of an PublishInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.0.0
      */
@@ -94,7 +94,7 @@ public interface ClientContext {
      * Removes an {@link PublishOutboundInterceptor} for this client. <br>
      * Nothing happens if the interceptor that should be removed, has not been added in the first place.
      *
-     * @param publishOutboundInterceptor The implementation of a PublishOutboundInterceptor.
+     * @param publishOutboundInterceptor The implementation of an PublishOutboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.2.0
      */
@@ -114,7 +114,7 @@ public interface ClientContext {
      * Removes an {@link DisconnectInboundInterceptor} for this client <br> Nothing happens if the interceptor that
      * should be removed, has not been added in the first place.
      *
-     * @param disconnectInboundInterceptor The implementation of a DisconnectInboundInterceptor.
+     * @param disconnectInboundInterceptor The implementation of an DisconnectInboundInterceptor.
      */
     void removeDisconnectInboundInterceptor(@NotNull DisconnectInboundInterceptor disconnectInboundInterceptor);
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
@@ -172,6 +172,22 @@ public interface ClientContext {
     @NotNull List<@NotNull SubscribeInboundInterceptor> getSubscribeInboundInterceptors();
 
     /**
+     * Returns all {@link DisconnectOutboundInterceptor} which are registered for this client by this extension.
+     *
+     * @return List of DisconnectOutboundInterceptors for this client.
+     */
+    @Immutable
+    @NotNull List<@NotNull DisconnectOutboundInterceptor> getDisconnectOutboundInterceptors();
+
+    /**
+     * Returns all {@link DisconnectInboundInterceptor} which are registered for this client by this extension.
+     *
+     * @return List of DisconnectInboundInterceptors for this client.
+     */
+    @Immutable
+    @NotNull List<@NotNull DisconnectInboundInterceptor> getDisconnectInboundInterceptors();
+
+    /**
      * The default permissions for this client. Default permissions are automatically applied by HiveMQ for every MQTT
      * PUBLISH and SUBSCRIBE packet sent by this client.
      *

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
@@ -21,6 +21,7 @@ import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
@@ -41,8 +42,8 @@ import java.util.List;
 public interface ClientContext {
 
     /**
-     * Adds an {@link PublishInboundInterceptor} for this client. <br>
-     * Subsequent adding of the same interceptor will be ignored.
+     * Adds an {@link PublishInboundInterceptor} for this client. <br> Subsequent adding of the same interceptor will be
+     * ignored.
      *
      * @param publishInboundInterceptor The implementation of an PublishInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
@@ -51,8 +52,8 @@ public interface ClientContext {
     void addPublishInboundInterceptor(@NotNull PublishInboundInterceptor publishInboundInterceptor);
 
     /**
-     * Adds an {@link PublishOutboundInterceptor} for this client. <br>
-     * Subsequent adding of the same interceptor will be ignored.
+     * Adds an {@link PublishOutboundInterceptor} for this client. <br> Subsequent adding of the same interceptor will
+     * be ignored.
      *
      * @param publishOutboundInterceptor The implementation of an PublishOutboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
@@ -61,8 +62,8 @@ public interface ClientContext {
     void addPublishOutboundInterceptor(@NotNull PublishOutboundInterceptor publishOutboundInterceptor);
 
     /**
-     * Adds an {@link SubscribeInboundInterceptor} for this client. <br>
-     * Subsequent adding of the same interceptor will be ignored.
+     * Adds an {@link SubscribeInboundInterceptor} for this client. <br> Subsequent adding of the same interceptor will
+     * be ignored.
      *
      * @param subscribeInboundInterceptor The implementation of an SubscribeInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
@@ -71,7 +72,7 @@ public interface ClientContext {
     void addSubscribeInboundInterceptor(@NotNull SubscribeInboundInterceptor subscribeInboundInterceptor);
 
     /**
-     * Ads an {@link DisconnectInboundInterceptor} for this client. <br> Subsequent adding of the same interceptor will
+     * Adds an {@link DisconnectInboundInterceptor} for this client. <br> Subsequent adding of the same interceptor will
      * be ignored.
      *
      * @param disconnectInboundInterceptor The implementation of an DisconnectInboundInterceptor.
@@ -80,8 +81,17 @@ public interface ClientContext {
     void addDisconnectInboundInterceptor(@NotNull DisconnectInboundInterceptor disconnectInboundInterceptor);
 
     /**
-     * Removes an {@link PublishInboundInterceptor} for this client. <br>
-     * Nothing happens if the interceptor that should be removed, has not been added in the first place.
+     * Adds an {@link DisconnectOutboundInterceptor} for this client <br> Subsequent adding of the same interceptor will
+     * be ignored.
+     *
+     * @param disconnectOutboundInterceptor The implementation of an DisconnectOutboundInterceptor.
+     * @throws NullPointerException If the interceptor is null.
+     */
+    void addDisconnectOutboundInterceptor(@NotNull DisconnectOutboundInterceptor disconnectOutboundInterceptor);
+
+    /**
+     * Removes an {@link PublishInboundInterceptor} for this client. <br> Nothing happens if the interceptor that should
+     * be removed, has not been added in the first place.
      *
      * @param publishInboundInterceptor The implementation of an PublishInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
@@ -89,10 +99,9 @@ public interface ClientContext {
      */
     void removePublishInboundInterceptor(@NotNull PublishInboundInterceptor publishInboundInterceptor);
 
-
     /**
-     * Removes an {@link PublishOutboundInterceptor} for this client. <br>
-     * Nothing happens if the interceptor that should be removed, has not been added in the first place.
+     * Removes an {@link PublishOutboundInterceptor} for this client. <br> Nothing happens if the interceptor that
+     * should be removed, has not been added in the first place.
      *
      * @param publishOutboundInterceptor The implementation of an PublishOutboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
@@ -101,8 +110,8 @@ public interface ClientContext {
     void removePublishOutboundInterceptor(@NotNull PublishOutboundInterceptor publishOutboundInterceptor);
 
     /**
-     * Removes an {@link SubscribeInboundInterceptor} for this client. <br>
-     * Nothing happens if the interceptor that should be removed, has not been added in the first place.
+     * Removes an {@link SubscribeInboundInterceptor} for this client. <br> Nothing happens if the interceptor that
+     * should be removed, has not been added in the first place.
      *
      * @param subscribeInboundInterceptor The implementation of an SubscribeInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
@@ -117,6 +126,14 @@ public interface ClientContext {
      * @param disconnectInboundInterceptor The implementation of an DisconnectInboundInterceptor.
      */
     void removeDisconnectInboundInterceptor(@NotNull DisconnectInboundInterceptor disconnectInboundInterceptor);
+
+    /**
+     * Removes an {@link DisconnectOutboundInterceptor} for this client <br> Nothing happens if the interceptor that
+     * should be removed, has not been added in the first place.
+     *
+     * @param disconnectOutboundInterceptor The implementation of an DisconnectOutboundInterceptor.
+     */
+    void removeDisconnectOutboundInterceptor(@NotNull DisconnectOutboundInterceptor disconnectOutboundInterceptor);
 
     /**
      * Returns all {@link Interceptor} which are registered for this client.
@@ -155,8 +172,8 @@ public interface ClientContext {
     @NotNull List<@NotNull SubscribeInboundInterceptor> getSubscribeInboundInterceptors();
 
     /**
-     * The default permissions for this client. Default permissions are automatically applied by HiveMQ for every
-     * MQTT PUBLISH and SUBSCRIBE packet sent by this client.
+     * The default permissions for this client. Default permissions are automatically applied by HiveMQ for every MQTT
+     * PUBLISH and SUBSCRIBE packet sent by this client.
      *
      * @return The {@link ModifiableDefaultPermissions}.
      * @since 4.0.0

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
@@ -20,6 +20,7 @@ import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
@@ -43,7 +44,7 @@ public interface ClientContext {
      * Adds an {@link PublishInboundInterceptor} for this client. <br>
      * Subsequent adding of the same interceptor will be ignored.
      *
-     * @param publishInboundInterceptor The implementation of an PublishInboundInterceptor.
+     * @param publishInboundInterceptor The implementation of a PublishInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.0.0
      */
@@ -53,7 +54,7 @@ public interface ClientContext {
      * Adds an {@link PublishOutboundInterceptor} for this client. <br>
      * Subsequent adding of the same interceptor will be ignored.
      *
-     * @param publishOutboundInterceptor The implementation of an PublishOutboundInterceptor.
+     * @param publishOutboundInterceptor The implementation of a PublishOutboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.2.0
      */
@@ -63,17 +64,26 @@ public interface ClientContext {
      * Adds an {@link SubscribeInboundInterceptor} for this client. <br>
      * Subsequent adding of the same interceptor will be ignored.
      *
-     * @param subscribeInboundInterceptor The implementation of an SubscribeInboundInterceptor.
+     * @param subscribeInboundInterceptor The implementation of a SubscribeInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.2.0
      */
     void addSubscribeInboundInterceptor(@NotNull SubscribeInboundInterceptor subscribeInboundInterceptor);
 
     /**
+     * Ads an {@link DisconnectInboundInterceptor} for this client. <br> Subsequent adding of the same interceptor will
+     * be ignored.
+     *
+     * @param disconnectInboundInterceptor The implementation of a DisconnectInboundInterceptor.
+     * @throws NullPointerException If the interceptor is null.
+     */
+    void addDisconnectInboundInterceptor(@NotNull DisconnectInboundInterceptor disconnectInboundInterceptor);
+
+    /**
      * Removes an {@link PublishInboundInterceptor} for this client. <br>
      * Nothing happens if the interceptor that should be removed, has not been added in the first place.
      *
-     * @param publishInboundInterceptor The implementation of an PublishInboundInterceptor.
+     * @param publishInboundInterceptor The implementation of a PublishInboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.0.0
      */
@@ -84,7 +94,7 @@ public interface ClientContext {
      * Removes an {@link PublishOutboundInterceptor} for this client. <br>
      * Nothing happens if the interceptor that should be removed, has not been added in the first place.
      *
-     * @param publishOutboundInterceptor The implementation of an PublishOutboundInterceptor.
+     * @param publishOutboundInterceptor The implementation of a PublishOutboundInterceptor.
      * @throws NullPointerException If the interceptor is null.
      * @since 4.2.0
      */
@@ -99,6 +109,14 @@ public interface ClientContext {
      * @since 4.2.0
      */
     void removeSubscribeInboundInterceptor(@NotNull SubscribeInboundInterceptor subscribeInboundInterceptor);
+
+    /**
+     * Removes an {@link DisconnectInboundInterceptor} for this client <br> Nothing happens if the interceptor that
+     * should be removed, has not been added in the first place.
+     *
+     * @param disconnectInboundInterceptor The implementation of a DisconnectInboundInterceptor.
+     */
+    void removeDisconnectInboundInterceptor(@NotNull DisconnectInboundInterceptor disconnectInboundInterceptor);
 
     /**
      * Returns all {@link Interceptor} which are registered for this client.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectInboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectInboundInterceptor.java
@@ -8,7 +8,7 @@ import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectI
 /**
  * Interface for the inbound DISCONNECT interception.
  * <p>
- * Interceptors are always called by the same Thread for all message from the same client.
+ * Interceptors are always called by the same Thread for all messages from the same client.
  * <p>
  * If the same instance is shared between multiple clients it can be called in different Threads and must therefore be
  * thread-safe.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectInboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectInboundInterceptor.java
@@ -1,0 +1,20 @@
+package com.hivemq.extension.sdk.api.interceptor.disconnect;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundInput;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundOutput;
+
+public interface DisconnectInboundInterceptor extends Interceptor {
+
+    /**
+     * When a {@link DisconnectInboundInterceptor} is set through any extension, this method gets called for every
+     * inbound DISCONNECT packet from any MQTT client.
+     *
+     * @param disconnectInboundInput  The {@link DisconnectInboundInput} parameter.
+     * @param disconnectInboundOutput The {@link DisconnectInboundOutput} parameter.
+     */
+    void onDisconnect(
+            @NotNull DisconnectInboundInput disconnectInboundInput,
+            @NotNull DisconnectInboundOutput disconnectInboundOutput);
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectInboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectInboundInterceptor.java
@@ -5,6 +5,18 @@ import com.hivemq.extension.sdk.api.interceptor.Interceptor;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundInput;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundOutput;
 
+/**
+ * Interface for the inbound DISCONNECT interception.
+ * <p>
+ * Interceptors are always called by the same Thread for all message from the same client.
+ * <p>
+ * If the same instance is shared between multiple clients it can be called in different Threads and must therefore be
+ * thread-safe.
+ * </p>
+ *
+ * @author Robin Atherton
+ */
+@FunctionalInterface
 public interface DisconnectInboundInterceptor extends Interceptor {
 
     /**
@@ -14,7 +26,7 @@ public interface DisconnectInboundInterceptor extends Interceptor {
      * @param disconnectInboundInput  The {@link DisconnectInboundInput} parameter.
      * @param disconnectInboundOutput The {@link DisconnectInboundOutput} parameter.
      */
-    void onDisconnect(
+    void onInboundDisconnect(
             @NotNull DisconnectInboundInput disconnectInboundInput,
             @NotNull DisconnectInboundOutput disconnectInboundOutput);
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
@@ -1,0 +1,13 @@
+package com.hivemq.extension.sdk.api.interceptor.disconnect;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundInput;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundOutput;
+
+public interface DisconnectOutboundInterceptor extends Interceptor {
+
+    void onOutboundDisconnect(
+            @NotNull DisconnectOutboundInput disconnectOutboundInput,
+            @NotNull DisconnectOutboundOutput disconnectOutboundOutput);
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
@@ -17,6 +17,13 @@ import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectO
 @FunctionalInterface
 public interface DisconnectOutboundInterceptor extends Interceptor {
 
+    /**
+     * When a {@link DisconnectOutboundInterceptor} is set through any extension, this method gets called for every
+     * outbound DISCONNECT packet from any MQTT client.
+     *
+     * @param disconnectOutboundInput  The {@link DisconnectOutboundInput} parameter.
+     * @param disconnectOutboundOutput The {@link DisconnectOutboundOutput} parameter.
+     */
     void onOutboundDisconnect(
             @NotNull DisconnectOutboundInput disconnectOutboundInput,
             @NotNull DisconnectOutboundOutput disconnectOutboundOutput);

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
@@ -8,7 +8,7 @@ import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectO
 /**
  * Interface for the outbound DISCONNECT interception.
  * <p>
- * Interceptors are always called by the same Thread for all messages from th4e same client. If the same instance is
+ * Interceptors are always called by the same Thread for all messages from the same client. If the same instance is
  * shared between multiple clients it can be called in different Threads and must therefore be thread-safe.
  * </p>
  *

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
@@ -5,6 +5,16 @@ import com.hivemq.extension.sdk.api.interceptor.Interceptor;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundInput;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundOutput;
 
+/**
+ * Interface for the outbound DISCONNECT interception.
+ * <p>
+ * Interceptors are always called by the same Thread for all messages from th4e same client. If the same instance is
+ * shared between multiple clients it can be called in different Threads and must therefore be thread-safe.
+ * </p>
+ *
+ * @author Robin Atherton
+ */
+@FunctionalInterface
 public interface DisconnectOutboundInterceptor extends Interceptor {
 
     void onOutboundDisconnect(

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundInput.java
@@ -1,0 +1,24 @@
+package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
+
+import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
+
+/**
+ * This is the input parameter of any {@link DisconnectInboundInterceptor} providing DISCONNECT
+ *
+ * @author Robin Atherton
+ */
+public interface DisconnectInboundInput extends ClientBasedInput {
+
+    /**
+     * The unmodifiable DISCONNECT packet that was intercepted.
+     *
+     * @return An unmodifiable {@link DisconnectPacket}.
+     */
+    @Immutable
+    @NotNull DisconnectPacket getDisconnectPacket();
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
@@ -11,6 +11,7 @@ public interface DisconnectInboundOutput extends AsyncOutput<DisconnectInboundOu
 
     /**
      *
+     * @return the disconnect packet.
      */
     @NotNull DisconnectPacket getDisconnectPacket();
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
@@ -2,18 +2,24 @@ package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.async.AsyncOutput;
+import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
 
 /**
- *
- *
+ * This is the output parameter of any {@link ConnectInboundInterceptor} providing methods to define the outcome of a
+ * DISCONNECT interception.
+ * <p>
+ * It can be used to
+ * <ul>
+ * <li>Modify a DISCONNECT packet</li>
+ * </ul>
  *
  * @author Robin Atherton
  */
 public interface DisconnectInboundOutput extends AsyncOutput<DisconnectInboundOutput> {
 
     /**
-     *  Use this object to make any changes to the DISCONNECT message.
+     * Use this object to make any changes to the DISCONNECT message.
      *
      * @return a modifiable disconnect packet.
      */

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
@@ -2,7 +2,7 @@ package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.async.AsyncOutput;
-import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
 
 /**
  *
@@ -13,9 +13,10 @@ import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
 public interface DisconnectInboundOutput extends AsyncOutput<DisconnectInboundOutput> {
 
     /**
+     *  Use this object to make any changes to the DISCONNECT message.
      *
-     * @return the disconnect packet.
+     * @return a modifiable disconnect packet.
      */
-    @NotNull DisconnectPacket getDisconnectPacket();
+    @NotNull ModifiableDisconnectPacket getDisconnectPacket();
 
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
@@ -1,0 +1,17 @@
+package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.async.AsyncOutput;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+
+/**
+ * @author Robin Atherton
+ */
+public interface DisconnectInboundOutput extends AsyncOutput<DisconnectInboundOutput> {
+
+    /**
+     *
+     */
+    @NotNull DisconnectPacket getDisconnectPacket();
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
@@ -5,6 +5,9 @@ import com.hivemq.extension.sdk.api.async.AsyncOutput;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
 
 /**
+ *
+ *
+ *
  * @author Robin Atherton
  */
 public interface DisconnectInboundOutput extends AsyncOutput<DisconnectInboundOutput> {

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundInput.java
@@ -1,0 +1,16 @@
+package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
+
+import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
+
+public interface DisconnectOutboundInput extends ClientBasedInput {
+
+    /**
+     * //TODO
+     */
+    @Immutable
+    @NotNull DisconnectPacket getDisconnectPacket();
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundInput.java
@@ -1,14 +1,22 @@
 package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
 
+import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectOutboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
 import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
 
+/**
+ * This is the input parameter of any {@link DisconnectOutboundInterceptor} providing DISCONNECT. //TODO more
+ *
+ * @author Robin Atherton
+ */
+@DoNotImplement
 public interface DisconnectOutboundInput extends ClientBasedInput {
 
     /**
-     * //TODO
+     * //TODO Write appropriate DOC
      */
     @Immutable
     @NotNull DisconnectPacket getDisconnectPacket();

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundInput.java
@@ -8,7 +8,7 @@ import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
 import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
 
 /**
- * This is the input parameter of any {@link DisconnectOutboundInterceptor} providing DISCONNECT. //TODO more
+ * This is the input parameter of any {@link DisconnectOutboundInterceptor} providing DISCONNECT information.
  *
  * @author Robin Atherton
  */
@@ -16,7 +16,9 @@ import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
 public interface DisconnectOutboundInput extends ClientBasedInput {
 
     /**
-     * //TODO Write appropriate DOC
+     * The unmodifiable DISCONNECT packet that was intercepted.
+     *
+     * @return an unmodifiable {@link DisconnectPacket}
      */
     @Immutable
     @NotNull DisconnectPacket getDisconnectPacket();

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundOutput.java
@@ -1,0 +1,13 @@
+package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
+
+public interface DisconnectOutboundOutput {
+
+    /**
+     * @return
+     */
+    @NotNull ModifiableDisconnectPacket getDisconnectPacket();
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundOutput.java
@@ -1,13 +1,37 @@
 package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
 
+import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.async.Async;
+import com.hivemq.extension.sdk.api.async.TimeoutFallback;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectOutboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
 
+import java.time.Duration;
+
+/**
+ * This is the output parameter of any {@link DisconnectOutboundInterceptor} providing methods to define the outcome of
+ * DISCONNECT interception. It can be used to modify an outbound DISCONNECT packet.
+ *
+ * @author Robin Atherton
+ */
+@DoNotImplement
 public interface DisconnectOutboundOutput {
 
     /**
-     * @return
+     * Use this object to make changes to the outbound DISCONNECT.
+     *
+     * @return A modifiable DISCONNECT packet.
      */
     @NotNull ModifiableDisconnectPacket getDisconnectPacket();
+
+    /**
+     * //TODO Write appropriate DOC
+     *
+     * @param timeout
+     * @param timeoutFallback
+     * @return
+     */
+    @NotNull Async<DisconnectOutboundOutput> async(@NotNull Duration timeout, @NotNull TimeoutFallback timeoutFallback);
 
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundOutput.java
@@ -26,12 +26,19 @@ public interface DisconnectOutboundOutput {
     @NotNull ModifiableDisconnectPacket getDisconnectPacket();
 
     /**
-     * //TODO Write appropriate DOC
+     * If the timeout expires before {@link Async#resume()} is called then the outcome is handled either as failed or
+     * successful, depending on the specified fallback.
+     * <p>
+     * Do not call this method more than once. If an async method is called multiple times an exception is thrown.
+     * <p>
+     * {@link TimeoutFallback#FAILURE} results in closed connection without a DISCONNECT sent to the client.
+     * <p>
+     * {@link TimeoutFallback#SUCCESS} will proceed the DISCONNECT.
      *
-     * @param timeout
-     * @param timeoutFallback
-     * @return
+     * @param timeout Timeout that HiveMQ waits for the result of the async operation.
+     * @param fallback Fallback behavior if a timeout occurs.
+     * @throws UnsupportedOperationException if async is called more than once.
      */
-    @NotNull Async<DisconnectOutboundOutput> async(@NotNull Duration timeout, @NotNull TimeoutFallback timeoutFallback);
+    @NotNull Async<DisconnectOutboundOutput> async(@NotNull Duration timeout, @NotNull TimeoutFallback fallback);
 
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
@@ -13,12 +13,12 @@ public interface DisconnectPacket {
     /**
      * Sets the server reference of the DISCONNECT packet.
      *
-     * @return a String representing the  the server reference to set.
+     * @return a String representing the server reference to set.
      */
     String getServerReference();
 
     /**
-     * //TODO
+     * The reason code of the DISCONNECT packet.
      *
      * @return an enum containing the reason for disconnecting.
      */

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
@@ -1,0 +1,39 @@
+package com.hivemq.extension.sdk.api.packets.disconnect;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.general.UserProperties;
+
+import java.util.Optional;
+
+public interface DisconnectPacket {
+
+    /**
+     * Sets the server reference of the DISCONNECT packet.
+     *
+     * @return a String representing the  the server reference to set.
+     */
+    String getServerReference();
+
+    /**
+     * The reason string of the DISCONNECT packet.
+     *
+     * @return a string containing the disconnect reason if present.
+     */
+    String getReasonString();
+
+    /**
+     * Duration in seconds how long session for the client is stored.
+     * <p>
+     * For an MQTT 3 client this {@link Optional} for the MQTT 5 property will always be empty.
+     *
+     * @return a long representing the session expiry interval.
+     */
+    long getSessionExpiryInterval();
+
+    /**
+     * The user properties from the DISCONNECT packet.
+     *
+     * @return The {@link UserProperties} of the DISCONNECT packet.
+     */
+    @NotNull UserProperties getUserProperties();
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
@@ -5,6 +5,9 @@ import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 
 import java.util.Optional;
 
+/**
+ * @author Robin Atherton
+ */
 public interface DisconnectPacket {
 
     /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
@@ -15,6 +15,13 @@ public interface DisconnectPacket {
     String getServerReference();
 
     /**
+     * //TODO
+     *
+     * @return an enum containing the reason for disconnecting.
+     */
+    DisconnectReasonCode getReasonCode();
+
+    /**
      * The reason string of the DISCONNECT packet.
      *
      * @return a string containing the disconnect reason if present.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableDisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableDisconnectPacket.java
@@ -1,0 +1,36 @@
+package com.hivemq.extension.sdk.api.packets.disconnect;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.general.ModifiableUserProperties;
+import com.hivemq.extension.sdk.api.packets.general.UserProperties;
+
+public interface ModifiableDisconnectPacket extends DisconnectPacket {
+
+    /**
+     * Sets a reasonString for the DISCONNECT packet.
+     *
+     * @param reasonString the reason to set.
+     */
+    void setReasonString(String reasonString);
+
+    /**
+     * Sets the session expiry interval of the DISCONNECT packet.
+     *
+     * @param expiryInterval a settable value indicating the interval after which the session will expire.
+     */
+    void setSessionExpiryInterval(long expiryInterval);
+
+    /**
+     * Sets the server reference of the DISCONNECT packet.
+     *
+     * @param serverReference the server reference to set.
+     */
+    void setServerReference(String serverReference);
+
+    /**
+     * Gets the modifiable {@link UserProperties} of the DISCONNECT packet.
+     */
+    @Override
+    @NotNull ModifiableUserProperties getUserProperties();
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableDisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableDisconnectPacket.java
@@ -33,4 +33,5 @@ public interface ModifiableDisconnectPacket extends DisconnectPacket {
     @Override
     @NotNull ModifiableUserProperties getUserProperties();
 
+    boolean isModified();
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableDisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableDisconnectPacket.java
@@ -4,12 +4,15 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.packets.general.ModifiableUserProperties;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 
+/**
+ * @author Robin Atherton
+ */
 public interface ModifiableDisconnectPacket extends DisconnectPacket {
 
     /**
      * Sets a reasonString for the DISCONNECT packet.
      *
-     * @param reasonString the reason to set.
+     * @param reasonString the reason to be set as a string.
      */
     void setReasonString(String reasonString);
 
@@ -23,12 +26,14 @@ public interface ModifiableDisconnectPacket extends DisconnectPacket {
     /**
      * Sets the server reference of the DISCONNECT packet.
      *
-     * @param serverReference the server reference to set.
+     * @param serverReference the server reference value to be set.
      */
     void setServerReference(String serverReference);
 
     /**
      * Gets the modifiable {@link UserProperties} of the DISCONNECT packet.
+     *
+     * @return Modifiable user properties.
      */
     @Override
     @NotNull ModifiableUserProperties getUserProperties();

--- a/src/main/java/com/hivemq/bootstrap/netty/ChannelDependencies.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/ChannelDependencies.java
@@ -25,10 +25,6 @@ import com.hivemq.codec.encoder.MQTTMessageEncoder;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.RestrictionsConfigurationService;
 import com.hivemq.extensions.handler.*;
-import com.hivemq.extensions.handler.ClientLifecycleEventHandler;
-import com.hivemq.extensions.handler.IncomingPublishHandler;
-import com.hivemq.extensions.handler.IncomingSubscribeHandler;
-import com.hivemq.extensions.handler.PluginInitializerHandler;
 import com.hivemq.logging.EventLog;
 import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.metrics.handler.MetricsInitializer;
@@ -165,6 +161,13 @@ public class ChannelDependencies {
     @NotNull
     private final ConnackOutboundInterceptorHandler connackOutboundInterceptorHandler;
 
+    @NotNull
+    private final DisconnectInboundInterceptorHandler disconnectInboundInterceptorHandler;
+
+    @NotNull
+    private final DisconnectOutboundInterceptorHandler disconnectOutboundInterceptorHandler;
+
+
     @Inject
     public ChannelDependencies(
             @NotNull final Provider<MetricsInitializer> statisticsInitializer,
@@ -201,7 +204,9 @@ public class ChannelDependencies {
             @NotNull final Provider<PublishMessageExpiryHandler> publishMessageExpiryHandlerProvider,
             @NotNull final PublishOutboundInterceptorHandler publishOutboundInterceptorHandler,
             @NotNull final ConnectInboundInterceptorHandler connectInboundInterceptorHandler,
-            @NotNull final ConnackOutboundInterceptorHandler connackOutboundInterceptorHandler) {
+            @NotNull final ConnackOutboundInterceptorHandler connackOutboundInterceptorHandler,
+            @NotNull final DisconnectInboundInterceptorHandler disconnectInboundInterceptorHandler,
+            @NotNull final DisconnectOutboundInterceptorHandler disconnectOutboundInterceptorHandler) {
 
 
         this.statisticsInitializer = statisticsInitializer;
@@ -239,6 +244,8 @@ public class ChannelDependencies {
         this.publishOutboundInterceptorHandler = publishOutboundInterceptorHandler;
         this.connectInboundInterceptorHandler = connectInboundInterceptorHandler;
         this.connackOutboundInterceptorHandler = connackOutboundInterceptorHandler;
+        this.disconnectInboundInterceptorHandler = disconnectInboundInterceptorHandler;
+        this.disconnectOutboundInterceptorHandler = disconnectOutboundInterceptorHandler;
     }
 
     @NotNull
@@ -414,5 +421,15 @@ public class ChannelDependencies {
     @NotNull
     public ConnackOutboundInterceptorHandler getConnackOutboundInterceptorHandler() {
         return connackOutboundInterceptorHandler;
+    }
+
+    @NotNull
+    public DisconnectInboundInterceptorHandler getDisconnectInboundInterceptorHandler() {
+        return disconnectInboundInterceptorHandler;
+    }
+
+    @NotNull
+    public DisconnectOutboundInterceptorHandler getDisconnectOutboundInterceptorHandler() {
+        return disconnectOutboundInterceptorHandler;
     }
 }

--- a/src/main/java/com/hivemq/bootstrap/netty/ChannelHandlerNames.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/ChannelHandlerNames.java
@@ -114,6 +114,8 @@ public class ChannelHandlerNames {
     public static final String PUBLISH_OUTBOUND_INTERCEPTOR_HANDLER = "publish_outbound_interceptor_handler";
     public static final String CONNECT_INBOUND_INTERCEPTOR_HANDLER = "connect_inbound_interceptor_handler";
     public static final String CONNACK_OUTBOUND_INTERCEPTOR_HANDLER = "connack_outbound_interceptor_handler";
+    public static final String DISCONNECT_INBOUND_INTERCEPTOR_HANDLER = "disconnect_inbound_interceptor_handlser";
+    public static final String DISCONNECT_OUTBOUND_INTERCEPTOR_HANDLER = "disconnect_outbound_interceptor_handler";
 
     /* *************
      *     Misc    *

--- a/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
@@ -121,8 +121,6 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
         ch.pipeline().addLast(MQTT_PINGREQ_HANDLER, channelDependencies.getPingRequestHandler());
         ch.pipeline().addLast(CHANNEL_INACTIVE_HANDLER, new ChannelInactiveHandler());
 
-        ch.pipeline().addLast(INCOMING_SUBSCRIBE_HANDLER, channelDependencies.getDisconnectInboundInterceptorHandler());
-
         ch.pipeline().addLast(INCOMING_PUBLISH_HANDLER, channelDependencies.getIncomingPublishHandler());
         ch.pipeline().addLast(INCOMING_SUBSCRIBE_HANDLER, channelDependencies.getIncomingSubscribeHandler());
 

--- a/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
@@ -124,6 +124,15 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
         ch.pipeline().addLast(INCOMING_PUBLISH_HANDLER, channelDependencies.getIncomingPublishHandler());
         ch.pipeline().addLast(INCOMING_SUBSCRIBE_HANDLER, channelDependencies.getIncomingSubscribeHandler());
 
+        ch.pipeline()
+                .addLast(
+                        DISCONNECT_INBOUND_INTERCEPTOR_HANDLER,
+                        channelDependencies.getDisconnectInboundInterceptorHandler());
+        ch.pipeline()
+                .addLast(
+                        DISCONNECT_OUTBOUND_INTERCEPTOR_HANDLER,
+                        channelDependencies.getDisconnectOutboundInterceptorHandler());
+
         ch.pipeline().addLast(MQTT_SUBSCRIBE_HANDLER, channelDependencies.getSubscribeHandler());
         ch.pipeline().addLast(MQTT_PUBLISH_USER_EVENT_HANDLER, channelDependencies.getPublishUserEventReceivedHandler());
 

--- a/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
@@ -121,6 +121,8 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
         ch.pipeline().addLast(MQTT_PINGREQ_HANDLER, channelDependencies.getPingRequestHandler());
         ch.pipeline().addLast(CHANNEL_INACTIVE_HANDLER, new ChannelInactiveHandler());
 
+        ch.pipeline().addLast(INCOMING_SUBSCRIBE_HANDLER, channelDependencies.getInboundDisconnectInterceptorHandler());
+
         ch.pipeline().addLast(INCOMING_PUBLISH_HANDLER, channelDependencies.getIncomingPublishHandler());
         ch.pipeline().addLast(INCOMING_SUBSCRIBE_HANDLER, channelDependencies.getIncomingSubscribeHandler());
 

--- a/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
@@ -121,7 +121,7 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
         ch.pipeline().addLast(MQTT_PINGREQ_HANDLER, channelDependencies.getPingRequestHandler());
         ch.pipeline().addLast(CHANNEL_INACTIVE_HANDLER, new ChannelInactiveHandler());
 
-        ch.pipeline().addLast(INCOMING_SUBSCRIBE_HANDLER, channelDependencies.getInboundDisconnectInterceptorHandler());
+        ch.pipeline().addLast(INCOMING_SUBSCRIBE_HANDLER, channelDependencies.getDisconnectInboundInterceptorHandler());
 
         ch.pipeline().addLast(INCOMING_PUBLISH_HANDLER, channelDependencies.getIncomingPublishHandler());
         ch.pipeline().addLast(INCOMING_SUBSCRIBE_HANDLER, channelDependencies.getIncomingSubscribeHandler());

--- a/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
@@ -20,6 +20,7 @@ import com.hivemq.annotations.Immutable;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
@@ -74,6 +75,10 @@ public class ClientContextImpl {
         addInterceptor(interceptor);
     }
 
+    public void addDisconnectOutboundInterceptor(@NotNull final DisconnectOutboundInterceptor interceptor) {
+        addInterceptor(interceptor);
+    }
+
     public void removePublishInboundInterceptor(@NotNull final PublishInboundInterceptor interceptor) {
         removeInterceptor(interceptor);
     }
@@ -94,6 +99,9 @@ public class ClientContextImpl {
         removeInterceptor(interceptor);
     }
 
+    public void removeDisconnectOutboundInterceptor(@NotNull final DisconnectOutboundInterceptor interceptor) {
+        removeInterceptor(interceptor);
+    }
     public void removeInterceptor(@NotNull final Interceptor interceptor) {
         interceptorList.remove(interceptor);
     }
@@ -188,6 +196,17 @@ public class ClientContextImpl {
                 .filter(this::hasPluginForClassloader)
                 .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
                 .map(interceptor -> (DisconnectInboundInterceptor) interceptor)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @NotNull
+    @Immutable
+    public List<DisconnectOutboundInterceptor> getDisconnectOutboundInterceptor() {
+        return interceptorList.stream()
+                .filter(interceptor -> interceptor instanceof DisconnectOutboundInterceptor)
+                .filter(this::hasPluginForClassloader)
+                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
+                .map(interceptor -> (DisconnectOutboundInterceptor) interceptor)
                 .collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
@@ -19,9 +19,10 @@ package com.hivemq.extensions.client;
 import com.hivemq.annotations.Immutable;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
-import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.auth.ModifiableDefaultPermissions;
 import com.hivemq.extensions.HiveMQExtension;
 import com.hivemq.extensions.HiveMQExtensions;
@@ -69,6 +70,10 @@ public class ClientContextImpl {
         addInterceptor(interceptor);
     }
 
+    public void addDisconnectInboundInterceptor(@NotNull final DisconnectInboundInterceptor interceptor) {
+        addInterceptor(interceptor);
+    }
+
     public void removePublishInboundInterceptor(@NotNull final PublishInboundInterceptor interceptor) {
         removeInterceptor(interceptor);
     }
@@ -82,6 +87,10 @@ public class ClientContextImpl {
     }
 
     public void removeSubscribeInboundInterceptor(@NotNull final SubscribeInboundInterceptor interceptor) {
+        removeInterceptor(interceptor);
+    }
+
+    public void removeDisconnectInboundInterceptor(@NotNull final DisconnectInboundInterceptor interceptor) {
         removeInterceptor(interceptor);
     }
 
@@ -107,7 +116,8 @@ public class ClientContextImpl {
 
     @NotNull
     @Immutable
-    public List<PublishInboundInterceptor> getPublishInboundInterceptorsForPlugin(@NotNull final IsolatedPluginClassloader pluginClassloader) {
+    public List<PublishInboundInterceptor> getPublishInboundInterceptorsForPlugin(
+            @NotNull final IsolatedPluginClassloader pluginClassloader) {
         return interceptorList.stream()
                 .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
                 .filter(interceptor -> interceptor instanceof PublishInboundInterceptor)
@@ -117,7 +127,8 @@ public class ClientContextImpl {
 
     @NotNull
     @Immutable
-    public List<SubscribeInboundInterceptor> getSubscribeInboundInterceptorsForPlugin(@NotNull final IsolatedPluginClassloader pluginClassloader) {
+    public List<SubscribeInboundInterceptor> getSubscribeInboundInterceptorsForPlugin(
+            @NotNull final IsolatedPluginClassloader pluginClassloader) {
         return interceptorList.stream()
                 .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
                 .filter(interceptor -> interceptor instanceof SubscribeInboundInterceptor)
@@ -138,7 +149,8 @@ public class ClientContextImpl {
 
     @NotNull
     @Immutable
-    public List<PublishOutboundInterceptor> getPublishOutboundInterceptorsForPlugin(@NotNull final IsolatedPluginClassloader pluginClassloader) {
+    public List<PublishOutboundInterceptor> getPublishOutboundInterceptorsForPlugin(
+            @NotNull final IsolatedPluginClassloader pluginClassloader) {
         return interceptorList.stream()
                 .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
                 .filter(interceptor -> interceptor instanceof PublishOutboundInterceptor)
@@ -165,6 +177,17 @@ public class ClientContextImpl {
                 .filter(this::hasPluginForClassloader)
                 .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
                 .map(interceptor -> (SubscribeInboundInterceptor) interceptor)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @NotNull
+    @Immutable
+    public List<DisconnectInboundInterceptor> getDisconnectInboundInterceptors() {
+        return interceptorList.stream()
+                .filter(interceptor -> interceptor instanceof DisconnectInboundInterceptor)
+                .filter(this::hasPluginForClassloader)
+                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
+                .map(interceptor -> (DisconnectInboundInterceptor) interceptor)
                 .collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
@@ -102,6 +102,7 @@ public class ClientContextImpl {
     public void removeDisconnectOutboundInterceptor(@NotNull final DisconnectOutboundInterceptor interceptor) {
         removeInterceptor(interceptor);
     }
+
     public void removeInterceptor(@NotNull final Interceptor interceptor) {
         interceptorList.remove(interceptor);
     }
@@ -190,6 +191,17 @@ public class ClientContextImpl {
 
     @NotNull
     @Immutable
+    public List<DisconnectInboundInterceptor> getDisconnectInboundInterceptorsForPlugin(
+            @NotNull final IsolatedPluginClassloader pluginClassloader) {
+        return interceptorList.stream()
+                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
+                .filter(interceptor -> interceptor instanceof DisconnectInboundInterceptor)
+                .map(interceptor -> (DisconnectInboundInterceptor) interceptor)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @NotNull
+    @Immutable
     public List<DisconnectInboundInterceptor> getDisconnectInboundInterceptors() {
         return interceptorList.stream()
                 .filter(interceptor -> interceptor instanceof DisconnectInboundInterceptor)
@@ -201,7 +213,18 @@ public class ClientContextImpl {
 
     @NotNull
     @Immutable
-    public List<DisconnectOutboundInterceptor> getDisconnectOutboundInterceptor() {
+    public List<DisconnectOutboundInterceptor> getDisconnectOutboundInterceptorsForPlugin(
+            @NotNull final IsolatedPluginClassloader pluginClassloader) {
+        return interceptorList.stream()
+                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
+                .filter(interceptor -> interceptor instanceof DisconnectOutboundInterceptor)
+                .map(interceptor -> (DisconnectOutboundInterceptor) interceptor)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @NotNull
+    @Immutable
+    public List<DisconnectOutboundInterceptor> getDisconnectOutboundInterceptors() {
         return interceptorList.stream()
                 .filter(interceptor -> interceptor instanceof DisconnectOutboundInterceptor)
                 .filter(this::hasPluginForClassloader)

--- a/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
@@ -20,6 +20,7 @@ import com.hivemq.annotations.Immutable;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.extension.sdk.api.client.ClientContext;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
@@ -65,18 +66,30 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     }
 
     @Override
+    public void addDisconnectInboundInterceptor(
+            final @NotNull DisconnectInboundInterceptor interceptor) {
+        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+    }
+
+    @Override
     public void removePublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
         clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePublishOutboundInterceptor(final @NotNull PublishOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(interceptor);
+        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removeSubscribeInboundInterceptor(final @NotNull SubscribeInboundInterceptor interceptor) {
         clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+    }
+
+    @Override
+    public void removeDisconnectInboundInterceptor(
+            final @NotNull DisconnectInboundInterceptor interceptor) {
+
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
@@ -21,6 +21,7 @@ import com.hivemq.annotations.NotNull;
 import com.hivemq.extension.sdk.api.client.ClientContext;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
@@ -72,6 +73,12 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     }
 
     @Override
+    public void addDisconnectOutboundInterceptor(
+            final @NotNull DisconnectOutboundInterceptor interceptor) {
+        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+    }
+
+    @Override
     public void removePublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
         clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
@@ -89,7 +96,13 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     @Override
     public void removeDisconnectInboundInterceptor(
             final @NotNull DisconnectInboundInterceptor interceptor) {
+        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+    }
 
+    @Override
+    public void removeDisconnectOutboundInterceptor(
+            final @NotNull DisconnectOutboundInterceptor interceptor) {
+        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
@@ -135,6 +135,20 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
 
     @NotNull
     @Override
+    @Immutable
+    public List<DisconnectOutboundInterceptor> getDisconnectOutboundInterceptors() {
+        return clientContext.getDisconnectOutboundInterceptorsForPlugin(pluginClassloader);
+    }
+
+    @NotNull
+    @Override
+    @Immutable
+    public List<DisconnectInboundInterceptor> getDisconnectInboundInterceptors() {
+        return clientContext.getDisconnectInboundInterceptorsForPlugin(pluginClassloader);
+    }
+
+    @NotNull
+    @Override
     public ModifiableDefaultPermissions getDefaultPermissions() {
         return clientContext.getDefaultPermissions();
     }

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
@@ -3,6 +3,7 @@ package com.hivemq.extensions.handler;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.inject.Inject;
 import com.hivemq.annotations.Nullable;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -43,6 +44,7 @@ public class DisconnectInboundInterceptorHandler extends SimpleChannelInboundHan
     private final @NotNull PluginTaskExecutorService pluginTaskExecutorService;
     private final @NotNull FullConfigurationService configurationService;
 
+    @Inject
     public DisconnectInboundInterceptorHandler(
             @NotNull final FullConfigurationService configurationService,
             @NotNull final PluginOutPutAsyncer asyncer,

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
@@ -159,7 +159,7 @@ public class DisconnectInboundInterceptorHandler extends SimpleChannelInboundHan
                 final @NotNull DisconnectInboundInputImpl disconnectInboundInput,
                 final @NotNull DisconnectInboundOutputImpl disconnectInboundOutput) {
             try {
-                interceptor.onDisconnect(disconnectInboundInput, disconnectInboundOutput);
+                interceptor.onInboundDisconnect(disconnectInboundInput, disconnectInboundOutput);
             } catch (final Throwable e) {
                 log.warn(
                         "Uncaught exception was thrown from extension with id \"{}\" on inbound disconnect request interception." +

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
@@ -20,7 +20,6 @@ import com.hivemq.extensions.interceptor.disconnect.DisconnectInboundInputImpl;
 import com.hivemq.extensions.interceptor.disconnect.DisconnectInboundOutputImpl;
 import com.hivemq.mqtt.message.disconnect.DISCONNECT;
 import com.hivemq.util.ChannelAttributes;
-import com.hivemq.util.Exceptions;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -168,18 +167,19 @@ public class DisconnectInboundInterceptorHandler extends SimpleChannelInboundHan
 
         @Override
         public DisconnectInboundOutputImpl apply(
-                final @NotNull DisconnectInboundInputImpl disconnectInboundInput,
-                final @NotNull DisconnectInboundOutputImpl disconnectInboundOutput) {
+                final @NotNull DisconnectInboundInputImpl input,
+                final @NotNull DisconnectInboundOutputImpl output) {
             try {
-                interceptor.onInboundDisconnect(disconnectInboundInput, disconnectInboundOutput);
+                interceptor.onInboundDisconnect(input, output);
             } catch (final Throwable e) {
                 log.warn(
                         "Uncaught exception was thrown from extension with id \"{}\" on inbound disconnect request interception." +
                                 "Extensions are responsible for their own exception handling.",
                         pluginId);
-                Exceptions.rethrowError(e);
+                final DISCONNECT disconnect = DISCONNECT.createDisconnectFrom(input.getDisconnectPacket());
+                output.update(disconnect);
             }
-            return disconnectInboundOutput;
+            return output;
         }
 
         @Override

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
@@ -1,0 +1,199 @@
+package com.hivemq.extensions.handler;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import com.hivemq.annotations.Nullable;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
+import com.hivemq.extensions.HiveMQExtension;
+import com.hivemq.extensions.HiveMQExtensions;
+import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
+import com.hivemq.extensions.client.ClientContextImpl;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.task.PluginInOutTask;
+import com.hivemq.extensions.executor.task.PluginInOutTaskContext;
+import com.hivemq.extensions.interceptor.disconnect.DisconnectInboundInputImpl;
+import com.hivemq.extensions.interceptor.disconnect.DisconnectInboundOutputImpl;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import com.hivemq.util.ChannelAttributes;
+import com.hivemq.util.Exceptions;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Robin Atherton
+ */
+@ChannelHandler.Sharable
+public class DisconnectInboundInterceptorHandler extends SimpleChannelInboundHandler<DISCONNECT> {
+
+    private static final Logger log = LoggerFactory.getLogger(DisconnectInboundInterceptorHandler.class);
+
+    private final @NotNull PluginOutPutAsyncer asyncer;
+    private final @NotNull HiveMQExtensions hiveMQExtensions;
+    private final @NotNull PluginTaskExecutorService pluginTaskExecutorService;
+    private final @NotNull FullConfigurationService configurationService;
+
+    public DisconnectInboundInterceptorHandler(
+            @NotNull final FullConfigurationService configurationService,
+            @NotNull final PluginOutPutAsyncer asyncer,
+            @NotNull final HiveMQExtensions hiveMQExtensions,
+            @NotNull final PluginTaskExecutorService pluginTaskExecutorService) {
+        this.asyncer = asyncer;
+        this.hiveMQExtensions = hiveMQExtensions;
+        this.pluginTaskExecutorService = pluginTaskExecutorService;
+        this.configurationService = configurationService;
+    }
+
+    @Override
+    protected void channelRead0(
+            final @NotNull ChannelHandlerContext ctx, final @NotNull DISCONNECT disconnect) throws Exception {
+
+        final Channel channel = ctx.channel();
+        if (!channel.isActive()) {
+            return;
+        }
+
+        final String clientId = channel.attr(ChannelAttributes.CLIENT_ID).get();
+        if (clientId == null) {
+            return;
+        }
+
+        final ClientContextImpl clientContext = channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).get();
+        final List<DisconnectInboundInterceptor> disconnectInboundInterceptors =
+                clientContext.getDisconnectInboundInterceptors();
+
+        if (disconnectInboundInterceptors.isEmpty()) {
+            super.channelRead(ctx, disconnect);
+            return;
+        }
+
+        final DisconnectInboundOutputImpl output =
+                new DisconnectInboundOutputImpl(configurationService, asyncer, disconnect);
+        final DisconnectInboundInputImpl input = new DisconnectInboundInputImpl(disconnect, clientId, channel);
+        final SettableFuture<Void> interceptorFuture = SettableFuture.create();
+        final DisconnectInboundInterceptorContext interceptorContext =
+                new DisconnectInboundInterceptorContext(DisconnectInboundInterceptorTask.class, clientId,
+                        interceptorFuture, disconnectInboundInterceptors.size());
+
+        for (final DisconnectInboundInterceptor interceptor : disconnectInboundInterceptors) {
+            if (!interceptorFuture.isDone()) {
+                interceptorFuture.set(null);
+            }
+
+            final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
+                    (IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
+            if (extension == null) {
+                interceptorContext.increment();
+                continue;
+            }
+
+            final DisconnectInboundInterceptorTask interceptorTask =
+                    new DisconnectInboundInterceptorTask(interceptor, extension.getId());
+            pluginTaskExecutorService.handlePluginInOutTaskExecution(
+                    interceptorContext, input, output, interceptorTask);
+        }
+
+        final DisconnectInterceptorFutureCallback callback = new DisconnectInterceptorFutureCallback(ctx);
+        Futures.addCallback(interceptorFuture, callback, ctx.executor());
+    }
+
+    private static class DisconnectInboundInterceptorContext
+            extends PluginInOutTaskContext<DisconnectInboundOutputImpl> {
+
+        private final @NotNull SettableFuture<Void> interceptorFuture;
+        private final int interceptorCount;
+        private final @NotNull AtomicInteger counter;
+
+        DisconnectInboundInterceptorContext(
+                @NotNull final Class<?> taskClazz,
+                @NotNull final String identifier,
+                @NotNull final SettableFuture<Void> interceptorFuture,
+                final int interceptorCount) {
+            super(taskClazz, identifier);
+            this.interceptorFuture = interceptorFuture;
+            this.interceptorCount = interceptorCount;
+            this.counter = new AtomicInteger(0);
+        }
+
+        @Override
+        public void pluginPost(
+                final @NotNull DisconnectInboundOutputImpl pluginOutput) {
+            if (counter.incrementAndGet() == interceptorCount) {
+                interceptorFuture.set(null);
+            }
+        }
+
+        public void increment() {
+            //we must set the future when no more interceptors are registered
+            if (counter.incrementAndGet() == interceptorCount) {
+                interceptorFuture.set(null);
+            }
+        }
+    }
+
+    private static class DisconnectInboundInterceptorTask
+            implements PluginInOutTask<DisconnectInboundInputImpl, DisconnectInboundOutputImpl> {
+
+        private final @NotNull DisconnectInboundInterceptor interceptor;
+        private final @NotNull String pluginId;
+
+        private DisconnectInboundInterceptorTask(
+                @NotNull final DisconnectInboundInterceptor interceptor,
+                @NotNull final String pluginId) {
+            this.interceptor = interceptor;
+            this.pluginId = pluginId;
+        }
+
+        @Override
+        public DisconnectInboundOutputImpl apply(
+                final @NotNull DisconnectInboundInputImpl disconnectInboundInput,
+                final @NotNull DisconnectInboundOutputImpl disconnectInboundOutput) {
+            try {
+                interceptor.onDisconnect(disconnectInboundInput, disconnectInboundOutput);
+            } catch (final Throwable e) {
+                log.warn(
+                        "Uncaught exception was thrown from extension with id \"{}\" on inbound disconnect request interception." +
+                                "Extensions are responsible for their own exception handling.",
+                        pluginId);
+                Exceptions.rethrowError(e);
+            }
+            return disconnectInboundOutput;
+        }
+
+        @Override
+        public @NotNull ClassLoader getPluginClassLoader() {
+            return interceptor.getClass().getClassLoader();
+        }
+    }
+
+    private static class DisconnectInterceptorFutureCallback implements FutureCallback<Void> {
+
+        private final @NotNull ChannelHandlerContext ctx;
+
+        DisconnectInterceptorFutureCallback(
+                final @NotNull ChannelHandlerContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void onSuccess(final @Nullable Void result) {
+            final DISCONNECT disconnect = new DISCONNECT();
+            ctx.fireChannelRead(disconnect);
+        }
+
+        @Override
+        public void onFailure(final Throwable t) {
+
+        }
+    }
+}

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandler.java
@@ -94,7 +94,10 @@ public class DisconnectInboundInterceptorHandler extends ChannelInboundHandlerAd
 
         final DisconnectInboundOutputImpl output =
                 new DisconnectInboundOutputImpl(configurationService, asyncer, disconnect);
-        final DisconnectInboundInputImpl input = new DisconnectInboundInputImpl(disconnect, clientId, channel);
+
+        final DisconnectInboundInputImpl input =
+                new DisconnectInboundInputImpl(new DisconnectPacketImpl(disconnect), clientId, channel);
+
         final SettableFuture<Void> interceptorFuture = SettableFuture.create();
         final DisconnectInboundInterceptorContext interceptorContext =
                 new DisconnectInboundInterceptorContext(DisconnectInboundInterceptorTask.class, clientId, input, output,

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandler.java
@@ -92,7 +92,7 @@ public class DisconnectOutboundInterceptorHandler extends ChannelOutboundHandler
         final DisconnectOutboundInputImpl input =
                 new DisconnectOutboundInputImpl(new DisconnectPacketImpl(disconnect), clientId, channel);
         final DisconnectOutboundOutputImpl output =
-                new DisconnectOutboundOutputImpl(asyncer, configurationService, disconnect);
+                new DisconnectOutboundOutputImpl(configurationService, asyncer, disconnect);
         final SettableFuture<Void> interceptorFuture = SettableFuture.create();
 
         final DisconnectOutboundInterceptorContext interceptorContext =

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandler.java
@@ -1,0 +1,77 @@
+package com.hivemq.extensions.handler;
+
+import com.google.inject.Inject;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectOutboundInterceptor;
+import com.hivemq.extensions.HiveMQExtensions;
+import com.hivemq.extensions.client.ClientContextImpl;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.util.List;
+
+/**
+ * @author Robin Atherton
+ */
+@Singleton
+@ChannelHandler.Sharable
+public class DisconnectOutboundInterceptorHandler extends ChannelOutboundHandlerAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(DisconnectOutboundInterceptorHandler.class);
+
+    private final @NotNull FullConfigurationService configurationService;
+
+    private final @NotNull PluginOutPutAsyncer asyncer;
+
+    private final @NotNull HiveMQExtensions hiveMQExtensions;
+
+    private final @NotNull PluginTaskExecutorService executorService;
+
+    @Inject
+    public DisconnectOutboundInterceptorHandler(
+            @NotNull final FullConfigurationService configurationService,
+            @NotNull final PluginOutPutAsyncer asyncer,
+            @NotNull final HiveMQExtensions hiveMQExtensions,
+            @NotNull final PluginTaskExecutorService executorService) {
+        this.configurationService = configurationService;
+        this.asyncer = asyncer;
+        this.hiveMQExtensions = hiveMQExtensions;
+        this.executorService = executorService;
+    }
+
+    @Override
+    public void write(
+            final @NotNull ChannelHandlerContext ctx, final @NotNull Object msg, final @NotNull ChannelPromise promise)
+            throws Exception {
+
+        if (!(msg instanceof DISCONNECT)) {
+            super.write(ctx, msg, promise);
+        }
+
+        final DISCONNECT disconnect = (DISCONNECT) msg;
+
+        final Channel channel = ctx.channel();
+        if (!channel.isActive()) {
+            return;
+        }
+
+        final String clientId = channel.attr(ChannelAttributes.CLIENT_ID).get();
+        if (clientId == null) {
+            return;
+        }
+
+        final ClientContextImpl clientContext = channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).get();
+        if (clientContext == null || clientContext.getPublishOutboundInterceptors().isEmpty()) {
+            return;
+        }
+
+        final List<DisconnectOutboundInterceptor> disconnectOutboundInterceptors; //TODO
+    }
+}

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandler.java
@@ -82,7 +82,7 @@ public class DisconnectOutboundInterceptorHandler extends ChannelOutboundHandler
         }
 
         final ClientContextImpl clientContext = channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).get();
-        if (clientContext == null || clientContext.getPublishOutboundInterceptors().isEmpty()) {
+        if (clientContext == null || clientContext.getDisconnectOutboundInterceptors().isEmpty()) {
             super.write(ctx, msg, promise);
             return;
         }
@@ -132,7 +132,7 @@ public class DisconnectOutboundInterceptorHandler extends ChannelOutboundHandler
         private final int interceptorCount;
         private final @NotNull AtomicInteger counter;
 
-        public DisconnectOutboundInterceptorContext(
+        DisconnectOutboundInterceptorContext(
                 @NotNull final Class<?> taskClazz,
                 @NotNull final String identifier,
                 @NotNull final DisconnectOutboundInputImpl input,
@@ -172,7 +172,7 @@ public class DisconnectOutboundInterceptorHandler extends ChannelOutboundHandler
         private final @NotNull SettableFuture<Void> interceptorFuture;
         private final @NotNull String pluginId;
 
-        public DisconnectOutboundInterceptorTask(
+        DisconnectOutboundInterceptorTask(
                 @NotNull final DisconnectOutboundInterceptor interceptor,
                 @NotNull final SettableFuture<Void> interceptorFuture,
                 @NotNull final String pluginId) {

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandler.java
@@ -1,21 +1,32 @@
 package com.hivemq.extensions.handler;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.inject.Inject;
+import com.hivemq.annotations.Nullable;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectOutboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundOutput;
 import com.hivemq.extensions.HiveMQExtensions;
 import com.hivemq.extensions.client.ClientContextImpl;
 import com.hivemq.extensions.executor.PluginOutPutAsyncer;
 import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.task.PluginInOutTask;
+import com.hivemq.extensions.executor.task.PluginInOutTaskContext;
+import com.hivemq.extensions.interceptor.disconnect.DisconnectOutboundInputImpl;
+import com.hivemq.extensions.interceptor.disconnect.DisconnectOutboundOutputImpl;
+import com.hivemq.extensions.packets.disconnect.DisconnectPacketImpl;
 import com.hivemq.mqtt.message.disconnect.DISCONNECT;
 import com.hivemq.util.ChannelAttributes;
+import com.hivemq.util.Exceptions;
 import io.netty.channel.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Robin Atherton
@@ -72,6 +83,123 @@ public class DisconnectOutboundInterceptorHandler extends ChannelOutboundHandler
             return;
         }
 
-        final List<DisconnectOutboundInterceptor> disconnectOutboundInterceptors; //TODO
+        final List<DisconnectOutboundInterceptor> disconnectOutboundInterceptors =
+                clientContext.getDisconnectOutboundInterceptor();
+        final DisconnectOutboundInputImpl input =
+                new DisconnectOutboundInputImpl(new DisconnectPacketImpl(disconnect), clientId, channel);
+        final DisconnectOutboundOutputImpl output =
+                new DisconnectOutboundOutputImpl(asyncer, configurationService, disconnect);
+        final SettableFuture<Void> interceptorFuture = SettableFuture.create();
+
+    }
+
+    static class DisconnectOutboundInterceptorContext extends PluginInOutTaskContext<DisconnectOutboundOutputImpl> {
+
+        private final @NotNull DisconnectOutboundOutputImpl output;
+        private final @NotNull DisconnectOutboundInputImpl input;
+        final @NotNull SettableFuture<Void> interceptorFuture;
+        private final int interceptorCount;
+        private final @NotNull AtomicInteger counter;
+
+        public DisconnectOutboundInterceptorContext(
+                @NotNull final Class<?> taskClazz,
+                @NotNull final String identifier,
+                @NotNull final DisconnectOutboundOutputImpl output,
+                @NotNull final DisconnectOutboundInputImpl input,
+                @NotNull final SettableFuture<Void> interceptorFuture, final int interceptorCount,
+                @NotNull final AtomicInteger counter) {
+            super(taskClazz, identifier);
+            this.output = output;
+            this.input = input;
+            this.interceptorFuture = interceptorFuture;
+            this.interceptorCount = interceptorCount;
+            this.counter = counter;
+        }
+
+        @Override
+        public void pluginPost(
+                final @NotNull DisconnectOutboundOutputImpl pluginOutput) {
+            if (output.getDisconnectPacket().isModified()) {
+                input.updateDisconnect(output.getDisconnectPacket());
+            }
+
+            if (counter.incrementAndGet() == interceptorCount) {
+                interceptorFuture.set(null);
+            }
+        }
+
+        public void increment() {
+            //we must set the future when no more interceptors are registered
+            if (counter.incrementAndGet() == interceptorCount) {
+                interceptorFuture.set(null);
+            }
+        }
+    }
+
+    private class DisconnectOutboundInterceptorTask
+            implements PluginInOutTask<DisconnectOutboundInputImpl, DisconnectOutboundOutputImpl> {
+
+        private final @NotNull DisconnectOutboundInterceptor interceptor;
+        private final @NotNull String pluginId;
+
+        public DisconnectOutboundInterceptorTask(
+                @NotNull final DisconnectOutboundInterceptor interceptor,
+                @NotNull final String pluginId) {
+            this.interceptor = interceptor;
+            this.pluginId = pluginId;
+        }
+
+        @Override
+        public DisconnectOutboundOutputImpl apply(
+                final @NotNull DisconnectOutboundInputImpl disconnectOutboundInput,
+                final @NotNull DisconnectOutboundOutputImpl disconnectOutboundOutput) {
+            try {
+                interceptor.onOutboundDisconnect(disconnectOutboundInput, disconnectOutboundOutput);
+            } catch (final Throwable e) {
+                log.warn(
+                        "Uncaught exception was thrown from extension with id \"{}\" on outbound disconnect interception. " +
+                                "Extensions are responsible on their own to handle exceptions.", pluginId);
+                Exceptions.rethrowError(e);
+            }
+            return disconnectOutboundOutput;
+        }
+
+        @Override
+        public @NotNull ClassLoader getPluginClassLoader() {
+            return interceptor.getClass().getClassLoader();
+        }
+    }
+
+    private static class InterceptorFutureCallback implements FutureCallback<Void> {
+
+        private final @NotNull DisconnectOutboundOutput outboundOutput;
+        private final @NotNull DISCONNECT disconnect;
+        private final @NotNull ChannelHandlerContext ctx;
+        private final @NotNull ChannelPromise promise;
+
+        public InterceptorFutureCallback(
+                @NotNull final DisconnectOutboundOutput outboundOutput,
+                @NotNull final DISCONNECT disconnect,
+                @NotNull final ChannelHandlerContext ctx,
+                @NotNull final ChannelPromise promise) {
+            this.outboundOutput = outboundOutput;
+            this.disconnect = disconnect;
+            this.ctx = ctx;
+            this.promise = promise;
+        }
+
+        @Override
+        public void onSuccess(@Nullable final Void result) {
+            //TODO
+            //try {
+            //  @NotNull ModifiableDisconnectPacket dc = outboundOutput.getDisconnectPacket();
+
+            //}
+        }
+
+        @Override
+        public void onFailure(final Throwable t) {
+
+        }
     }
 }

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
@@ -1,0 +1,56 @@
+package com.hivemq.extensions.interceptor.disconnect;
+
+import com.hivemq.annotations.Immutable;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
+import com.hivemq.extension.sdk.api.client.parameter.ConnectionInformation;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundInput;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extensions.PluginInformationUtil;
+import com.hivemq.extensions.executor.task.PluginTaskInput;
+import com.hivemq.extensions.packets.disconnect.DisconnectPacketImpl;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import io.netty.channel.Channel;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Robin Atherton
+ */
+public class DisconnectInboundInputImpl
+        implements Supplier<DisconnectInboundInputImpl>, DisconnectInboundInput, PluginTaskInput {
+
+    private final @NotNull DisconnectPacket disconnectPacket;
+    private final @NotNull ConnectionInformation connectionInformation;
+    private final @NotNull ClientInformation clientInformation;
+
+    public DisconnectInboundInputImpl(
+            final @NotNull DISCONNECT disconnect,
+            final @NotNull String clientId,
+            final @NotNull Channel channel) {
+        this.disconnectPacket = new DisconnectPacketImpl(disconnect);
+        this.connectionInformation = PluginInformationUtil.getAndSetConnectionInformation(channel);
+        this.clientInformation = PluginInformationUtil.getAndSetClientInformation(channel, clientId);
+    }
+
+    @Override
+    public @Immutable
+    @NotNull DisconnectPacket getDisconnectPacket() {
+        return disconnectPacket;
+    }
+
+    @Override
+    public @NotNull ConnectionInformation getConnectionInformation() {
+        return connectionInformation;
+    }
+
+    @Override
+    public @NotNull ClientInformation getClientInformation() {
+        return clientInformation;
+    }
+
+    @Override
+    public DisconnectInboundInputImpl get() {
+        return this;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
@@ -55,6 +55,6 @@ public class DisconnectInboundInputImpl
     }
 
     public void updateDisconnect(final @NotNull DisconnectPacket disconnectPacket) {
-        this.disconnectPacket = disconnectPacket;
+        this.disconnectPacket = new DisconnectPacketImpl(disconnectPacket);
     }
 }

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
@@ -9,7 +9,6 @@ import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
 import com.hivemq.extensions.PluginInformationUtil;
 import com.hivemq.extensions.executor.task.PluginTaskInput;
 import com.hivemq.extensions.packets.disconnect.DisconnectPacketImpl;
-import com.hivemq.mqtt.message.disconnect.DISCONNECT;
 import io.netty.channel.Channel;
 
 import java.util.function.Supplier;
@@ -25,10 +24,10 @@ public class DisconnectInboundInputImpl
     private final @NotNull ClientInformation clientInformation;
 
     public DisconnectInboundInputImpl(
-            final @NotNull DISCONNECT disconnect,
+            final @NotNull DisconnectPacket disconnectPacket,
             final @NotNull String clientId,
             final @NotNull Channel channel) {
-        this.disconnectPacket = new DisconnectPacketImpl(disconnect);
+        this.disconnectPacket = disconnectPacket;
         this.connectionInformation = PluginInformationUtil.getAndSetConnectionInformation(channel);
         this.clientInformation = PluginInformationUtil.getAndSetClientInformation(channel, clientId);
     }

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
@@ -34,8 +34,8 @@ public class DisconnectInboundInputImpl
     }
 
     @Override
-    public @Immutable
-    @NotNull DisconnectPacket getDisconnectPacket() {
+    @Immutable
+    public @NotNull DisconnectPacket getDisconnectPacket() {
         return disconnectPacket;
     }
 

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
 public class DisconnectInboundInputImpl
         implements Supplier<DisconnectInboundInputImpl>, DisconnectInboundInput, PluginTaskInput {
 
-    private final @NotNull DisconnectPacket disconnectPacket;
+    private @NotNull DisconnectPacket disconnectPacket;
     private final @NotNull ConnectionInformation connectionInformation;
     private final @NotNull ClientInformation clientInformation;
 
@@ -52,5 +52,9 @@ public class DisconnectInboundInputImpl
     @Override
     public DisconnectInboundInputImpl get() {
         return this;
+    }
+
+    public void updateDisconnect(final @NotNull DisconnectPacket disconnectPacket) {
+        this.disconnectPacket = disconnectPacket;
     }
 }

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImpl.java
@@ -18,8 +18,8 @@ public class DisconnectInboundOutputImpl extends AbstractAsyncOutput<DisconnectI
         implements DisconnectInboundOutput,
         PluginTaskOutput, Supplier<DisconnectInboundOutputImpl> {
 
-    private @NotNull ModifiableDisconnectPacketImpl disconnectPacket;
     private final @NotNull FullConfigurationService configurationService;
+    private @NotNull ModifiableDisconnectPacketImpl disconnectPacket;
 
     public DisconnectInboundOutputImpl(
             final @NotNull FullConfigurationService configurationService,
@@ -27,7 +27,7 @@ public class DisconnectInboundOutputImpl extends AbstractAsyncOutput<DisconnectI
             final @NotNull DISCONNECT disconnect) {
         super(asyncer);
         this.configurationService = configurationService;
-        this.disconnectPacket = new ModifiableDisconnectPacketImpl(configurationService, disconnect);
+        this.disconnectPacket = new ModifiableDisconnectPacketImpl(this.configurationService, disconnect);
     }
 
     @Override

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImpl.java
@@ -1,0 +1,43 @@
+package com.hivemq.extensions.interceptor.disconnect;
+
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundOutput;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.task.AbstractAsyncOutput;
+import com.hivemq.extensions.executor.task.PluginTaskOutput;
+import com.hivemq.extensions.packets.disconnect.ModifiableDisconnectPacketImpl;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Robin Atherton
+ */
+public class DisconnectInboundOutputImpl extends AbstractAsyncOutput<DisconnectInboundOutput>
+        implements DisconnectInboundOutput,
+        PluginTaskOutput, Supplier<DisconnectInboundOutputImpl> {
+
+    private final @NotNull ModifiableDisconnectPacket disconnectPacket;
+
+    public DisconnectInboundOutputImpl(
+            final @NotNull FullConfigurationService configurationService,
+            final @NotNull PluginOutPutAsyncer asyncer,
+            final @NotNull DISCONNECT disconnect) {
+        super(asyncer);
+
+        this.disconnectPacket = new ModifiableDisconnectPacketImpl(configurationService, disconnect);
+    }
+
+    @Override
+    public @NotNull DisconnectPacket getDisconnectPacket() {
+        return this.disconnectPacket;
+    }
+
+    @Override
+    public DisconnectInboundOutputImpl get() {
+        return this;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImpl.java
@@ -3,8 +3,6 @@ package com.hivemq.extensions.interceptor.disconnect;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundOutput;
-import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
-import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
 import com.hivemq.extensions.executor.PluginOutPutAsyncer;
 import com.hivemq.extensions.executor.task.AbstractAsyncOutput;
 import com.hivemq.extensions.executor.task.PluginTaskOutput;
@@ -20,24 +18,33 @@ public class DisconnectInboundOutputImpl extends AbstractAsyncOutput<DisconnectI
         implements DisconnectInboundOutput,
         PluginTaskOutput, Supplier<DisconnectInboundOutputImpl> {
 
-    private final @NotNull ModifiableDisconnectPacket disconnectPacket;
+    private @NotNull ModifiableDisconnectPacketImpl disconnectPacket;
+    private final @NotNull FullConfigurationService configurationService;
 
     public DisconnectInboundOutputImpl(
             final @NotNull FullConfigurationService configurationService,
             final @NotNull PluginOutPutAsyncer asyncer,
             final @NotNull DISCONNECT disconnect) {
         super(asyncer);
-
+        this.configurationService = configurationService;
         this.disconnectPacket = new ModifiableDisconnectPacketImpl(configurationService, disconnect);
     }
 
     @Override
-    public @NotNull DisconnectPacket getDisconnectPacket() {
+    public @NotNull ModifiableDisconnectPacketImpl getDisconnectPacket() {
         return this.disconnectPacket;
     }
 
     @Override
     public DisconnectInboundOutputImpl get() {
         return this;
+    }
+
+    public void update(final @NotNull ModifiableDisconnectPacketImpl modifiedDisconnectPacket) {
+        this.disconnectPacket = modifiedDisconnectPacket;
+    }
+
+    public void update(final @NotNull DISCONNECT disconnect) {
+        this.disconnectPacket = new ModifiableDisconnectPacketImpl(configurationService, disconnect);
     }
 }

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundInputImpl.java
@@ -1,0 +1,57 @@
+package com.hivemq.extensions.interceptor.disconnect;
+
+import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
+import com.hivemq.extension.sdk.api.client.parameter.ConnectionInformation;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundInput;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extensions.PluginInformationUtil;
+import com.hivemq.extensions.executor.task.PluginTaskInput;
+import io.netty.channel.Channel;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Robin Atherton
+ */
+public class DisconnectOutboundInputImpl implements Supplier<DisconnectOutboundInputImpl>, DisconnectOutboundInput,
+        PluginTaskInput {
+
+    private final @NotNull ConnectionInformation connectionInformation;
+    private final @NotNull ClientInformation clientInformation;
+    private @NotNull DisconnectPacket disconnectPacket;
+
+    public DisconnectOutboundInputImpl(
+            final @NotNull DisconnectPacket disconnectPacket,
+            final @NotNull String clientId,
+            final @NotNull Channel channel) {
+        this.disconnectPacket = disconnectPacket;
+        this.connectionInformation = PluginInformationUtil.getAndSetConnectionInformation(channel);
+        this.clientInformation = PluginInformationUtil.getAndSetClientInformation(channel, clientId);
+    }
+
+    @Override
+    public @Immutable @NotNull DisconnectPacket getDisconnectPacket() {
+        return disconnectPacket;
+    }
+
+    @Override
+    public @NotNull ConnectionInformation getConnectionInformation() {
+        return connectionInformation;
+    }
+
+    @Override
+    public @NotNull ClientInformation getClientInformation() {
+        return clientInformation;
+    }
+
+    @Override
+    public DisconnectOutboundInputImpl get() {
+        return this;
+    }
+
+    public void updateDisconnect(final @NotNull DisconnectPacket disconnectPacket) {
+        this.disconnectPacket = disconnectPacket;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
@@ -18,12 +18,12 @@ public class DisconnectOutboundOutputImpl extends AbstractAsyncOutput<Disconnect
         implements DisconnectOutboundOutput,
         PluginTaskOutput, Supplier<DisconnectOutboundOutputImpl> {
 
-    private final @NotNull FullConfigurationService configurationService;
     private @NotNull ModifiableDisconnectPacketImpl disconnectPacket;
+    private final @NotNull FullConfigurationService configurationService;
 
     public DisconnectOutboundOutputImpl(
-            final @NotNull PluginOutPutAsyncer asyncer,
             final @NotNull FullConfigurationService configurationService,
+            final @NotNull PluginOutPutAsyncer asyncer,
             final @NotNull DISCONNECT disconnect) {
         super(asyncer);
         this.configurationService = configurationService;

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
@@ -1,0 +1,41 @@
+package com.hivemq.extensions.interceptor.disconnect;
+
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundOutput;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.task.AbstractAsyncOutput;
+import com.hivemq.extensions.executor.task.PluginTaskOutput;
+import com.hivemq.extensions.packets.disconnect.ModifiableDisconnectPacketImpl;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Robin Atherton
+ */
+public class DisconnectOutboundOutputImpl extends AbstractAsyncOutput<DisconnectOutboundOutput>
+        implements DisconnectOutboundOutput,
+        PluginTaskOutput, Supplier<DisconnectOutboundOutputImpl> {
+
+    private final @NotNull ModifiableDisconnectPacketImpl disconnectPacket;
+
+    public DisconnectOutboundOutputImpl(
+            final @NotNull PluginOutPutAsyncer asyncer,
+            final @NotNull FullConfigurationService configurationService,
+            final @NotNull DISCONNECT disconnect) {
+        super(asyncer);
+        this.disconnectPacket = new ModifiableDisconnectPacketImpl(configurationService, disconnect);
+    }
+
+    @Override
+    public @NotNull ModifiableDisconnectPacket getDisconnectPacket() {
+        return disconnectPacket;
+    }
+
+    @Override
+    public DisconnectOutboundOutputImpl get() {
+        return this;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
@@ -19,7 +19,8 @@ public class DisconnectOutboundOutputImpl extends AbstractAsyncOutput<Disconnect
         implements DisconnectOutboundOutput,
         PluginTaskOutput, Supplier<DisconnectOutboundOutputImpl> {
 
-    private final @NotNull ModifiableDisconnectPacketImpl disconnectPacket;
+    private final @NotNull FullConfigurationService configurationService;
+    private @NotNull ModifiableDisconnectPacketImpl disconnectPacket;
 
     public DisconnectOutboundOutputImpl(
             final @NotNull PluginOutPutAsyncer asyncer,
@@ -27,6 +28,7 @@ public class DisconnectOutboundOutputImpl extends AbstractAsyncOutput<Disconnect
             final @NotNull DISCONNECT disconnect) {
         super(asyncer);
         this.disconnectPacket = new ModifiableDisconnectPacketImpl(configurationService, disconnect);
+        this.configurationService = configurationService;
     }
 
     @Override
@@ -37,5 +39,13 @@ public class DisconnectOutboundOutputImpl extends AbstractAsyncOutput<Disconnect
     @Override
     public DisconnectOutboundOutputImpl get() {
         return this;
+    }
+
+    public void update(final @NotNull ModifiableDisconnectPacketImpl modifiedDisconnectPacket) {
+        this.disconnectPacket = modifiedDisconnectPacket;
+    }
+
+    public void update(final @NotNull DISCONNECT disconnect) {
+        this.disconnectPacket = new ModifiableDisconnectPacketImpl(configurationService, disconnect);
     }
 }

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
@@ -3,7 +3,6 @@ package com.hivemq.extensions.interceptor.disconnect;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundOutput;
-import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
 import com.hivemq.extensions.executor.PluginOutPutAsyncer;
 import com.hivemq.extensions.executor.task.AbstractAsyncOutput;
 import com.hivemq.extensions.executor.task.PluginTaskOutput;
@@ -27,12 +26,12 @@ public class DisconnectOutboundOutputImpl extends AbstractAsyncOutput<Disconnect
             final @NotNull FullConfigurationService configurationService,
             final @NotNull DISCONNECT disconnect) {
         super(asyncer);
-        this.disconnectPacket = new ModifiableDisconnectPacketImpl(configurationService, disconnect);
         this.configurationService = configurationService;
+        this.disconnectPacket = new ModifiableDisconnectPacketImpl(this.configurationService, disconnect);
     }
 
     @Override
-    public @NotNull ModifiableDisconnectPacket getDisconnectPacket() {
+    public @NotNull ModifiableDisconnectPacketImpl getDisconnectPacket() {
         return disconnectPacket;
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/DisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/DisconnectPacketImpl.java
@@ -1,0 +1,40 @@
+package com.hivemq.extensions.packets.disconnect;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extension.sdk.api.packets.general.UserProperties;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+
+/**
+ * @author Robin Atherton
+ */
+public class DisconnectPacketImpl implements DisconnectPacket {
+
+    private final @NotNull DISCONNECT disconnect;
+
+    public DisconnectPacketImpl(
+            @NotNull final DISCONNECT disconnect) {
+        this.disconnect = disconnect;
+    }
+
+    public DISCONNECT getDisconnect() {
+        return disconnect;
+    }
+
+    public String getServerReference() {
+        return disconnect.getServerReference();
+    }
+
+    public String getReasonString() {
+        return disconnect.getReasonString();
+    }
+
+    public long getSessionExpiryInterval() {
+        return disconnect.getSessionExpiryInterval();
+    }
+
+    public @NotNull UserProperties getUserProperties() {
+        return disconnect.getUserProperties().getPluginUserProperties();
+    }
+
+}

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/DisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/DisconnectPacketImpl.java
@@ -2,6 +2,7 @@ package com.hivemq.extensions.packets.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.mqtt.message.disconnect.DISCONNECT;
 
@@ -10,31 +11,48 @@ import com.hivemq.mqtt.message.disconnect.DISCONNECT;
  */
 public class DisconnectPacketImpl implements DisconnectPacket {
 
-    private final @NotNull DISCONNECT disconnect;
+    private final @NotNull DisconnectReasonCode reasonCode;
+    private final String serverReference;
+    private final String reasonString;
+    private final @NotNull UserProperties userProperties;
+    private final long sessionExpiryInterval;
 
     public DisconnectPacketImpl(
             @NotNull final DISCONNECT disconnect) {
-        this.disconnect = disconnect;
+        this.serverReference = disconnect.getServerReference();
+        this.reasonString = disconnect.getReasonString();
+        this.reasonCode = DisconnectReasonCode.valueOf(disconnect.getReasonCode().name());
+        this.userProperties = disconnect.getUserProperties().getPluginUserProperties();
+        this.sessionExpiryInterval = disconnect.getSessionExpiryInterval();
     }
 
-    public DISCONNECT getDisconnect() {
-        return disconnect;
+    public DisconnectPacketImpl(final @NotNull DisconnectPacket disconnectPacket) {
+        this.serverReference = disconnectPacket.getServerReference();
+        this.reasonString = disconnectPacket.getReasonString();
+        this.reasonCode = disconnectPacket.getReasonCode();
+        this.userProperties = disconnectPacket.getUserProperties();
+        this.sessionExpiryInterval = disconnectPacket.getSessionExpiryInterval();
     }
 
     public String getServerReference() {
-        return disconnect.getServerReference();
+        return this.serverReference;
+    }
+
+    @Override
+    public DisconnectReasonCode getReasonCode() {
+        return reasonCode;
     }
 
     public String getReasonString() {
-        return disconnect.getReasonString();
+        return this.reasonString;
     }
 
     public long getSessionExpiryInterval() {
-        return disconnect.getSessionExpiryInterval();
+        return this.sessionExpiryInterval;
     }
 
     public @NotNull UserProperties getUserProperties() {
-        return disconnect.getUserProperties().getPluginUserProperties();
+        return userProperties;
     }
 
 }

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableDisconnectPacketImpl.java
@@ -3,6 +3,7 @@ package com.hivemq.extensions.packets.disconnect;
 import com.hivemq.annotations.Nullable;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
 import com.hivemq.extension.sdk.api.packets.general.ModifiableUserProperties;
 import com.hivemq.extensions.packets.general.ModifiableUserPropertiesImpl;
@@ -17,6 +18,8 @@ public class ModifiableDisconnectPacketImpl implements ModifiableDisconnectPacke
 
     private final @NotNull FullConfigurationService configurationService;
     private boolean modified = false;
+    private final @NotNull DisconnectReasonCode reasonCode;
+
 
     private long sessionExpiryInterval;
     private String reasonString;
@@ -27,6 +30,7 @@ public class ModifiableDisconnectPacketImpl implements ModifiableDisconnectPacke
             final @NotNull FullConfigurationService fullConfigurationService,
             final @NotNull DISCONNECT originalDisconnect) {
         this.configurationService = fullConfigurationService;
+        this.reasonCode = DisconnectReasonCode.valueOf(originalDisconnect.getReasonCode().name());
         this.userProperties = new ModifiableUserPropertiesImpl(
                 originalDisconnect.getUserProperties().getPluginUserProperties(),
                 configurationService.securityConfiguration().validateUTF8());
@@ -34,6 +38,7 @@ public class ModifiableDisconnectPacketImpl implements ModifiableDisconnectPacke
         this.sessionExpiryInterval = originalDisconnect.getSessionExpiryInterval();
         this.serverReference = originalDisconnect.getServerReference();
     }
+
 
     @Override
     public synchronized void setReasonString(final @NotNull String reasonString) {
@@ -66,6 +71,11 @@ public class ModifiableDisconnectPacketImpl implements ModifiableDisconnectPacke
     @Override
     public String getServerReference() {
         return this.serverReference;
+    }
+
+    @Override
+    public DisconnectReasonCode getReasonCode() {
+        return reasonCode;
     }
 
     @Override

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableDisconnectPacketImpl.java
@@ -1,0 +1,80 @@
+package com.hivemq.extensions.packets.disconnect;
+
+import com.hivemq.annotations.Nullable;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
+import com.hivemq.extension.sdk.api.packets.general.ModifiableUserProperties;
+import com.hivemq.extensions.packets.general.ModifiableUserPropertiesImpl;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * @author Robin Atherton
+ */
+public class ModifiableDisconnectPacketImpl implements ModifiableDisconnectPacket {
+
+    private final @NotNull FullConfigurationService configurationService;
+    private boolean modified = false;
+
+    private long sessionExpiryInterval;
+    private String reasonString;
+    private String serverReference;
+    private final @Nullable ModifiableUserPropertiesImpl userProperties;
+
+    public ModifiableDisconnectPacketImpl(
+            final @NotNull FullConfigurationService fullConfigurationService,
+            final @NotNull DISCONNECT originalDisconnect) {
+        this.configurationService = fullConfigurationService;
+        this.userProperties = new ModifiableUserPropertiesImpl(
+                originalDisconnect.getUserProperties().getPluginUserProperties(),
+                configurationService.securityConfiguration().validateUTF8());
+        this.reasonString = originalDisconnect.getReasonString();
+        this.sessionExpiryInterval = originalDisconnect.getSessionExpiryInterval();
+        this.serverReference = originalDisconnect.getServerReference();
+    }
+
+    @Override
+    public synchronized void setReasonString(final @NotNull String reasonString) {
+        this.reasonString = reasonString;
+        modified = true;
+    }
+
+    @Override
+    public synchronized void setSessionExpiryInterval(final long sessionExpiryInterval) {
+        this.sessionExpiryInterval = sessionExpiryInterval;
+        final long configuredMaximum = configurationService.mqttConfiguration().maxSessionExpiryInterval();
+        checkArgument(sessionExpiryInterval >= 0, "Session expiry interval must NOT be less than 0");
+        checkArgument(
+                sessionExpiryInterval < configuredMaximum,
+                "Expiry interval must be less than the configured maximum of" + configuredMaximum);
+        modified = true;
+    }
+
+    @Override
+    public synchronized void setServerReference(final @NotNull String serverReference) {
+        this.serverReference = serverReference;
+        modified = true;
+    }
+
+    @Override
+    public String getServerReference() {
+        return this.serverReference;
+    }
+
+    @Override
+    public String getReasonString() {
+        return this.reasonString;
+    }
+
+    @Override
+    public long getSessionExpiryInterval() {
+        return this.sessionExpiryInterval;
+    }
+
+    @Override
+    public @NotNull ModifiableUserProperties getUserProperties() {
+        return this.userProperties;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableDisconnectPacketImpl.java
@@ -59,6 +59,11 @@ public class ModifiableDisconnectPacketImpl implements ModifiableDisconnectPacke
     }
 
     @Override
+    public boolean isModified() {
+        return modified;
+    }
+
+    @Override
     public String getServerReference() {
         return this.serverReference;
     }

--- a/src/main/java/com/hivemq/mqtt/message/disconnect/DISCONNECT.java
+++ b/src/main/java/com/hivemq/mqtt/message/disconnect/DISCONNECT.java
@@ -16,12 +16,16 @@
 
 package com.hivemq.mqtt.message.disconnect;
 
+import com.google.common.collect.ImmutableList;
 import com.hivemq.annotations.Immutable;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.annotations.Nullable;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extension.sdk.api.packets.general.UserProperty;
 import com.hivemq.mqtt.message.MessageType;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttMessageWithUserProperties;
+import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 
 import static com.hivemq.mqtt.message.connect.Mqtt5CONNECT.SESSION_EXPIRY_NOT_SET;
@@ -53,6 +57,19 @@ public class DISCONNECT extends MqttMessageWithUserProperties.MqttMessageWithRea
         super(reasonCode, reasonString, userProperties);
         this.serverReference = serverReference;
         this.sessionExpiryInterval = sessionExpiryInterval;
+    }
+
+    public static DISCONNECT createDisconnectFrom(final @NotNull DisconnectPacket packet) {
+        final Mqtt5DisconnectReasonCode reasonCode = Mqtt5DisconnectReasonCode.valueOf(packet.getReasonCode().name());
+        final String reasonString = packet.getReasonString();
+        final String serverReference = packet.getServerReference();
+        final ImmutableList.Builder<MqttUserProperty> userPropertyBuilder = ImmutableList.builder();
+        for (final UserProperty userProperty : packet.getUserProperties().asList()) {
+            userPropertyBuilder.add(new MqttUserProperty(userProperty.getName(), userProperty.getValue()));
+        }
+        final long sessionExpiryInterval = packet.getSessionExpiryInterval();
+        final Mqtt5UserProperties mqtt5UserProperties = Mqtt5UserProperties.of(userPropertyBuilder.build());
+        return new DISCONNECT(reasonCode, reasonString, mqtt5UserProperties, serverReference, sessionExpiryInterval);
     }
 
     @Override

--- a/src/test/java/com/hivemq/bootstrap/netty/ChannelDependenciesTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/ChannelDependenciesTest.java
@@ -23,10 +23,6 @@ import com.hivemq.codec.encoder.EncoderFactory;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.RestrictionsConfigurationService;
 import com.hivemq.extensions.handler.*;
-import com.hivemq.extensions.handler.ClientLifecycleEventHandler;
-import com.hivemq.extensions.handler.IncomingPublishHandler;
-import com.hivemq.extensions.handler.IncomingSubscribeHandler;
-import com.hivemq.extensions.handler.PluginInitializerHandler;
 import com.hivemq.logging.EventLog;
 import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.metrics.handler.MetricsInitializer;
@@ -169,6 +165,12 @@ public class ChannelDependenciesTest {
     @Mock
     private ConnackOutboundInterceptorHandler connackOutboundInterceptorHandler;
 
+    @Mock
+    private DisconnectInboundInterceptorHandler disconnectInboundInterceptorHandler;
+
+    @Mock
+    private DisconnectOutboundInterceptorHandler disconnectOutboundInterceptorHandler;
+
     @Before
     public void setUp() throws Exception {
 
@@ -209,7 +211,10 @@ public class ChannelDependenciesTest {
                 () -> publishMessageExpiryHandler,
                 publishOutboundInterceptorHandler,
                 connectInterceptorHandler,
-                connackOutboundInterceptorHandler);
+                connackOutboundInterceptorHandler,
+                disconnectInboundInterceptorHandler,
+                disconnectOutboundInterceptorHandler
+        );
 
     }
 
@@ -250,5 +255,7 @@ public class ChannelDependenciesTest {
         assertNotNull(channelDependencies.getIncomingSubscribeHandler());
         assertNotNull(channelDependencies.getConnectInboundInterceptorHandler());
         assertNotNull(channelDependencies.getConnackOutboundInterceptorHandler());
+        assertNotNull(channelDependencies.getDisconnectInboundInterceptorHandler());
+        assertNotNull(channelDependencies.getDisconnectOutboundInterceptorHandler());
     }
 }

--- a/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
@@ -222,7 +222,6 @@ public class DisconnectInboundInterceptorHandlerTest {
                 final @NotNull DisconnectInboundOutput disconnectInboundOutput) {
             final ModifiableDisconnectPacket packet = disconnectInboundOutput.getDisconnectPacket();
             packet.setReasonString("modified");
-            System.out.println("wtf");
         }
     }
 

--- a/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
@@ -69,7 +69,7 @@ public class DisconnectInboundInterceptorHandlerTest {
         when(extension.getId()).thenReturn("extension");
 
         configurationService = new TestConfigurationBootstrap().getFullConfigurationService();
-        PluginOutPutAsyncer asyncer = new PluginOutputAsyncerImpl(Mockito.mock(ShutdownHooks.class));
+        final PluginOutPutAsyncer asyncer = new PluginOutputAsyncerImpl(Mockito.mock(ShutdownHooks.class));
         final PluginTaskExecutorService pluginTaskExecutorService = new PluginTaskExecutorServiceImpl(() -> executor);
 
         final DisconnectInboundInterceptorHandler handler = new DisconnectInboundInterceptorHandler(
@@ -151,7 +151,7 @@ public class DisconnectInboundInterceptorHandlerTest {
     public static class SimpleDisconnectTestInterceptor implements DisconnectInboundInterceptor {
 
         @Override
-        public void onDisconnect(
+        public void onInboundDisconnect(
                 final @NotNull DisconnectInboundInput disconnectInboundInput,
                 final @NotNull DisconnectInboundOutput disconnectInboundOutput) {
             System.out.println("Intercepting DISCONNECT at: " + System.currentTimeMillis());
@@ -161,7 +161,7 @@ public class DisconnectInboundInterceptorHandlerTest {
     public static class AsyncDisconnectTestInterceptor implements DisconnectInboundInterceptor {
 
         @Override
-        public void onDisconnect(
+        public void onInboundDisconnect(
                 @NotNull final DisconnectInboundInput disconnectInboundInput,
                 @NotNull final DisconnectInboundOutput disconnectInboundOutput) {
             final Async<DisconnectInboundOutput> async =

--- a/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
@@ -75,6 +75,7 @@ public class DisconnectInboundInterceptorHandlerTest {
 
         channel = new EmbeddedChannel();
         channel.attr(ChannelAttributes.CLIENT_ID).set("client");
+        channel.attr(ChannelAttributes.REQUEST_RESPONSE_INFORMATION).set(true);
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         when(extension.getId()).thenReturn("extension");
 
@@ -144,7 +145,6 @@ public class DisconnectInboundInterceptorHandlerTest {
 
     @Test(timeout = 20000)
     public void test_modified() throws Exception {
-        //TODO Why is there null in the reasonString
         final DisconnectInboundInterceptor interceptor =
                 getIsolatedInboundInterceptor("TestModifyInboundInterceptor");
         final List<DisconnectInboundInterceptor> interceptors = ImmutableList.of(interceptor);
@@ -222,6 +222,7 @@ public class DisconnectInboundInterceptorHandlerTest {
                 final @NotNull DisconnectInboundOutput disconnectInboundOutput) {
             final ModifiableDisconnectPacket packet = disconnectInboundOutput.getDisconnectPacket();
             packet.setReasonString("modified");
+            System.out.println("wtf");
         }
     }
 

--- a/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
@@ -1,0 +1,177 @@
+package com.hivemq.extensions.handler;
+
+import com.hivemq.annotations.NotNull;
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.async.Async;
+import com.hivemq.extension.sdk.api.async.TimeoutFallback;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundInput;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectInboundOutput;
+import com.hivemq.extensions.HiveMQExtension;
+import com.hivemq.extensions.HiveMQExtensions;
+import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
+import com.hivemq.extensions.client.ClientContextImpl;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginOutputAsyncerImpl;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.PluginTaskExecutorServiceImpl;
+import com.hivemq.extensions.executor.task.PluginTaskExecutor;
+import com.hivemq.extensions.packets.general.ModifiableDefaultPermissionsImpl;
+import com.hivemq.mqtt.message.ProtocolVersion;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import util.TestConfigurationBootstrap;
+
+import java.io.File;
+import java.net.URL;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+public class DisconnectInboundInterceptorHandlerTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private HiveMQExtension extension;
+
+    @Mock
+    private HiveMQExtensions hiveMQExtensions;
+
+    @Mock
+    private FullConfigurationService configurationService;
+
+    private PluginTaskExecutor executor;
+    private EmbeddedChannel channel;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        executor = new PluginTaskExecutor(new AtomicLong());
+        executor.postConstruct();
+
+        channel = new EmbeddedChannel();
+        channel.attr(ChannelAttributes.CLIENT_ID).set("client");
+        when(extension.getId()).thenReturn("extension");
+
+        configurationService = new TestConfigurationBootstrap().getFullConfigurationService();
+        PluginOutPutAsyncer asyncer = new PluginOutputAsyncerImpl(Mockito.mock(ShutdownHooks.class));
+        final PluginTaskExecutorService pluginTaskExecutorService = new PluginTaskExecutorServiceImpl(() -> executor);
+
+        final DisconnectInboundInterceptorHandler handler = new DisconnectInboundInterceptorHandler(
+                configurationService, asyncer, hiveMQExtensions, pluginTaskExecutorService);
+        channel.pipeline().addFirst(handler);
+    }
+
+    @After
+    public void tearDown() {
+        executor.stop();
+        channel.close();
+    }
+
+    @Test(timeout = 5000)
+    public void test_read_simple_disconnect() throws Exception {
+        final ClientContextImpl clientContext =
+                new ClientContextImpl(hiveMQExtensions, new ModifiableDefaultPermissionsImpl());
+
+        final DisconnectInboundInterceptor interceptor =
+                getIsolatedInboundInterceptor("SimpleDisconnectTestInterceptor");
+        clientContext.addDisconnectInboundInterceptor(interceptor);
+
+        channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
+
+        when(hiveMQExtensions.getExtensionForClassloader(any(IsolatedPluginClassloader.class))).thenReturn(extension);
+
+        channel.writeInbound(new DISCONNECT());
+        DISCONNECT disconnect = channel.readInbound();
+        while (disconnect == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            disconnect = channel.readInbound();
+        }
+        Assert.assertNotNull(disconnect);
+    }
+
+    @Test
+    public void test_read_async_disconnect() throws Exception {
+        final ClientContextImpl clientContext =
+                new ClientContextImpl(hiveMQExtensions, new ModifiableDefaultPermissionsImpl());
+
+        final DisconnectInboundInterceptor interceptor =
+                getIsolatedInboundInterceptor("AsyncDisconnectTestInterceptor");
+        clientContext.addDisconnectInboundInterceptor(interceptor);
+
+        channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
+
+        when(hiveMQExtensions.getExtensionForClassloader(any(IsolatedPluginClassloader.class))).thenReturn(extension);
+
+        channel.writeInbound(new DISCONNECT());
+        DISCONNECT disconnect = channel.readInbound();
+        while (disconnect == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            disconnect = channel.readInbound();
+        }
+        Assert.assertNotNull(disconnect);
+    }
+
+    private DisconnectInboundInterceptor getIsolatedInboundInterceptor(final @NotNull String name) throws Exception {
+        final JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
+                .addClass("com.hivemq.extensions.handler.DisconnectInboundInterceptorHandlerTest$" + name);
+
+        final File jarFile = temporaryFolder.newFile();
+        javaArchive.as(ZipExporter.class).exportTo(jarFile, true);
+
+        final IsolatedPluginClassloader
+                cl =
+                new IsolatedPluginClassloader(new URL[]{jarFile.toURI().toURL()}, this.getClass().getClassLoader());
+
+        final Class<?> interceptorClass =
+                cl.loadClass("com.hivemq.extensions.handler.DisconnectInboundInterceptorHandlerTest$" + name);
+
+        return (DisconnectInboundInterceptor) interceptorClass.newInstance();
+    }
+
+    public static class SimpleDisconnectTestInterceptor implements DisconnectInboundInterceptor {
+
+        @Override
+        public void onDisconnect(
+                final @NotNull DisconnectInboundInput disconnectInboundInput,
+                final @NotNull DisconnectInboundOutput disconnectInboundOutput) {
+            System.out.println("Intercepting DISCONNECT at: " + System.currentTimeMillis());
+        }
+    }
+
+    public static class AsyncDisconnectTestInterceptor implements DisconnectInboundInterceptor {
+
+        @Override
+        public void onDisconnect(
+                @NotNull final DisconnectInboundInput disconnectInboundInput,
+                @NotNull final DisconnectInboundOutput disconnectInboundOutput) {
+            final Async<DisconnectInboundOutput> async =
+                    disconnectInboundOutput.async(Duration.ofMillis(10), TimeoutFallback.FAILURE);
+            try {
+                Thread.sleep(100);
+            } catch (final InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandlerTest.java
@@ -82,7 +82,6 @@ public class DisconnectOutboundInterceptorHandlerTest {
         executor.postConstruct();
 
         channel = new EmbeddedChannel();
-
         channel.attr(ChannelAttributes.CLIENT_ID).set("client");
         channel.attr(ChannelAttributes.REQUEST_RESPONSE_INFORMATION).set(true);
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);

--- a/src/test/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandlerTest.java
@@ -1,0 +1,276 @@
+package com.hivemq.extensions.handler;
+
+import com.google.common.collect.ImmutableList;
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.async.TimeoutFallback;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.DisconnectOutboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundInput;
+import com.hivemq.extension.sdk.api.interceptor.disconnect.parameter.DisconnectOutboundOutput;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
+import com.hivemq.extensions.HiveMQExtension;
+import com.hivemq.extensions.HiveMQExtensions;
+import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
+import com.hivemq.extensions.client.ClientContextImpl;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginOutputAsyncerImpl;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.PluginTaskExecutorServiceImpl;
+import com.hivemq.extensions.executor.task.PluginTaskExecutor;
+import com.hivemq.mqtt.message.ProtocolVersion;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
+import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import util.TestConfigurationBootstrap;
+
+import java.io.File;
+import java.net.URL;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DisconnectOutboundInterceptorHandlerTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private HiveMQExtensions hiveMQExtensions;
+
+    @Mock
+    private HiveMQExtension extension;
+
+    @Mock
+    private ClientContextImpl clientContext;
+
+    private PluginOutPutAsyncer asyncer;
+
+    private FullConfigurationService configurationService;
+
+    private PluginTaskExecutor executor;
+
+    private EmbeddedChannel channel;
+
+    private PluginTaskExecutorService pluginTaskExecutorService;
+
+    private DisconnectOutboundInterceptorHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        executor = new PluginTaskExecutor(new AtomicLong());
+        executor.postConstruct();
+
+        channel = new EmbeddedChannel();
+
+        channel.attr(ChannelAttributes.CLIENT_ID).set("client");
+        channel.attr(ChannelAttributes.REQUEST_RESPONSE_INFORMATION).set(true);
+        channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
+        when(extension.getId()).thenReturn("extension");
+
+        configurationService = new TestConfigurationBootstrap().getFullConfigurationService();
+        asyncer = new PluginOutputAsyncerImpl(mock(ShutdownHooks.class));
+        pluginTaskExecutorService = new PluginTaskExecutorServiceImpl(() -> executor);
+
+        handler = new DisconnectOutboundInterceptorHandler(configurationService, asyncer, hiveMQExtensions,
+                pluginTaskExecutorService);
+        channel.pipeline().addFirst(handler);
+    }
+
+    @Test(timeout = 5000)
+    public void test_client_id_not_set() {
+        channel.attr(ChannelAttributes.CLIENT_ID).set(null);
+        channel.writeOutbound(testDisconnect());
+        channel.runPendingTasks();
+        assertNull(channel.readOutbound());
+    }
+
+    @Test(timeout = 5000)
+    public void test_channel_inactive() throws Exception {
+        final ChannelHandlerContext context = channel.pipeline().context(handler);
+        channel.close();
+
+        handler.write(context, testDisconnect(), mock(ChannelPromise.class));
+        channel.runPendingTasks();
+        assertNull(channel.readOutbound());
+    }
+
+    @Test(timeout = 5000)
+    public void test_no_interceptors() {
+        when(clientContext.getDisconnectOutboundInterceptors()).thenReturn(ImmutableList.of());
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(extension);
+
+        final DISCONNECT disconnect = testDisconnect();
+        channel.writeOutbound(disconnect);
+        channel.runPendingTasks();
+        DISCONNECT readDisconnect = channel.readOutbound();
+        while (readDisconnect == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            readDisconnect = channel.readOutbound();
+        }
+        assertEquals(disconnect.getReasonCode(), readDisconnect.getReasonCode());
+
+    }
+
+    @Test(timeout = 5000)
+    public void test_plugin_null() throws Exception {
+
+        final DisconnectOutboundInterceptor interceptor =
+                getIsolatedOutboundInterceptor("TestModifyOutboundInterceptor");
+        final List<DisconnectOutboundInterceptor> list = ImmutableList.of(interceptor);
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+        when(clientContext.getDisconnectOutboundInterceptors()).thenReturn(list);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(null);
+
+        channel.writeOutbound(testDisconnect());
+        channel.runPendingTasks();
+        DISCONNECT disconnect = channel.readOutbound();
+        while (disconnect == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            disconnect = channel.readOutbound();
+        }
+
+        assertEquals("reason", disconnect.getReasonString());
+    }
+
+    @Test(timeout = 5000)
+    public void test_modified() throws Exception {
+
+        final DisconnectOutboundInterceptor interceptor =
+                getIsolatedOutboundInterceptor("TestModifyOutboundInterceptor");
+        final List<DisconnectOutboundInterceptor> interceptors = ImmutableList.of(interceptor);
+
+        when(clientContext.getDisconnectOutboundInterceptors()).thenReturn(interceptors);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(extension);
+
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        channel.writeOutbound(testDisconnect());
+        channel.runPendingTasks();
+        DISCONNECT disconnect = channel.readOutbound();
+        while (disconnect == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            disconnect = channel.readOutbound();
+        }
+
+        assertEquals("modified", disconnect.getReasonString());
+    }
+
+    @Test(timeout = 10_000)
+    public void test_timeout_failed() throws Exception {
+
+        final DisconnectOutboundInterceptor interceptor =
+                getIsolatedOutboundInterceptor("TestTimeoutFailedOutboundInterceptor");
+        final List<DisconnectOutboundInterceptor> list = ImmutableList.of(interceptor);
+
+        when(clientContext.getDisconnectOutboundInterceptors()).thenReturn(list);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(extension);
+
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        channel.writeOutbound(testDisconnect());
+
+        channel.runPendingTasks();
+        channel.runScheduledPendingTasks();
+
+        assertTrue(channel.isActive());
+    }
+
+    @Test(timeout = 5000)
+    public void test_exception() throws Exception {
+
+        final DisconnectOutboundInterceptor interceptor =
+                getIsolatedOutboundInterceptor("TestExceptionOutboundInterceptor");
+        final List<DisconnectOutboundInterceptor> list = ImmutableList.of(interceptor);
+
+        when(clientContext.getDisconnectOutboundInterceptors()).thenReturn(list);
+        when(hiveMQExtensions.getExtensionForClassloader(any())).thenReturn(extension);
+
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        channel.writeOutbound(testDisconnect());
+        channel.runPendingTasks();
+        channel.runScheduledPendingTasks();
+
+        assertTrue(channel.isActive());
+    }
+
+    private @NotNull DISCONNECT testDisconnect() {
+        return new DISCONNECT(
+                Mqtt5DisconnectReasonCode.UNSPECIFIED_ERROR, "reason", Mqtt5UserProperties.NO_USER_PROPERTIES,
+                "serverReference", 1);
+    }
+
+    private DisconnectOutboundInterceptor getIsolatedOutboundInterceptor(final @NotNull String name) throws Exception {
+        final JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
+                .addClass("com.hivemq.extensions.handler.DisconnectOutboundInterceptorHandlerTest$" + name);
+
+        final File jarFile = temporaryFolder.newFile();
+        javaArchive.as(ZipExporter.class).exportTo(jarFile, true);
+
+        final IsolatedPluginClassloader
+                cl =
+                new IsolatedPluginClassloader(new URL[]{jarFile.toURI().toURL()}, this.getClass().getClassLoader());
+
+        final Class<?> interceptorClass =
+                cl.loadClass("com.hivemq.extensions.handler.DisconnectOutboundInterceptorHandlerTest$" + name);
+
+        return (DisconnectOutboundInterceptor) interceptorClass.newInstance();
+    }
+
+    public static class TestModifyOutboundInterceptor implements DisconnectOutboundInterceptor {
+
+        @Override
+        public void onOutboundDisconnect(
+                final @NotNull DisconnectOutboundInput disconnectOutboundInput,
+                final @NotNull DisconnectOutboundOutput disconnectOutboundOutput) {
+            final ModifiableDisconnectPacket packet = disconnectOutboundOutput.getDisconnectPacket();
+            packet.setReasonString("modified");
+        }
+    }
+
+    public static class TestTimeoutFailedOutboundInterceptor implements DisconnectOutboundInterceptor {
+
+        @Override
+        public void onOutboundDisconnect(
+                final @NotNull DisconnectOutboundInput disconnectOutboundInput,
+                final @NotNull DisconnectOutboundOutput disconnectOutboundOutput) {
+            disconnectOutboundOutput.async(Duration.ofMillis(10), TimeoutFallback.FAILURE);
+        }
+    }
+
+    public static class TestExceptionOutboundInterceptor implements DisconnectOutboundInterceptor {
+
+        @Override
+        public void onOutboundDisconnect(
+                final @NotNull DisconnectOutboundInput disconnectOutboundInput,
+                final @NotNull DisconnectOutboundOutput disconnectOutboundOutput) {
+            throw new RuntimeException();
+        }
+    }
+
+}

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImplTest.java
@@ -1,0 +1,88 @@
+package com.hivemq.extensions.interceptor.disconnect;
+
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
+import com.hivemq.extensions.packets.disconnect.DisconnectPacketImpl;
+import com.hivemq.extensions.packets.disconnect.ModifiableDisconnectPacketImpl;
+import com.hivemq.mqtt.message.ProtocolVersion;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Assert;
+import org.junit.Test;
+import util.TestConfigurationBootstrap;
+import util.TestMessageUtil;
+
+public class DisconnectInboundInputImplTest {
+
+    @Test
+    public void test_construction() {
+        final EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        final DisconnectPacket disconnectPacket = new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+        final DisconnectInboundInputImpl input =
+                new DisconnectInboundInputImpl(disconnectPacket, "client", embeddedChannel);
+        Assert.assertNotNull(input.getClientInformation());
+        Assert.assertNotNull(input.getConnectionInformation());
+        Assert.assertNotNull(input.getDisconnectPacket());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_clientId_null() {
+        final DisconnectPacketImpl disconnectPacket =
+                new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+        final DisconnectInboundInputImpl disconnectInboundInput =
+                new DisconnectInboundInputImpl(disconnectPacket, null, new EmbeddedChannel());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_channel_null() {
+        final DisconnectPacketImpl disconnectPacket =
+                new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+        final DisconnectInboundInputImpl disconnectInboundInput =
+                new DisconnectInboundInputImpl(disconnectPacket, "client", null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_packet_null() {
+        final DisconnectInboundInputImpl disconnectInboundInput =
+                new DisconnectInboundInputImpl(null, null, new EmbeddedChannel());
+    }
+
+    @Test
+    public void test_update() {
+        final EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        final DisconnectPacketImpl disconnectPacket1 =
+                new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+        final DisconnectPacketImpl disconnectPacket2 =
+                new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+
+        final DisconnectInboundInputImpl input =
+                new DisconnectInboundInputImpl(disconnectPacket1, "client", embeddedChannel);
+        input.updateDisconnect(disconnectPacket2);
+
+        Assert.assertNotEquals(input.getDisconnectPacket(), disconnectPacket1);
+        Assert.assertEquals(input.getDisconnectPacket(), disconnectPacket2);
+    }
+
+    @Test
+    public void test_overrideReasonString() {
+        final EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        final FullConfigurationService fullConfigurationService =
+                new TestConfigurationBootstrap().getFullConfigurationService();
+        final DISCONNECT disconnect = TestMessageUtil.createFullMqtt5Disconnect();
+
+        final ModifiableDisconnectPacket disconnectPacket =
+                new ModifiableDisconnectPacketImpl(fullConfigurationService, disconnect);
+        disconnectPacket.setReasonString("modified");
+
+        Assert.assertEquals("modified", disconnectPacket.getReasonString());
+    }
+
+}

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImplTest.java
@@ -65,8 +65,8 @@ public class DisconnectInboundInputImplTest {
                 new DisconnectInboundInputImpl(disconnectPacket1, "client", embeddedChannel);
         input.updateDisconnect(disconnectPacket2);
 
-        Assert.assertNotEquals(input.getDisconnectPacket(), disconnectPacket1);
-        Assert.assertEquals(input.getDisconnectPacket(), disconnectPacket2);
+        Assert.assertNotSame(input.getDisconnectPacket(), disconnectPacket1);
+        Assert.assertNotSame(input.getDisconnectPacket(), disconnectPacket2);
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImplTest.java
@@ -1,0 +1,43 @@
+package com.hivemq.extensions.interceptor.disconnect;
+
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import util.TestConfigurationBootstrap;
+import util.TestMessageUtil;
+
+import static org.junit.Assert.assertEquals;
+
+public class DisconnectInboundOutputImplTest {
+
+    private DISCONNECT disconnect;
+
+    @Mock
+    private PluginOutPutAsyncer asyncer;
+    private DisconnectInboundOutputImpl output;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        final FullConfigurationService configurationService =
+                new TestConfigurationBootstrap().getFullConfigurationService();
+        disconnect = TestMessageUtil.createFullMqtt5Disconnect();
+        output = new DisconnectInboundOutputImpl(configurationService, asyncer, disconnect);
+    }
+
+    @Test
+    public void test_getModifiable() {
+        final ModifiableDisconnectPacket modifiableDisconnectPacket = output.get().getDisconnectPacket();
+        assertEquals(disconnect.getServerReference(), modifiableDisconnectPacket.getServerReference());
+        assertEquals(disconnect.getSessionExpiryInterval(), modifiableDisconnectPacket.getSessionExpiryInterval());
+        assertEquals(disconnect.getReasonCode().name(), modifiableDisconnectPacket.getReasonCode().name());
+        assertEquals(disconnect.getReasonString(), modifiableDisconnectPacket.getReasonString());
+        assertEquals(
+                disconnect.getUserProperties().size(), modifiableDisconnectPacket.getUserProperties().asList().size());
+    }
+}

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundInputImplTest.java
@@ -1,0 +1,66 @@
+package com.hivemq.extensions.interceptor.disconnect;
+
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectPacket;
+import com.hivemq.extensions.packets.disconnect.DisconnectPacketImpl;
+import com.hivemq.mqtt.message.ProtocolVersion;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Assert;
+import org.junit.Test;
+import util.TestMessageUtil;
+
+public class DisconnectOutboundInputImplTest {
+
+    @Test
+    public void test_construction() {
+        final EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        final DisconnectPacket disconnectPacket = new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+        final DisconnectOutboundInputImpl input =
+                new DisconnectOutboundInputImpl(disconnectPacket, "client", embeddedChannel);
+        Assert.assertNotNull(input.getClientInformation());
+        Assert.assertNotNull(input.getConnectionInformation());
+        Assert.assertNotNull(input.getDisconnectPacket());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_clientId_null() {
+        final DisconnectPacketImpl disconnectPacket =
+                new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+        final DisconnectOutboundInputImpl disconnectInboundInput =
+                new DisconnectOutboundInputImpl(disconnectPacket, null, new EmbeddedChannel());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_channel_null() {
+        final DisconnectPacketImpl disconnectPacket =
+                new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+        final DisconnectOutboundInputImpl disconnectInboundInput =
+                new DisconnectOutboundInputImpl(disconnectPacket, "client", null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_packet_null() {
+        final DisconnectOutboundInputImpl disconnectInboundInput =
+                new DisconnectOutboundInputImpl(null, null, new EmbeddedChannel());
+    }
+
+    @Test
+    public void test_update() {
+        final EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        final DisconnectPacketImpl disconnectPacket1 =
+                new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+        final DisconnectPacketImpl disconnectPacket2 =
+                new DisconnectPacketImpl(TestMessageUtil.createFullMqtt5Disconnect());
+
+        final DisconnectOutboundInputImpl input =
+                new DisconnectOutboundInputImpl(disconnectPacket1, "client", embeddedChannel);
+        input.updateDisconnect(disconnectPacket2);
+
+        Assert.assertNotEquals(input.getDisconnectPacket(), disconnectPacket1);
+        Assert.assertEquals(input.getDisconnectPacket(), disconnectPacket2);
+    }
+}

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImplTest.java
@@ -1,0 +1,44 @@
+package com.hivemq.extensions.interceptor.disconnect;
+
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.packets.disconnect.ModifiableDisconnectPacket;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import util.TestConfigurationBootstrap;
+import util.TestMessageUtil;
+
+import static org.junit.Assert.assertEquals;
+
+public class DisconnectOutboundOutputImplTest {
+
+    private DISCONNECT disconnect;
+
+    @Mock
+    private PluginOutPutAsyncer asyncer;
+    private DisconnectOutboundOutputImpl output;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        final FullConfigurationService configurationService =
+                new TestConfigurationBootstrap().getFullConfigurationService();
+        disconnect = TestMessageUtil.createFullMqtt5Disconnect();
+        output = new DisconnectOutboundOutputImpl(configurationService, asyncer, disconnect);
+    }
+
+    @Test
+    public void test_getModifiable() {
+        final ModifiableDisconnectPacket modifiableDisconnectPacket = output.get().getDisconnectPacket();
+        assertEquals(disconnect.getServerReference(), modifiableDisconnectPacket.getServerReference());
+        assertEquals(disconnect.getSessionExpiryInterval(), modifiableDisconnectPacket.getSessionExpiryInterval());
+        assertEquals(disconnect.getReasonCode().name(), modifiableDisconnectPacket.getReasonCode().name());
+        assertEquals(disconnect.getReasonString(), modifiableDisconnectPacket.getReasonString());
+        assertEquals(
+                disconnect.getUserProperties().size(), modifiableDisconnectPacket.getUserProperties().asList().size());
+    }
+
+}


### PR DESCRIPTION
Resolves [#47](https://github.com/hivemq/hivemq-community-edition/issues/47) and [#48](https://github.com/hivemq/hivemq-community-edition/issues/48)

**Motivation**
Makes it possible for extension developers to intercept in- and outbound disconnect messages.

**Changes**
Implemented disconnect inbound and outbound interceptor.
Extension developers can change the following parameters of the DISCONNECT message:

- the session expiry interval
- the reason string
- the server reference



