### PR TITLE
Get password as byte-array in ConnectPacket.

### DIFF
--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -208,7 +208,7 @@ public interface ConnectPacket {
     @NotNull Optional<ByteBuffer> getPassword();
 
     /**
-     * If a password is set in the CONNECT packet, a copy of it is returned as a byte array. If no password is set null
+     * If a password is set in the CONNECT packet, a copy of it is returned as a byte array. If no password is set, null
      * is returned.
      *
      * @return the password from the CONNECT packet or null.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -19,10 +19,11 @@ package com.hivemq.extension.sdk.api.packets.connect;
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
+import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.general.MqttVersion;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.services.publish.Publish;
-import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptor;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
@@ -205,4 +206,12 @@ public interface ConnectPacket {
      * @since 4.0.0
      */
     @NotNull Optional<ByteBuffer> getPassword();
+
+    /**
+     * If a password is set in the CONNECT packet, a copy of it is returned as a byte array. If no password is set null
+     * is returned.
+     *
+     * @return the password from the CONNECT packet or null.
+     */
+    @Nullable byte[] getPasswordAsArray();
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiableConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiableConnectPacket.java
@@ -19,6 +19,7 @@ package com.hivemq.extension.sdk.api.packets.publish;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
+import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.connect.parameter.ConnectInboundInput;
 import com.hivemq.extension.sdk.api.packets.connect.ConnectPacket;
 import com.hivemq.extension.sdk.api.packets.connect.WillPublishPacket;
@@ -26,7 +27,6 @@ import com.hivemq.extension.sdk.api.packets.general.ModifiableUserProperties;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.services.builder.Builders;
 import com.hivemq.extension.sdk.api.services.builder.WillPublishBuilder;
-import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptor;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
@@ -181,6 +181,13 @@ public interface ModifiableConnectPacket extends ConnectPacket {
      * @since 4.2.0
      */
     void setPassword(@Nullable ByteBuffer password);
+
+    /**
+     * Set the password.
+     *
+     * @param bytes The new password for the CONNECT.
+     */
+    void setPassword(@Nullable byte[] bytes);
 
     /**
      * Get the modifiable {@link UserProperties} of the CONNECT packet.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiableConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiableConnectPacket.java
@@ -185,9 +185,9 @@ public interface ModifiableConnectPacket extends ConnectPacket {
     /**
      * Set the password.
      *
-     * @param bytes The new password for the CONNECT.
+     * @param password The new password for the CONNECT.
      */
-    void setPassword(@Nullable byte[] bytes);
+    void setPassword(@Nullable byte[] password);
 
     /**
      * Get the modifiable {@link UserProperties} of the CONNECT packet.

--- a/src/main/java/com/hivemq/extensions/packets/connect/ConnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/ConnectPacketImpl.java
@@ -26,6 +26,7 @@ import com.hivemq.extensions.packets.general.MqttVersionUtil;
 import com.hivemq.mqtt.message.connect.CONNECT;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Optional;
 
 /**
@@ -137,5 +138,16 @@ public class ConnectPacketImpl implements ConnectPacket {
             return Optional.empty();
         }
         return Optional.of(ByteBuffer.wrap(password));
+    }
+
+    @Nullable
+    @Override
+    public byte[] getPasswordAsArray() {
+        final byte[] password = connect.getPassword();
+        if (password == null) {
+            return null;
+        } else {
+            return Arrays.copyOf(password, password.length);
+        }
     }
 }

--- a/src/main/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImpl.java
@@ -294,15 +294,15 @@ public class ModifiableConnectPacketImpl implements ModifiableConnectPacket {
     }
 
     @Override
-    public void setPassword(@Nullable final byte[] bytes) {
-        if (bytes != null && Arrays.equals(bytes, this.passwordBytes)) {
+    public void setPassword(@Nullable final byte[] password) {
+        if (Arrays.equals(password, this.passwordBytes)) {
             return;
         }
-        if (bytes == null && this.passwordBytes == null) {
+        if (password == null && this.passwordBytes == null) {
             return;
         }
-        this.passwordBytes = bytes;
-        this.password = bytes == null ? null : ByteBuffer.wrap(bytes);
+        this.passwordBytes = password;
+        this.password = password == null ? null : ByteBuffer.wrap(password);
         modified = true;
     }
 

--- a/src/test/java/com/hivemq/extensions/packets/connect/ConnectPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/connect/ConnectPacketImplTest.java
@@ -143,6 +143,12 @@ public class ConnectPacketImplTest {
         assertFalse(emptyPacket.getPassword().isPresent());
     }
 
+    @Test
+    public void test_passwordArray() {
+        assertArrayEquals("password".getBytes(StandardCharsets.UTF_8), connectPacket.getPasswordAsArray());
+        assertNull(emptyPacket.getPasswordAsArray());
+    }
+
     @Test(timeout = 5000)
     public void test_auth_method() {
         assertEquals("method", connectPacket.getAuthenticationMethod().get());

--- a/src/test/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImplTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import util.TestConfigurationBootstrap;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.*;
 
@@ -188,5 +189,21 @@ public class ModifiableConnectPacketImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_client_id_empty() {
         modifiablePacket.setClientId("");
+    }
+
+    @Test
+    public void test_change_password_array_changes_both() {
+        final byte[] bytes = "password".getBytes(StandardCharsets.UTF_8);
+        modifiablePacket.setPassword(bytes);
+        assertArrayEquals(bytes, modifiablePacket.getPasswordAsArray());
+        assertEquals(ByteBuffer.wrap(bytes), modifiablePacket.getPassword().get());
+    }
+
+    @Test
+    public void test_change_password_buffer_changes_both() {
+        final byte[] bytes = "password".getBytes(StandardCharsets.UTF_8);
+        modifiablePacket.setPassword(ByteBuffer.wrap(bytes));
+        assertArrayEquals(bytes, modifiablePacket.getPasswordAsArray());
+        assertEquals(ByteBuffer.wrap(bytes), modifiablePacket.getPassword().get());
     }
 }


### PR DESCRIPTION
**Motivation**
A convenience method to retrieve passwords from connect packets as plain byte array is needed, otherwise an extension developer has to convert the ByteBuffer manually. 

**Changes**
Added a method to retrieve the passwords as byte arrays to the ConnectPacket and an additional setter method to the ModifiableConnectPacket. 