### PR TITLE
Feature/add reason string and reason code for clientservice disconnect client

### DIFF
--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
@@ -32,7 +32,7 @@ public enum DisconnectReasonCode {
     /**
      * @since 4.0.0
      */
-    DISCONNECT_WITH_WILL_MESSAGE,
+    @Deprecated DISCONNECT_WITH_WILL_MESSAGE,
     /**
      * @since 4.0.0
      */
@@ -64,7 +64,7 @@ public enum DisconnectReasonCode {
     /**
      * @since 4.0.0
      */
-    BAD_AUTHENTICATION_METHOD,
+    @Deprecated BAD_AUTHENTICATION_METHOD,
     /**
      * @since 4.0.0
      */
@@ -76,7 +76,7 @@ public enum DisconnectReasonCode {
     /**
      * @since 4.0.0
      */
-    CLIENT_IDENTIFIER_NOT_VALID,
+    @Deprecated CLIENT_IDENTIFIER_NOT_VALID,
     /**
      * @since 4.0.0
      */

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
@@ -90,6 +90,7 @@ public enum DisconnectReasonCode {
     SESSION_TAKEN_OVER,
     /**
      * @since 4.0.0
+     * @deprecated Must not be used for disconnect packets.
      */
     @Deprecated
     CLIENT_IDENTIFIER_NOT_VALID,

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
@@ -32,7 +32,6 @@ public enum DisconnectReasonCode {
     /**
      * @since 4.0.0
      */
-    @Deprecated
     DISCONNECT_WITH_WILL_MESSAGE,
     /**
      * @since 4.0.0
@@ -65,7 +64,6 @@ public enum DisconnectReasonCode {
     /**
      * @since 4.0.0
      */
-    @Deprecated
     BAD_AUTHENTICATION_METHOD,
     /**
      * @since 4.0.0

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
@@ -32,7 +32,8 @@ public enum DisconnectReasonCode {
     /**
      * @since 4.0.0
      */
-    @Deprecated DISCONNECT_WITH_WILL_MESSAGE,
+    @Deprecated
+    DISCONNECT_WITH_WILL_MESSAGE,
     /**
      * @since 4.0.0
      */
@@ -64,7 +65,8 @@ public enum DisconnectReasonCode {
     /**
      * @since 4.0.0
      */
-    @Deprecated BAD_AUTHENTICATION_METHOD,
+    @Deprecated
+    BAD_AUTHENTICATION_METHOD,
     /**
      * @since 4.0.0
      */
@@ -76,7 +78,8 @@ public enum DisconnectReasonCode {
     /**
      * @since 4.0.0
      */
-    @Deprecated CLIENT_IDENTIFIER_NOT_VALID,
+    @Deprecated
+    CLIENT_IDENTIFIER_NOT_VALID,
     /**
      * @since 4.0.0
      */

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
@@ -25,11 +25,14 @@ package com.hivemq.extension.sdk.api.packets.disconnect;
  * @since 4.0.0
  */
 public enum DisconnectReasonCode {
+
     /**
      * @since 4.0.0
      */
     NORMAL_DISCONNECTION,
     /**
+     * Must not be used for outbound disconnect packets from the server to clients.
+     *
      * @since 4.0.0
      */
     DISCONNECT_WITH_WILL_MESSAGE,
@@ -50,26 +53,38 @@ public enum DisconnectReasonCode {
      */
     IMPLEMENTATION_SPECIFIC_ERROR,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     NOT_AUTHORIZED,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     SERVER_BUSY,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     SERVER_SHUTTING_DOWN,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     BAD_AUTHENTICATION_METHOD,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     KEEP_ALIVE_TIMEOUT,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     SESSION_TAKEN_OVER,
@@ -111,42 +126,62 @@ public enum DisconnectReasonCode {
      */
     ADMINISTRATIVE_ACTION,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     PAYLOAD_FORMAT_INVALID,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     RETAIN_NOT_SUPPORTED,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     QOS_NOT_SUPPORTED,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     USE_ANOTHER_SERVER,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     SERVER_MOVED,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     SHARED_SUBSCRIPTION_NOT_SUPPORTED,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     CONNECTION_RATE_EXCEEDED,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     MAXIMUM_CONNECT_TIME,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED,
     /**
+     * Must not be used for inbound disconnect packets from a client to the server.
+     *
      * @since 4.0.0
      */
     WILDCARD_SUBSCRIPTION_NOT_SUPPORTED

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableInboundDisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableInboundDisconnectPacket.java
@@ -19,8 +19,10 @@ public interface ModifiableInboundDisconnectPacket extends DisconnectPacket {
      * Set the {@link DisconnectReasonCode} of the DISCONNECT packet.
      *
      * @param reasonCode The reason code to set.
-     * @throws NullPointerException If reason code is <code>null</code>.
-     * @see DisconnectReasonCode What reason codes exist for disconnecting.
+     * @throws NullPointerException     If reason code is <code>null</code>.
+     * @throws IllegalArgumentException If the disconnect reason code must not be used for inbound disconnect packets
+     *                                  from a client to the server.
+     * @see DisconnectReasonCode What reason codes exist for inbound disconnect packets from a client to the server.
      */
     void setReasonCode(@NotNull DisconnectReasonCode reasonCode);
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableOutboundDisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableOutboundDisconnectPacket.java
@@ -21,8 +21,11 @@ public interface ModifiableOutboundDisconnectPacket extends DisconnectPacket {
      * Set the {@link DisconnectReasonCode} of the DISCONNECT packet.
      *
      * @param reasonCode The reason code to set.
-     * @throws NullPointerException If the reason code is <code>null</code>.
-     * @see DisconnectReasonCode What reason codes exist for disconnecting.
+     * @throws NullPointerException     If the reason code is <code>null</code>.
+     * @throws IllegalArgumentException If the disconnect reason code must not be used for outbound disconnect packets
+     *                                  from the server to a client.
+     * @see DisconnectReasonCode What reason codes exist for outbound disconnect packets from the server to a
+     *         client.
      */
     void setReasonCode(@NotNull DisconnectReasonCode reasonCode);
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -90,7 +90,7 @@ public interface ClientService {
 
     /**
      * @param clientId The client identifier of the client to disconnect.
-     * @param prevenWillMessage If <b>true</b> the Will message for this client is not published when the client gets
+     * @param preventWillMessage If <b>true</b> the Will message for this client is not published when the client gets
      *                          disconnected.
      * @param reasonCode The reason for disconnecting this client.
      * @param reasonString The reason for disconnecting this client as a String.
@@ -98,7 +98,7 @@ public interface ClientService {
      * disconnected and <b>false</b> if no client with that id was found.
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(
-            @NotNull String clientId, boolean prevenWillMessage, @Nullable DisconnectReasonCode reasonCode,
+            @NotNull String clientId, boolean preventWillMessage, @Nullable DisconnectReasonCode reasonCode,
             @Nullable String reasonString);
 
     /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -88,11 +88,13 @@ public interface ClientService {
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId);
 
     /**
-     * @param clientId
-     * @param prevenWillMessage
-     * @param reasonCode
-     * @param reasonString
-     * @return
+     * @param clientId The client identifier of the client to disconnect.
+     * @param prevenWillMessage If <b>true</b> the Will message for this client is not published when the client gets
+     *                          disconnected.
+     * @param reasonCode The reason for disconnecting this client.
+     * @param reasonString The reason for disconnecting this client as a String.
+     * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
+     * disconnected and <b>false</b> if no client with that id was found.
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(
             @NotNull String clientId, boolean prevenWillMessage, @NotNull DisconnectReasonCode reasonCode,

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -89,19 +89,6 @@ public interface ClientService {
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId);
 
     /**
-     * @param clientId The client identifier of the client to disconnect.
-     * @param preventWillMessage If <b>true</b> the Will message for this client is not published when the client gets
-     *                          disconnected.
-     * @param reasonCode The reason for disconnecting this client.
-     * @param reasonString The reason for disconnecting this client as a String.
-     * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
-     * disconnected and <b>false</b> if no client with that id was found.
-     */
-    @NotNull CompletableFuture<Boolean> disconnectClient(
-            @NotNull String clientId, boolean preventWillMessage, @Nullable DisconnectReasonCode reasonCode,
-            @Nullable String reasonString);
-
-    /**
      * Forcefully disconnect a client with the specified clientId.
      * <p>
      * Setting the boolean parameter to true will prevent the sending of potential Will messages the client may have
@@ -118,6 +105,26 @@ public interface ClientService {
      * @since 4.0.0
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId, boolean preventWillMessage);
+
+    /**
+     * Forcefully disconnect a client with the specified clientId.
+     * <p>
+     * Setting the boolean parameter to true will prevent the sending of potential Will messages the client may have
+     * specified in its CONNECT packet.
+     * <p>
+     * {@link CompletableFuture} fails with a {@link RateLimitExceededException} if the extension service rate limit was
+     * exceeded.
+     *
+     * @param clientId           The client identifier of the client to disconnect.
+     * @param preventWillMessage If <b>true</b> the Will message for this client is not published when the client gets
+     *                           disconnected.
+     * @param reasonCode         The reason for disconnecting this client.
+     * @param reasonString       The reason for disconnecting this client as a String.
+     * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
+     * disconnected and <b>false</b> if no client with that id was found.
+     */
+    @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId, boolean preventWillMessage,
+                                                         @Nullable DisconnectReasonCode reasonCode, @Nullable String reasonString);
 
     /**
      * Invalidates the client session for a client with the given client identifier. If the client is currently

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Executor;
  * @author Lukas Brandl
  * @author Christoph Schäbel
  * @author Florian Limpöck
+ * @author Robin Atherton
  * @since 4.0.0
  */
 @DoNotImplement
@@ -91,6 +92,9 @@ public interface ClientService {
     /**
      * Forcefully disconnect a client with the specified clientId.
      * <p>
+     * If a specific reason code and/or reason string should be sent with the DISCONNECT packet use
+     * {@link ClientService#disconnectClient(String, boolean, DisconnectReasonCode, String)}.
+     * <p>
      * Setting the boolean parameter to true will prevent the sending of potential Will messages the client may have
      * specified in its CONNECT packet.
      * <p>
@@ -100,8 +104,8 @@ public interface ClientService {
      * @param clientId           The client identifier of the client to disconnect.
      * @param preventWillMessage If <b>true</b> the Will message for this client is not published when the client gets
      *                           disconnected.
-     * @return A {@link CompletableFuture} which contains a {@link Boolean} that is true when the client has been
-     * disconnected and false if no client with that id was found.
+     * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
+     * disconnected and <b>false</b> if no client with that id was found.
      * @since 4.0.0
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId, boolean preventWillMessage);
@@ -109,6 +113,8 @@ public interface ClientService {
     /**
      * Forcefully disconnect a client with the specified clientId.
      * <p>
+     * A specific reason code and/or reason string can be set when wanted.
+     * <p>
      * Setting the boolean parameter to true will prevent the sending of potential Will messages the client may have
      * specified in its CONNECT packet.
      * <p>
@@ -118,10 +124,11 @@ public interface ClientService {
      * @param clientId           The client identifier of the client to disconnect.
      * @param preventWillMessage If <b>true</b> the Will message for this client is not published when the client gets
      *                           disconnected.
-     * @param reasonCode         The reason for disconnecting this client.
-     * @param reasonString       The reason for disconnecting this client as a String.
+     * @param reasonCode         The reason code for disconnecting this client.
+     * @param reasonString       The user defined reason string for disconnecting this client.
      * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
      * disconnected and <b>false</b> if no client with that id was found.
+     * @since 4.3.0
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId, boolean preventWillMessage,
                                                          @Nullable DisconnectReasonCode reasonCode, @Nullable String reasonString);

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -128,6 +128,9 @@ public interface ClientService {
      * @param reasonString       The user defined reason string for disconnecting this client.
      * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
      * disconnected and <b>false</b> if no client with that id was found.
+     * @throws IllegalArgumentException if the disconnect reason code is CLIENT_IDENTIFIER_NOT_VALID.
+     * @throws IllegalArgumentException if the disconnect reason code is DISCONNECT_WITH_WILL_MESSAGE.
+     * @throws IllegalArgumentException if the disconnect reason code is BAD_AUTHENTICATION METHOD.
      * @since 4.3.0
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId, boolean preventWillMessage,

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -18,6 +18,7 @@ package com.hivemq.extension.sdk.api.services.session;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.services.ManagedExtensionExecutorService;
 import com.hivemq.extension.sdk.api.services.exception.IncompatibleHiveMQVersionException;
 import com.hivemq.extension.sdk.api.services.exception.IterationFailedException;
@@ -85,6 +86,17 @@ public interface ClientService {
      * @since 4.0.0
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId);
+
+    /**
+     * @param clientId
+     * @param prevenWillMessage
+     * @param reasonCode
+     * @param reasonString
+     * @return
+     */
+    @NotNull CompletableFuture<Boolean> disconnectClient(
+            @NotNull String clientId, boolean prevenWillMessage, @NotNull DisconnectReasonCode reasonCode,
+            @NotNull String reasonString);
 
     /**
      * Forcefully disconnect a client with the specified clientId.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -18,6 +18,7 @@ package com.hivemq.extension.sdk.api.services.session;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.services.ManagedExtensionExecutorService;
 import com.hivemq.extension.sdk.api.services.exception.IncompatibleHiveMQVersionException;
@@ -97,8 +98,8 @@ public interface ClientService {
      * disconnected and <b>false</b> if no client with that id was found.
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(
-            @NotNull String clientId, boolean prevenWillMessage, @NotNull DisconnectReasonCode reasonCode,
-            @NotNull String reasonString);
+            @NotNull String clientId, boolean prevenWillMessage, @Nullable DisconnectReasonCode reasonCode,
+            @Nullable String reasonString);
 
     /**
      * Forcefully disconnect a client with the specified clientId.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -129,13 +129,15 @@ public interface ClientService {
      * @param reasonString       The user defined reason string for disconnecting this client.
      * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
      *         disconnected and <b>false</b> if no client with that id was found.
-     * @throws IllegalArgumentException if the disconnect reason code is {@link DisconnectReasonCode#CLIENT_IDENTIFIER_NOT_VALID}.
-     * @throws IllegalArgumentException if the disconnect reason code is {@link DisconnectReasonCode#DISCONNECT_WITH_WILL_MESSAGE}.
-     * @throws IllegalArgumentException if the disconnect reason code is {@link DisconnectReasonCode#BAD_AUTHENTICATION_METHOD}.
+     * @throws IllegalArgumentException If the disconnect reason code must not be used for outbound disconnect packets
+     *                                  from the server to a client.
+     * @see DisconnectReasonCode What reason codes exist for outbound disconnect packets from the server to a
+     *         client.
      * @since 4.3.0
      */
-    @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId, boolean preventWillMessage,
-                                                         @Nullable DisconnectReasonCode reasonCode, @Nullable String reasonString);
+    @NotNull CompletableFuture<Boolean> disconnectClient(
+            @NotNull String clientId, boolean preventWillMessage,
+            @Nullable DisconnectReasonCode reasonCode, @Nullable String reasonString);
 
     /**
      * Invalidates the client session for a client with the given client identifier. If the client is currently
@@ -218,6 +220,7 @@ public interface ClientService {
      * @throws NullPointerException If the passed callback or callbackExecutor are null.
      * @since 4.2.0
      */
-    @NotNull CompletableFuture<Void> iterateAllClients(@NotNull IterationCallback<SessionInformation> callback, @NotNull Executor callbackExecutor);
+    @NotNull CompletableFuture<Void> iterateAllClients(
+            @NotNull IterationCallback<SessionInformation> callback, @NotNull Executor callbackExecutor);
 
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -54,7 +54,7 @@ public interface ClientService {
      *
      * @param clientId The client identifier of the client.
      * @return A {@link CompletableFuture} which contains <b>true</b>, if a certain client is currently connected and
-     * <b>false</b> otherwise.
+     *         <b>false</b> otherwise.
      * @since 4.0.0
      */
     @NotNull CompletableFuture<Boolean> isClientConnected(@NotNull String clientId);
@@ -68,7 +68,8 @@ public interface ClientService {
      * exceeded.
      *
      * @param clientId The client identifier of the client.
-     * @return A {@link CompletableFuture} which contains the {@link SessionInformation} for the client, if the session exist.
+     * @return A {@link CompletableFuture} which contains the {@link SessionInformation} for the client, if the session
+     *         exist.
      * @since 4.0.0
      */
     @NotNull CompletableFuture<Optional<SessionInformation>> getSession(@NotNull String clientId);
@@ -76,15 +77,15 @@ public interface ClientService {
     /**
      * Forcefully disconnect a client with the specified clientId.
      * <p>
-     * If the client specified a Will message, it will be sent.
-     * To prevent the sending of Will messages, use the {@link #disconnectClient(String, boolean)} method.
+     * If the client specified a Will message, it will be sent. To prevent the sending of Will messages, use the {@link
+     * #disconnectClient(String, boolean)} method.
      * <p>
      * {@link CompletableFuture} fails with a {@link RateLimitExceededException} if the extension service rate limit was
      * exceeded.
      *
      * @param clientId The client identifier of the client to disconnect.
      * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
-     * disconnected and <b>false</b> if no client with that id was found.
+     *         disconnected and <b>false</b> if no client with that id was found.
      * @since 4.0.0
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId);
@@ -92,8 +93,8 @@ public interface ClientService {
     /**
      * Forcefully disconnect a client with the specified clientId.
      * <p>
-     * If a specific reason code and/or reason string should be sent with the DISCONNECT packet use
-     * {@link ClientService#disconnectClient(String, boolean, DisconnectReasonCode, String)}.
+     * If a specific reason code and/or reason string should be sent with the DISCONNECT packet use {@link
+     * ClientService#disconnectClient(String, boolean, DisconnectReasonCode, String)}.
      * <p>
      * Setting the boolean parameter to true will prevent the sending of potential Will messages the client may have
      * specified in its CONNECT packet.
@@ -105,7 +106,7 @@ public interface ClientService {
      * @param preventWillMessage If <b>true</b> the Will message for this client is not published when the client gets
      *                           disconnected.
      * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
-     * disconnected and <b>false</b> if no client with that id was found.
+     *         disconnected and <b>false</b> if no client with that id was found.
      * @since 4.0.0
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId, boolean preventWillMessage);
@@ -127,10 +128,10 @@ public interface ClientService {
      * @param reasonCode         The reason code for disconnecting this client.
      * @param reasonString       The user defined reason string for disconnecting this client.
      * @return A {@link CompletableFuture} which contains a {@link Boolean} that is <b>true</b> when the client has been
-     * disconnected and <b>false</b> if no client with that id was found.
-     * @throws IllegalArgumentException if the disconnect reason code is CLIENT_IDENTIFIER_NOT_VALID.
-     * @throws IllegalArgumentException if the disconnect reason code is DISCONNECT_WITH_WILL_MESSAGE.
-     * @throws IllegalArgumentException if the disconnect reason code is BAD_AUTHENTICATION METHOD.
+     *         disconnected and <b>false</b> if no client with that id was found.
+     * @throws IllegalArgumentException if the disconnect reason code is {@link DisconnectReasonCode#CLIENT_IDENTIFIER_NOT_VALID}.
+     * @throws IllegalArgumentException if the disconnect reason code is {@link DisconnectReasonCode#DISCONNECT_WITH_WILL_MESSAGE}.
+     * @throws IllegalArgumentException if the disconnect reason code is {@link DisconnectReasonCode#BAD_AUTHENTICATION_METHOD}.
      * @since 4.3.0
      */
     @NotNull CompletableFuture<Boolean> disconnectClient(@NotNull String clientId, boolean preventWillMessage,
@@ -147,80 +148,73 @@ public interface ClientService {
      * exists.
      *
      * @param clientId The client identifier of the client which session should be invalidated.
-     * @return A {@link CompletableFuture} succeeding with a {@link Boolean} that is <b>true</b> when the client has been
-     * actively disconnected by the broker otherwise <b>false</b>.
+     * @return A {@link CompletableFuture} succeeding with a {@link Boolean} that is <b>true</b> when the client has
+     *         been actively disconnected by the broker otherwise <b>false</b>.
      * @since 4.0.0
      */
     @NotNull CompletableFuture<Boolean> invalidateSession(@NotNull String clientId);
 
-
     /**
      * Iterate over all clients and their session information.
      * <p>
-     * The callback is called once for each client.
-     * Passed to each execution of the callback are the client identifier and its session information.
-     * Clients that have exceeded their session expiry interval are not included.
+     * The callback is called once for each client. Passed to each execution of the callback are the client identifier
+     * and its session information. Clients that have exceeded their session expiry interval are not included.
      * <p>
-     * The callback is executed in the {@link ManagedExtensionExecutorService} per default.
-     * Use the overloaded methods to pass a custom executor for the callback.
-     * If you want to collect the results of each execution of the callback in a collection please make sure to use a
-     * concurrent collection (thread-safe), as the callback might be executed in another thread as the calling thread
-     * of this method.
+     * The callback is executed in the {@link ManagedExtensionExecutorService} per default. Use the overloaded methods
+     * to pass a custom executor for the callback. If you want to collect the results of each execution of the callback
+     * in a collection please make sure to use a concurrent collection (thread-safe), as the callback might be executed
+     * in another thread as the calling thread of this method.
      * <p>
      * The results are not sorted in any way, no ordering of any kind is guaranteed.
      * <p>
-     * CAUTION: This method can be used in large scale deployments, but it is a very expensive operation.
-     * Do not call this method in short time intervals.
+     * CAUTION: This method can be used in large scale deployments, but it is a very expensive operation. Do not call
+     * this method in short time intervals.
      * <p>
      * If you are searching for a specific entry in the results and have found what you are looking for, you can abort
      * further iteration and save resources by calling {@link IterationContext#abortIteration()}.
      * <p>
-     * {@link CompletableFuture} fails with an {@link IncompatibleHiveMQVersionException} if not all
-     * HiveMQ nodes in the cluster have at least version 4.2.0.
-     * {@link CompletableFuture} fails with a {@link RateLimitExceededException} if the extension service rate limit was
-     * exceeded.
-     * {@link CompletableFuture} fails with a {@link IterationFailedException} if the cluster topology changed
-     * during the iteration (e.g. a network-split, node leave or node join)
+     * {@link CompletableFuture} fails with an {@link IncompatibleHiveMQVersionException} if not all HiveMQ nodes in the
+     * cluster have at least version 4.2.0. {@link CompletableFuture} fails with a {@link RateLimitExceededException} if
+     * the extension service rate limit was exceeded. {@link CompletableFuture} fails with a {@link
+     * IterationFailedException} if the cluster topology changed during the iteration (e.g. a network-split, node leave
+     * or node join)
      *
      * @param callback An {@link IterationCallback} that is called for every returned result.
-     * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found
-     * or the iteration is aborted manually with the {@link IterationContext}.
+     * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
+     *         iteration is aborted manually with the {@link IterationContext}.
      * @throws NullPointerException If the passed callback or callbackExecutor are null.
      * @since 4.2.0
      */
     @NotNull CompletableFuture<Void> iterateAllClients(@NotNull IterationCallback<SessionInformation> callback);
 
-
     /**
      * Iterate over all clients and their session information.
      * <p>
-     * The callback is called once for each client.
-     * Passed to each execution of the callback are the client identifier and its session information.
-     * Clients that have exceeded their session expiry interval are not included.
+     * The callback is called once for each client. Passed to each execution of the callback are the client identifier
+     * and its session information. Clients that have exceeded their session expiry interval are not included.
      * <p>
-     * The callback is executed in the passed {@link Executor}.
-     * If you want to collect the results of each execution of the callback in a collection please make sure to use a
-     * concurrent collection, as the callback might be executed in another thread as the calling thread of this method.
+     * The callback is executed in the passed {@link Executor}. If you want to collect the results of each execution of
+     * the callback in a collection please make sure to use a concurrent collection, as the callback might be executed
+     * in another thread as the calling thread of this method.
      * <p>
      * The results are not sorted in any way, no ordering of any kind is guaranteed.
      * <p>
-     * CAUTION: This method can be used in large scale deployments, but it is a very expensive operation.
-     * Do not call this method in short time intervals.
+     * CAUTION: This method can be used in large scale deployments, but it is a very expensive operation. Do not call
+     * this method in short time intervals.
      * <p>
      * If you are searching for a specific entry in the results and have found what you are looking for, you can abort
      * further iteration and save resources by calling {@link IterationContext#abortIteration()}.
      * <p>
-     * {@link CompletableFuture} fails with an {@link IncompatibleHiveMQVersionException} if not all
-     * HiveMQ nodes in the cluster have at least version 4.2.0.
-     * {@link CompletableFuture} fails with a {@link RateLimitExceededException} if the extension service rate limit was
-     * exceeded.
-     * {@link CompletableFuture} fails with a {@link IterationFailedException} if the cluster topology changed
-     * during the iteration (e.g. a network-split, node leave or node join)
+     * {@link CompletableFuture} fails with an {@link IncompatibleHiveMQVersionException} if not all HiveMQ nodes in the
+     * cluster have at least version 4.2.0. {@link CompletableFuture} fails with a {@link RateLimitExceededException} if
+     * the extension service rate limit was exceeded. {@link CompletableFuture} fails with a {@link
+     * IterationFailedException} if the cluster topology changed during the iteration (e.g. a network-split, node leave
+     * or node join)
      *
      * @param callback         An {@link IterationCallback} that is called for every returned result.
      * @param callbackExecutor An {@link Executor} in which the callback for each iteration is executed.
-     * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found
-     * or the iteration is aborted manually with the {@link IterationContext}.
+     * @return A {@link CompletableFuture} that is completed after all iterations are executed, no match is found or the
+     *         iteration is aborted manually with the {@link IterationContext}.
      * @throws NullPointerException If the passed callback or callbackExecutor are null.
      * @since 4.2.0
      */

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImpl.java
@@ -79,6 +79,9 @@ public class ModifiableInboundDisconnectPacketImpl implements ModifiableInboundD
     public synchronized void setReasonCode(final @NotNull DisconnectReasonCode reasonCode) {
         Preconditions.checkNotNull(reasonCode, "Reason code must never be null");
         Preconditions.checkArgument(
+                reasonCode != DisconnectReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
+                "Reason code %s must not be used for disconnect packets.", reasonCode);
+        Preconditions.checkArgument(
                 Mqtt5DisconnectReasonCode.canBeSentByClient(reasonCode),
                 "Reason code %s must not be used for inbound disconnect packets from a client to the server.",
                 reasonCode);

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImpl.java
@@ -80,7 +80,7 @@ public class ModifiableInboundDisconnectPacketImpl implements ModifiableInboundD
         Preconditions.checkNotNull(reasonCode, "Reason code must never be null");
         Preconditions.checkArgument(
                 Mqtt5DisconnectReasonCode.canBeSentByClient(reasonCode),
-                "Reason code {} must not be used for inbound disconnect packets from a client to the server.",
+                "Reason code %s must not be used for inbound disconnect packets from a client to the server.",
                 reasonCode);
         if (Objects.equals(this.reasonCode, reasonCode)) {
             return;

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImpl.java
@@ -13,6 +13,7 @@ import com.hivemq.extensions.packets.general.ModifiableUserPropertiesImpl;
 import com.hivemq.extensions.services.builder.PluginBuilderUtil;
 import com.hivemq.mqtt.message.connect.Mqtt5CONNECT;
 import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -77,6 +78,10 @@ public class ModifiableInboundDisconnectPacketImpl implements ModifiableInboundD
     @Override
     public synchronized void setReasonCode(final @NotNull DisconnectReasonCode reasonCode) {
         Preconditions.checkNotNull(reasonCode, "Reason code must never be null");
+        Preconditions.checkArgument(
+                Mqtt5DisconnectReasonCode.canBeSentByClient(reasonCode),
+                "Reason code {} must not be used for inbound disconnect packets from a client to the server.",
+                reasonCode);
         if (Objects.equals(this.reasonCode, reasonCode)) {
             return;
         }

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImpl.java
@@ -71,6 +71,9 @@ public class ModifiableOutboundDisconnectPacketImpl implements ModifiableOutboun
     public synchronized void setReasonCode(final @NotNull DisconnectReasonCode reasonCode) {
         Preconditions.checkNotNull(reasonCode, "Reason code must never be null");
         Preconditions.checkArgument(
+                reasonCode != DisconnectReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
+                "Reason code %s must not be used for disconnect packets.", reasonCode);
+        Preconditions.checkArgument(
                 Mqtt5DisconnectReasonCode.canBeSentByServer(reasonCode),
                 "Reason code %s must not be used for outbound disconnect packets from the server to a client.",
                 reasonCode);

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImpl.java
@@ -72,7 +72,7 @@ public class ModifiableOutboundDisconnectPacketImpl implements ModifiableOutboun
         Preconditions.checkNotNull(reasonCode, "Reason code must never be null");
         Preconditions.checkArgument(
                 Mqtt5DisconnectReasonCode.canBeSentByServer(reasonCode),
-                "Reason code {} must not be used for outbound disconnect packets from the server to a client.",
+                "Reason code %s must not be used for outbound disconnect packets from the server to a client.",
                 reasonCode);
         if (this.reasonCode == reasonCode) {
             return;

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImpl.java
@@ -13,6 +13,7 @@ import com.hivemq.extensions.packets.general.ModifiableUserPropertiesImpl;
 import com.hivemq.extensions.services.builder.PluginBuilderUtil;
 import com.hivemq.mqtt.message.connect.Mqtt5CONNECT;
 import com.hivemq.mqtt.message.disconnect.DISCONNECT;
+import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -69,6 +70,10 @@ public class ModifiableOutboundDisconnectPacketImpl implements ModifiableOutboun
     @Override
     public synchronized void setReasonCode(final @NotNull DisconnectReasonCode reasonCode) {
         Preconditions.checkNotNull(reasonCode, "Reason code must never be null");
+        Preconditions.checkArgument(
+                Mqtt5DisconnectReasonCode.canBeSentByServer(reasonCode),
+                "Reason code {} must not be used for outbound disconnect packets from the server to a client.",
+                reasonCode);
         if (this.reasonCode == reasonCode) {
             return;
         }

--- a/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
@@ -117,13 +117,7 @@ public class ClientServiceImpl implements ClientService {
     @Override
     public CompletableFuture<Boolean> disconnectClient(
             @NotNull final String clientId, final boolean preventWillMessage) {
-        Preconditions.checkNotNull(clientId, "A client id must never be null");
-        if (pluginServiceRateLimitService.rateLimitExceeded()) {
-            return CompletableFuture.failedFuture(PluginServiceRateLimitService.RATE_LIMIT_EXCEEDED_EXCEPTION);
-        }
-        return ListenableFutureConverter.toCompletable(
-                clientSessionPersistence.forceDisconnectClient(clientId, preventWillMessage, EXTENSION),
-                managedExtensionExecutorService);
+        return disconnectClient(clientId, preventWillMessage, null, null);
     }
 
     @NotNull
@@ -133,12 +127,20 @@ public class ClientServiceImpl implements ClientService {
             final boolean preventWillMessage,
             final @Nullable DisconnectReasonCode reasonCode,
             final @Nullable String reasonString) {
+        Preconditions.checkNotNull(clientId, "A client id must never be null");
         if (pluginServiceRateLimitService.rateLimitExceeded()) {
             return CompletableFuture.failedFuture(PluginServiceRateLimitService.RATE_LIMIT_EXCEEDED_EXCEPTION);
         }
-        return ListenableFutureConverter.toCompletable(
-                clientSessionPersistence.forceDisconnectClient(
-                        clientId, preventWillMessage, EXTENSION, reasonCode, reasonString));
+        if (reasonCode != null && reasonString != null) {
+            return ListenableFutureConverter.toCompletable(
+                    clientSessionPersistence.forceDisconnectClient(clientId, preventWillMessage, EXTENSION, reasonCode,
+                            reasonString), managedExtensionExecutorService);
+        } else {
+            return ListenableFutureConverter.toCompletable(
+                    clientSessionPersistence.forceDisconnectClient(clientId, preventWillMessage, EXTENSION),
+                    managedExtensionExecutorService);
+        }
+
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
@@ -137,14 +137,14 @@ public class ClientServiceImpl implements ClientService {
                         "It is only valid if used in the CONNACK message.");
         Preconditions.checkArgument(
                 !DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE.equals(reasonCode),
-                DisconnectReasonCode.CLIENT_IDENTIFIER_NOT_VALID.toString() +
+                DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE.toString() +
                         " is not a valid reason code for server side DISCONNECT messages. " +
                         "It is only valid if used by a DISCONNECT messages sent by a client.");
         Preconditions.checkArgument(
                 !DisconnectReasonCode.BAD_AUTHENTICATION_METHOD.equals(reasonCode),
                 DisconnectReasonCode.BAD_AUTHENTICATION_METHOD.toString() +
                         " is not a valid reason code for server side DISCONNECT messages. " +
-                        "This reason code is not contained in the MQTT specification for DISCONNECT messages.");
+                        "It is only valid if used in the CONNACK message.");
 
 
         if (pluginServiceRateLimitService.rateLimitExceeded()) {

--- a/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
@@ -128,7 +128,25 @@ public class ClientServiceImpl implements ClientService {
             final boolean preventWillMessage,
             final @Nullable DisconnectReasonCode reasonCode,
             final @Nullable String reasonString) {
+
         Preconditions.checkNotNull(clientId, "A client id must never be null");
+        Preconditions.checkArgument(
+                !DisconnectReasonCode.CLIENT_IDENTIFIER_NOT_VALID.equals(reasonCode),
+                DisconnectReasonCode.CLIENT_IDENTIFIER_NOT_VALID.toString() +
+                        " is not a valid reason code for server side DISCONNECT messages. " +
+                        "It is only valid if used in the CONNACK message.");
+        Preconditions.checkArgument(
+                !DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE.equals(reasonCode),
+                DisconnectReasonCode.CLIENT_IDENTIFIER_NOT_VALID.toString() +
+                        " is not a valid reason code for server side DISCONNECT messages. " +
+                        "It is only valid if used by a DISCONNECT messages sent by a client.");
+        Preconditions.checkArgument(
+                !DisconnectReasonCode.BAD_AUTHENTICATION_METHOD.equals(reasonCode),
+                DisconnectReasonCode.BAD_AUTHENTICATION_METHOD.toString() +
+                        " is not a valid reason code for server side DISCONNECT messages. " +
+                        "This reason code is not contained in the MQTT specification for DISCONNECT messages.");
+
+
         if (pluginServiceRateLimitService.rateLimitExceeded()) {
             return CompletableFuture.failedFuture(PluginServiceRateLimitService.RATE_LIMIT_EXCEEDED_EXCEPTION);
         }

--- a/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
@@ -121,7 +121,9 @@ public class ClientServiceImpl implements ClientService {
         if (pluginServiceRateLimitService.rateLimitExceeded()) {
             return CompletableFuture.failedFuture(PluginServiceRateLimitService.RATE_LIMIT_EXCEEDED_EXCEPTION);
         }
-        return ListenableFutureConverter.toCompletable(clientSessionPersistence.forceDisconnectClient(clientId, preventWillMessage, EXTENSION), managedExtensionExecutorService);
+        return ListenableFutureConverter.toCompletable(
+                clientSessionPersistence.forceDisconnectClient(clientId, preventWillMessage, EXTENSION),
+                managedExtensionExecutorService);
     }
 
     @NotNull
@@ -129,8 +131,8 @@ public class ClientServiceImpl implements ClientService {
     public CompletableFuture<Boolean> disconnectClient(
             final @NotNull String clientId,
             final boolean preventWillMessage,
-            final @NotNull DisconnectReasonCode reasonCode,
-            final @NotNull String reasonString) {
+            final @Nullable DisconnectReasonCode reasonCode,
+            final @Nullable String reasonString) {
         if (pluginServiceRateLimitService.rateLimitExceeded()) {
             return CompletableFuture.failedFuture(PluginServiceRateLimitService.RATE_LIMIT_EXCEEDED_EXCEPTION);
         }
@@ -196,7 +198,7 @@ public class ClientServiceImpl implements ClientService {
 
         final SettableFuture<Void> settableFuture = SettableFuture.create();
         asyncIterator.getFinishedFuture().whenComplete((aVoid, throwable) -> {
-            if(throwable != null) {
+            if (throwable != null) {
                 settableFuture.setException(throwable);
             } else {
                 settableFuture.set(null);
@@ -208,8 +210,10 @@ public class ClientServiceImpl implements ClientService {
 
     static class AllClientsItemCallback implements AsyncIterator.ItemCallback<SessionInformation> {
 
-        private @NotNull final Executor callbackExecutor;
-        private @NotNull final IterationCallback<SessionInformation> callback;
+        private @NotNull
+        final Executor callbackExecutor;
+        private @NotNull
+        final IterationCallback<SessionInformation> callback;
 
         AllClientsItemCallback(
                 @NotNull final Executor callbackExecutor,
@@ -227,10 +231,10 @@ public class ClientServiceImpl implements ClientService {
             //this is not a lambda because we want it to be identifiable in a heap-dump
             callbackExecutor.execute(() -> {
 
-                    final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-                    try {
-                        Thread.currentThread().setContextClassLoader(callback.getClass().getClassLoader());
-                        for (final SessionInformation sessionInformation : items) {
+                final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+                try {
+                    Thread.currentThread().setContextClassLoader(callback.getClass().getClassLoader());
+                    for (final SessionInformation sessionInformation : items) {
 
                         callback.iterate(iterationContext, sessionInformation);
 

--- a/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
@@ -133,7 +133,7 @@ public class ClientServiceImpl implements ClientService {
         if (reasonCode != null) {
             Preconditions.checkArgument(
                     Mqtt5DisconnectReasonCode.canBeSentByServer(reasonCode),
-                    "Reason code {} must not be used for outbound disconnect packets from the server to a client.",
+                    "Reason code %s must not be used for outbound disconnect packets from the server to a client.",
                     reasonCode);
         }
 

--- a/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
@@ -132,6 +132,9 @@ public class ClientServiceImpl implements ClientService {
         Preconditions.checkNotNull(clientId, "A client id must never be null");
         if (reasonCode != null) {
             Preconditions.checkArgument(
+                    reasonCode != DisconnectReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
+                    "Reason code %s must not be used for disconnect packets.", reasonCode);
+            Preconditions.checkArgument(
                     Mqtt5DisconnectReasonCode.canBeSentByServer(reasonCode),
                     "Reason code %s must not be used for outbound disconnect packets from the server to a client.",
                     reasonCode);
@@ -200,7 +203,8 @@ public class ClientServiceImpl implements ClientService {
         final FetchCallback<ChunkCursor, SessionInformation> fetchCallback =
                 new AllClientsFetchCallback(clientSessionPersistence);
         final AsyncIterator<ChunkCursor, SessionInformation> asyncIterator =
-                asyncIteratorFactory.createIterator(fetchCallback,
+                asyncIteratorFactory.createIterator(
+                        fetchCallback,
                         new AllClientsItemCallback(callbackExecutor, callback));
 
         asyncIterator.fetchAndIterate();

--- a/src/main/java/com/hivemq/mqtt/handler/disconnect/Mqtt3ServerDisconnector.java
+++ b/src/main/java/com/hivemq/mqtt/handler/disconnect/Mqtt3ServerDisconnector.java
@@ -50,6 +50,5 @@ public class Mqtt3ServerDisconnector implements MqttServerDisconnector {
             mqttDisconnectUtil.logDisconnect(channel, logMessage, eventLogMessage);
             mqttDisconnectUtil.disconnect(channel);
         }
-
     }
 }

--- a/src/main/java/com/hivemq/mqtt/handler/disconnect/Mqtt3ServerDisconnector.java
+++ b/src/main/java/com/hivemq/mqtt/handler/disconnect/Mqtt3ServerDisconnector.java
@@ -50,5 +50,6 @@ public class Mqtt3ServerDisconnector implements MqttServerDisconnector {
             mqttDisconnectUtil.logDisconnect(channel, logMessage, eventLogMessage);
             mqttDisconnectUtil.disconnect(channel);
         }
+
     }
 }

--- a/src/main/java/com/hivemq/mqtt/message/reason/Mqtt5DisconnectReasonCode.java
+++ b/src/main/java/com/hivemq/mqtt/message/reason/Mqtt5DisconnectReasonCode.java
@@ -29,7 +29,7 @@ import com.hivemq.extension.sdk.api.packets.general.DisconnectedReasonCode;
 public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
 
     NORMAL_DISCONNECTION(0x00),
-    DISCONNECT_WITH_WILL_MESSAGE(0x04),
+    @Deprecated DISCONNECT_WITH_WILL_MESSAGE(0x04),
     UNSPECIFIED_ERROR(MqttCommonReasonCode.UNSPECIFIED_ERROR),
     MALFORMED_PACKET(MqttCommonReasonCode.MALFORMED_PACKET),
     PROTOCOL_ERROR(MqttCommonReasonCode.PROTOCOL_ERROR),
@@ -37,7 +37,7 @@ public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
     NOT_AUTHORIZED(MqttCommonReasonCode.NOT_AUTHORIZED),
     SERVER_BUSY(MqttCommonReasonCode.SERVER_BUSY),
     SERVER_SHUTTING_DOWN(0x8B),
-    BAD_AUTHENTICATION_METHOD(MqttCommonReasonCode.BAD_AUTHENTICATION_METHOD),
+    @Deprecated BAD_AUTHENTICATION_METHOD(MqttCommonReasonCode.BAD_AUTHENTICATION_METHOD),
     KEEP_ALIVE_TIMEOUT(0x8D),
     SESSION_TAKEN_OVER(0x8E),
     TOPIC_FILTER_INVALID(MqttCommonReasonCode.TOPIC_FILTER_INVALID),

--- a/src/main/java/com/hivemq/mqtt/message/reason/Mqtt5DisconnectReasonCode.java
+++ b/src/main/java/com/hivemq/mqtt/message/reason/Mqtt5DisconnectReasonCode.java
@@ -29,7 +29,7 @@ import com.hivemq.extension.sdk.api.packets.general.DisconnectedReasonCode;
 public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
 
     NORMAL_DISCONNECTION(0x00),
-    @Deprecated DISCONNECT_WITH_WILL_MESSAGE(0x04),
+    DISCONNECT_WITH_WILL_MESSAGE(0x04),
     UNSPECIFIED_ERROR(MqttCommonReasonCode.UNSPECIFIED_ERROR),
     MALFORMED_PACKET(MqttCommonReasonCode.MALFORMED_PACKET),
     PROTOCOL_ERROR(MqttCommonReasonCode.PROTOCOL_ERROR),
@@ -37,7 +37,7 @@ public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
     NOT_AUTHORIZED(MqttCommonReasonCode.NOT_AUTHORIZED),
     SERVER_BUSY(MqttCommonReasonCode.SERVER_BUSY),
     SERVER_SHUTTING_DOWN(0x8B),
-    @Deprecated BAD_AUTHENTICATION_METHOD(MqttCommonReasonCode.BAD_AUTHENTICATION_METHOD),
+    BAD_AUTHENTICATION_METHOD(MqttCommonReasonCode.BAD_AUTHENTICATION_METHOD),
     KEEP_ALIVE_TIMEOUT(0x8D),
     SESSION_TAKEN_OVER(0x8E),
     TOPIC_FILTER_INVALID(MqttCommonReasonCode.TOPIC_FILTER_INVALID),

--- a/src/main/java/com/hivemq/mqtt/message/reason/Mqtt5DisconnectReasonCode.java
+++ b/src/main/java/com/hivemq/mqtt/message/reason/Mqtt5DisconnectReasonCode.java
@@ -21,6 +21,8 @@ import com.hivemq.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.packets.general.DisconnectedReasonCode;
 
+import java.util.EnumSet;
+
 /**
  * MQTT Reason Codes that can be used in DISCONNECT packets according to the MQTT 5 specification.
  *
@@ -108,6 +110,23 @@ public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
             return null;
         }
         return ERROR_CODE_LOOKUP[code - ERROR_CODE_MIN];
+    }
+
+    private static final @NotNull EnumSet<DisconnectReasonCode> BY_CLIENT =
+            EnumSet.of(DisconnectReasonCode.NORMAL_DISCONNECTION, DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE,
+                    DisconnectReasonCode.UNSPECIFIED_ERROR, DisconnectReasonCode.MALFORMED_PACKET,
+                    DisconnectReasonCode.PROTOCOL_ERROR, DisconnectReasonCode.IMPLEMENTATION_SPECIFIC_ERROR,
+                    DisconnectReasonCode.TOPIC_FILTER_INVALID, DisconnectReasonCode.TOPIC_NAME_INVALID,
+                    DisconnectReasonCode.RECEIVE_MAXIMUM_EXCEEDED, DisconnectReasonCode.TOPIC_ALIAS_INVALID,
+                    DisconnectReasonCode.PACKET_TOO_LARGE, DisconnectReasonCode.MESSAGE_RATE_TOO_HIGH,
+                    DisconnectReasonCode.QUOTA_EXCEEDED, DisconnectReasonCode.ADMINISTRATIVE_ACTION);
+
+    public static boolean canBeSentByServer(final @NotNull DisconnectReasonCode reasonCode) {
+        return reasonCode != DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE;
+    }
+
+    public static boolean canBeSentByClient(final @NotNull DisconnectReasonCode reasonCode) {
+        return BY_CLIENT.contains(reasonCode);
     }
 
     /**

--- a/src/main/java/com/hivemq/mqtt/message/reason/Mqtt5DisconnectReasonCode.java
+++ b/src/main/java/com/hivemq/mqtt/message/reason/Mqtt5DisconnectReasonCode.java
@@ -76,7 +76,6 @@ public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
         return code;
     }
 
-
     private static final int ERROR_CODE_MIN = UNSPECIFIED_ERROR.code;
     private static final int ERROR_CODE_MAX = WILDCARD_SUBSCRIPTION_NOT_SUPPORTED.code;
     private static final Mqtt5DisconnectReasonCode[] ERROR_CODE_LOOKUP =
@@ -95,7 +94,7 @@ public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
      *
      * @param code the byte code.
      * @return the DISCONNECT Reason Code belonging to the given byte code or null if the byte code is not a valid
-     * DISCONNECT Reason Code code.
+     *         DISCONNECT Reason Code code.
      */
     @Nullable
     public static Mqtt5DisconnectReasonCode fromCode(final int code) {
@@ -116,7 +115,7 @@ public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
      *
      * @param code the byte code.
      * @return the DISCONNECT Reason Code belonging to the given byte code or null if the byte code is not a valid
-     * DISCONNECT Reason Code code.
+     *         DISCONNECT Reason Code code.
      */
     @NotNull
     public static DisconnectReasonCode toPluginCode(final @NotNull Mqtt5DisconnectReasonCode code) {
@@ -128,11 +127,10 @@ public enum Mqtt5DisconnectReasonCode implements Mqtt5ReasonCode {
      *
      * @param code the byte code.
      * @return the DISCONNECT Reason Code belonging to the given byte code or null if the byte code is not a valid
-     * DISCONNECT Reason Code code.
+     *         DISCONNECT Reason Code code.
      */
     @NotNull
     public static DisconnectedReasonCode toPluginDisconnectedCode(final @NotNull Mqtt5DisconnectReasonCode code) {
         return DisconnectedReasonCode.valueOf(code.name());
     }
-
 }

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistence.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistence.java
@@ -20,8 +20,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.annotations.Nullable;
 import com.hivemq.codec.encoder.mqtt5.UnsignedDataTypes;
-import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
+import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 import com.hivemq.persistence.local.xodus.MultipleChunkResult;
 
 import java.util.Map;
@@ -107,12 +107,8 @@ public interface ClientSessionPersistence {
      * connected (false).
      */
     @NotNull
-    ListenableFuture<Boolean> forceDisconnectClient(
-            @NotNull String clientId,
-            boolean preventLwtMessage,
-            @NotNull DisconnectSource source,
-            @Nullable DisconnectReasonCode reasonCode,
-            @Nullable String reasonString);
+    ListenableFuture<Boolean> forceDisconnectClient(@NotNull String clientId, boolean preventLwtMessage, @NotNull DisconnectSource source,
+                                                    @Nullable Mqtt5DisconnectReasonCode reasonCode, @Nullable String reasonString);
 
     /**
      * Sets the session expiry interval for a client in seconds.

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistence.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistence.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.annotations.Nullable;
 import com.hivemq.codec.encoder.mqtt5.UnsignedDataTypes;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
 import com.hivemq.persistence.local.xodus.MultipleChunkResult;
 
@@ -93,6 +94,21 @@ public interface ClientSessionPersistence {
      */
     @NotNull
     ListenableFuture<Boolean> forceDisconnectClient(@NotNull String clientId, boolean preventLwtMessage, @NotNull DisconnectSource source);
+
+    /**
+     * TODO
+     *
+     * @param clientId
+     * @param preventLwtMesage
+     * @param source
+     * @param reasonCode
+     * @param reasonString
+     * @return
+     */
+    @NotNull
+    ListenableFuture<Boolean> forceDisconnectClient(
+            @NotNull String clientId, boolean preventLwtMesage, @NotNull DisconnectSource source,
+            @Nullable DisconnectReasonCode reasonCode, @Nullable String reasonString);
 
     /**
      * Sets the session expiry interval for a client in seconds.

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistence.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistence.java
@@ -99,7 +99,7 @@ public interface ClientSessionPersistence {
      * Enforce a client disconnect from a specific source, preventing or delivering the will message.
      *
      * @param clientId          The client id of the client to disconnect.
-     * @param preventLwtMesage  The flag if the will message should be prevented or delivered.
+     * @param preventLwtMessage The flag if the will message should be prevented or delivered.
      * @param source            The source of the enforce call.
      * @param reasonCode        The reason code for the enforced disconnect.
      * @param reasonString      The reason string for the enforced disconnect.
@@ -108,8 +108,11 @@ public interface ClientSessionPersistence {
      */
     @NotNull
     ListenableFuture<Boolean> forceDisconnectClient(
-            @NotNull String clientId, boolean preventLwtMesage, @NotNull DisconnectSource source,
-            @Nullable DisconnectReasonCode reasonCode, @Nullable String reasonString);
+            @NotNull String clientId,
+            boolean preventLwtMessage,
+            @NotNull DisconnectSource source,
+            @Nullable DisconnectReasonCode reasonCode,
+            @Nullable String reasonString);
 
     /**
      * Sets the session expiry interval for a client in seconds.

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistence.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistence.java
@@ -96,14 +96,15 @@ public interface ClientSessionPersistence {
     ListenableFuture<Boolean> forceDisconnectClient(@NotNull String clientId, boolean preventLwtMessage, @NotNull DisconnectSource source);
 
     /**
-     * TODO
+     * Enforce a client disconnect from a specific source, preventing or delivering the will message.
      *
-     * @param clientId
-     * @param preventLwtMesage
-     * @param source
-     * @param reasonCode
-     * @param reasonString
-     * @return
+     * @param clientId          The client id of the client to disconnect.
+     * @param preventLwtMesage  The flag if the will message should be prevented or delivered.
+     * @param source            The source of the enforce call.
+     * @param reasonCode        The reason code for the enforced disconnect.
+     * @param reasonString      The reason string for the enforced disconnect.
+     * @return a future of a boolean which gives the information that a client was disconnected (true) or wasn't
+     * connected (false).
      */
     @NotNull
     ListenableFuture<Boolean> forceDisconnectClient(

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -219,7 +219,6 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         Preconditions.checkNotNull(source, "Disconnect source cannot be null");
 
         final ClientSession session = getSession(clientId, false);
-
         if (session == null) {
             log.trace("Ignoring forced client disconnect request for client '{}', because client is not connected.", clientId);
             return Futures.immediateFuture(false);

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -265,7 +265,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         final String eventLogMessage = "Disconnected via extension system";
 
         if (version == ProtocolVersion.MQTTv5) {
-            if (reasonCode != null) {
+            if (reasonCode != null && reasonString != null) {
                 mqtt5ServerDisconnector.disconnect(
                         channel,
                         logMessage,

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -24,7 +24,6 @@ import com.hivemq.annotations.NotNull;
 import com.hivemq.annotations.Nullable;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.configuration.service.InternalConfigurations;
-import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
 import com.hivemq.mqtt.handler.disconnect.Mqtt5ServerDisconnector;
@@ -77,17 +76,16 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
     private final @NotNull Mqtt3ServerDisconnector mqtt3ServerDisconnector;
 
     @Inject
-    public ClientSessionPersistenceImpl(
-            final @NotNull ClientSessionLocalPersistence localPersistence,
-            final @NotNull ClientSessionSubscriptionPersistence sessionSubscriptionPersistence,
-            final @NotNull ClientQueuePersistence clientQueuePersistence,
-            final @NotNull SingleWriterService singleWriterService,
-            final @NotNull ChannelPersistence channelPersistence,
-            final @NotNull EventLog eventLog,
-            final @NotNull PublishPayloadPersistence publishPayloadPersistence,
-            final @NotNull PendingWillMessages pendingWillMessages,
-            final @NotNull Mqtt5ServerDisconnector mqtt5ServerDisconnector,
-            final @NotNull Mqtt3ServerDisconnector mqtt3ServerDisconnector) {
+    public ClientSessionPersistenceImpl(final @NotNull ClientSessionLocalPersistence localPersistence,
+                                        final @NotNull ClientSessionSubscriptionPersistence sessionSubscriptionPersistence,
+                                        final @NotNull ClientQueuePersistence clientQueuePersistence,
+                                        final @NotNull SingleWriterService singleWriterService,
+                                        final @NotNull ChannelPersistence channelPersistence,
+                                        final @NotNull EventLog eventLog,
+                                        final @NotNull PublishPayloadPersistence publishPayloadPersistence,
+                                        final @NotNull PendingWillMessages pendingWillMessages,
+                                        final @NotNull Mqtt5ServerDisconnector mqtt5ServerDisconnector,
+                                        final @NotNull Mqtt3ServerDisconnector mqtt3ServerDisconnector) {
 
 
         this.localPersistence = localPersistence;
@@ -129,14 +127,12 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
 
     @NotNull
     @Override
-    public ListenableFuture<Void> clientDisconnected(
-            @NotNull final String client, final boolean sendWill, final long sessionExpiry) {
+    public ListenableFuture<Void> clientDisconnected(@NotNull final String client, final boolean sendWill, final long sessionExpiry) {
         checkNotNull(client, "Client id must not be null");
         final long timestamp = System.currentTimeMillis();
         final SettableFuture<Void> resultFuture = SettableFuture.create();
         singleWriter.submit(client, (SingleWriterService.Task<Void>) (bucketIndex, queueBuckets, queueIndex) -> {
-            final ClientSession disconnectSession =
-                    localPersistence.disconnect(client, timestamp, sendWill, bucketIndex, sessionExpiry);
+            final ClientSession disconnectSession = localPersistence.disconnect(client, timestamp, sendWill, bucketIndex, sessionExpiry);
             if (sendWill) {
                 pendingWillMessages.addWill(client, disconnectSession);
             }
@@ -155,9 +151,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
 
     @NotNull
     @Override
-    public ListenableFuture<Void> clientConnected(
-            @NotNull final String client, final boolean cleanStart, final long clientSessionExpiryInterval,
-            @Nullable final MqttWillPublish willPublish) {
+    public ListenableFuture<Void> clientConnected(@NotNull final String client, final boolean cleanStart, final long clientSessionExpiryInterval, @Nullable final MqttWillPublish willPublish) {
         checkNotNull(client, "Client id must not be null");
         pendingWillMessages.cancelWill(client);
         final long timestamp = System.currentTimeMillis();
@@ -167,20 +161,16 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
             sessionWill = new ClientSessionWill(willPublish, willPayloadId);
         }
         final ClientSession clientSession = new ClientSession(true, clientSessionExpiryInterval, sessionWill);
-        final ListenableFuture<ConnectResult> submitFuture =
-                singleWriter.submit(client, new SingleWriterService.Task<>() {
-                    @NotNull
-                    @Override
-                    public ConnectResult doTask(
-                            final int bucketIndex, @NotNull final ImmutableList<Integer> queueBuckets,
-                            final int queueIndex) {
-                        final Long previousTimestamp = localPersistence.getTimestamp(client, bucketIndex);
-                        final ClientSession previousClientSession =
-                                localPersistence.getSession(client, bucketIndex, false);
-                        localPersistence.put(client, clientSession, timestamp, bucketIndex);
-                        return new ConnectResult(previousTimestamp, previousClientSession);
-                    }
-                });
+        final ListenableFuture<ConnectResult> submitFuture = singleWriter.submit(client, new SingleWriterService.Task<>() {
+            @NotNull
+            @Override
+            public ConnectResult doTask(final int bucketIndex, @NotNull final ImmutableList<Integer> queueBuckets, final int queueIndex) {
+                final Long previousTimestamp = localPersistence.getTimestamp(client, bucketIndex);
+                final ClientSession previousClientSession = localPersistence.getSession(client, bucketIndex, false);
+                localPersistence.put(client, clientSession, timestamp, bucketIndex);
+                return new ConnectResult(previousTimestamp, previousClientSession);
+            }
+        });
 
         final SettableFuture<Void> resultFuture = SettableFuture.create();
         FutureUtils.addPersistenceCallback(submitFuture, new FutureCallback<>() {
@@ -196,12 +186,10 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
                     cleanupFuture = cleanClientData(client);
                 } else {
                     final boolean expired = previousTimestamp != null &&
-                            ClientSessions.isExpired(
-                                    previousClientSession, System.currentTimeMillis() - previousTimestamp);
+                            ClientSessions.isExpired(previousClientSession, System.currentTimeMillis() - previousTimestamp);
                     if (expired) {
                         // timestamp in milliseconds + session expiry in seconds * 1000 = milliseconds
-                        eventLog.clientSessionExpired(
-                                previousTimestamp + previousClientSession.getSessionExpiryInterval() * 1000, client);
+                        eventLog.clientSessionExpired(previousTimestamp + previousClientSession.getSessionExpiryInterval() * 1000, client);
                         cleanupFuture = cleanClientData(client);
                     } else {
                         cleanupFuture = Futures.immediateFuture(null);
@@ -224,7 +212,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
             final @NotNull String clientId,
             final boolean preventLwtMessage,
             final @NotNull DisconnectSource source,
-            final @Nullable DisconnectReasonCode reasonCode,
+            final @Nullable Mqtt5DisconnectReasonCode reasonCode,
             final @Nullable String reasonString) {
 
         Preconditions.checkNotNull(clientId, "Parameter clientId cannot be null");
@@ -233,9 +221,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         final ClientSession session = getSession(clientId, false);
 
         if (session == null) {
-            log.trace(
-                    "Ignoring forced client disconnect request for client '{}', because client is not connected.",
-                    clientId);
+            log.trace("Ignoring forced client disconnect request for client '{}', because client is not connected.", clientId);
             return Futures.immediateFuture(false);
         }
         if (preventLwtMessage) {
@@ -243,14 +229,10 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         }
 
         log.debug("Request forced client disconnect for client {}.", clientId);
-
-
         final Channel channel = channelPersistence.get(clientId);
 
         if (channel == null) {
-            log.trace(
-                    "Ignoring forced client disconnect request for client '{}', because client is not connected.",
-                    clientId);
+            log.trace("Ignoring forced client disconnect request for client '{}', because client is not connected.", clientId);
             return Futures.immediateFuture(false);
         }
 
@@ -260,34 +242,18 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         }
 
         final ProtocolVersion version = channel.attr(ChannelAttributes.MQTT_VERSION).get();
-        final String logMessage =
-                String.format("Disconnecting client with clientId '%s' forcibly via extension system.", clientId);
+        final String logMessage = String.format("Disconnecting client with clientId '%s' forcibly via extension system.", clientId);
         final String eventLogMessage = "Disconnected via extension system";
 
+        final Mqtt5DisconnectReasonCode usedReasonCode =
+                reasonCode == null ? Mqtt5DisconnectReasonCode.ADMINISTRATIVE_ACTION : Mqtt5DisconnectReasonCode.valueOf(reasonCode.name());
+
         if (version == ProtocolVersion.MQTTv5) {
-            if (reasonCode != null && reasonString != null) {
-                mqtt5ServerDisconnector.disconnect(
-                        channel,
-                        logMessage,
-                        eventLogMessage,
-                        Mqtt5DisconnectReasonCode.fromCode(reasonCode.ordinal()),
-                        reasonString);
-            } else {
-                mqtt5ServerDisconnector.disconnect(
-                        channel,
-                        logMessage,
-                        eventLogMessage,
-                        Mqtt5DisconnectReasonCode.ADMINISTRATIVE_ACTION,
-                        reasonString);
-            }
+            mqtt5ServerDisconnector.disconnect(channel, logMessage, eventLogMessage, usedReasonCode, reasonString);
         } else {
-            mqtt3ServerDisconnector.disconnect(
-                    channel,
-                    logMessage,
-                    eventLogMessage,
-                    null,
-                    null);
+            mqtt3ServerDisconnector.disconnect(channel, logMessage, eventLogMessage, usedReasonCode, reasonString);
         }
+
         final SettableFuture<Boolean> resultFuture = SettableFuture.create();
         channel.closeFuture().addListener((ChannelFutureListener) future -> {
             resultFuture.set(true);
@@ -314,14 +280,13 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
     @NotNull
     @Override
     public ListenableFuture<Set<String>> getAllClients() {
-        final List<ListenableFuture<Set<String>>> futures =
-                singleWriter.submitToAllQueues((bucketIndex, queueBuckets, queueIndex) -> {
-                    final Set<String> clientSessions = new HashSet<>();
-                    for (final Integer bucket : queueBuckets) {
-                        clientSessions.addAll(localPersistence.getAllClients(bucket));
-                    }
-                    return clientSessions;
-                });
+        final List<ListenableFuture<Set<String>>> futures = singleWriter.submitToAllQueues((bucketIndex, queueBuckets, queueIndex) -> {
+            final Set<String> clientSessions = new HashSet<>();
+            for (final Integer bucket : queueBuckets) {
+                clientSessions.addAll(localPersistence.getAllClients(bucket));
+            }
+            return clientSessions;
+        });
         return FutureUtils.combineSetResults(Futures.allAsList(futures));
     }
 
@@ -338,15 +303,13 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
      */
     @NotNull
     @Override
-    public ListenableFuture<Boolean> setSessionExpiryInterval(
-            @NotNull final String clientId, final long sessionExpiryInterval) {
+    public ListenableFuture<Boolean> setSessionExpiryInterval(@NotNull final String clientId, final long sessionExpiryInterval) {
         checkNotNull(clientId, "Client id must not be null");
 
         final ListenableFuture<Boolean> setTTlFuture = singleWriter.submit(clientId, new SingleWriterService.Task<>() {
 
             @Override
-            public @NotNull Boolean doTask(
-                    final int bucketIndex, @NotNull final ImmutableList<Integer> queueBuckets, final int queueIndex) {
+            public @NotNull Boolean doTask(final int bucketIndex, @NotNull final ImmutableList<Integer> queueBuckets, final int queueIndex) {
 
                 final boolean clientSessionExists = localPersistence.getSession(clientId) != null;
 
@@ -421,8 +384,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
 
     @NotNull
     @Override
-    public ListenableFuture<Boolean> invalidateSession(
-            final @NotNull String clientId, final @NotNull DisconnectSource disconnectSource) {
+    public ListenableFuture<Boolean> invalidateSession(final @NotNull String clientId, final @NotNull DisconnectSource disconnectSource) {
 
         Preconditions.checkNotNull(clientId, "ClientId cannot be null");
         Preconditions.checkNotNull(disconnectSource, "Disconnect source cannot be null");
@@ -435,13 +397,11 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
             public void onSuccess(final Boolean sessionExists) {
 
                 if (sessionExists) {
-                    final ListenableFuture<Boolean> disconnectClientFuture =
-                            forceDisconnectClient(clientId, false, disconnectSource);
+                    final ListenableFuture<Boolean> disconnectClientFuture = forceDisconnectClient(clientId, false, disconnectSource);
                     resultFuture.setFuture(disconnectClientFuture);
                 } else {
                     resultFuture.set(null);
                 }
-
             }
 
             @Override
@@ -457,24 +417,18 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
     @Override
     public ListenableFuture<Map<String, PendingWillMessages.PendingWill>> pendingWills() {
 
-        final ListenableFuture<List<Map<String, PendingWillMessages.PendingWill>>> singleWriterFutures =
-                singleWriter.submitToAllQueuesAsList(
-                        new SingleWriterService.Task<Map<String, PendingWillMessages.PendingWill>>() {
-                            @NotNull
-                            @Override
-                            public Map<String, PendingWillMessages.PendingWill> doTask(
-                                    final int bucketIndex, @NotNull final ImmutableList<Integer> queueBuckets,
-                                    final int queueIndex) {
-                                final ImmutableMap.Builder<String, PendingWillMessages.PendingWill> queueWills =
-                                        ImmutableMap.builder();
-                                for (final Integer queueBucket : queueBuckets) {
-                                    final Map<String, PendingWillMessages.PendingWill> bucketMap =
-                                            localPersistence.getPendingWills(queueBucket);
-                                    queueWills.putAll(bucketMap);
-                                }
-                                return queueWills.build();
-                            }
-                        });
+        final ListenableFuture<List<Map<String, PendingWillMessages.PendingWill>>> singleWriterFutures = singleWriter.submitToAllQueuesAsList(new SingleWriterService.Task<Map<String, PendingWillMessages.PendingWill>>() {
+            @NotNull
+            @Override
+            public Map<String, PendingWillMessages.PendingWill> doTask(final int bucketIndex, @NotNull final ImmutableList<Integer> queueBuckets, final int queueIndex) {
+                final ImmutableMap.Builder<String, PendingWillMessages.PendingWill> queueWills = ImmutableMap.builder();
+                for (final Integer queueBucket : queueBuckets) {
+                    final Map<String, PendingWillMessages.PendingWill> bucketMap = localPersistence.getPendingWills(queueBucket);
+                    queueWills.putAll(bucketMap);
+                }
+                return queueWills.build();
+            }
+        });
 
         final SettableFuture<Map<String, PendingWillMessages.PendingWill>> settableFuture = SettableFuture.create();
         FutureUtils.addPersistenceCallback(singleWriterFutures, new FutureCallback<>() {
@@ -508,8 +462,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         return singleWriter.submit(clientId, new SingleWriterService.Task<Void>() {
             @NotNull
             @Override
-            public Void doTask(
-                    final int bucketIndex, @NotNull final ImmutableList<Integer> queueBuckets, final int queueIndex) {
+            public Void doTask(final int bucketIndex, @NotNull final ImmutableList<Integer> queueBuckets, final int queueIndex) {
                 localPersistence.removeWill(clientId, bucketIndex);
                 return null;
             }
@@ -517,24 +470,20 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
     }
 
     @Override
-    public @NotNull ListenableFuture<MultipleChunkResult<Map<String, ClientSession>>> getAllLocalClientsChunk(
-            @NotNull final ChunkCursor cursor) {
+    public @NotNull ListenableFuture<MultipleChunkResult<Map<String, ClientSession>>> getAllLocalClientsChunk(@NotNull final ChunkCursor cursor) {
         try {
             checkNotNull(cursor, "Cursor must not be null");
 
-            final ImmutableList.Builder<ListenableFuture<@NotNull BucketChunkResult<Map<String, ClientSession>>>>
-                    builder = ImmutableList.builder();
+            final ImmutableList.Builder<ListenableFuture<@NotNull BucketChunkResult<Map<String, ClientSession>>>> builder = ImmutableList.builder();
 
             final int bucketCount = InternalConfigurations.PERSISTENCE_BUCKET_COUNT.get();
-            final int maxResults = InternalConfigurations.PERSISTENCE_CLIENT_SESSIONS_MAX_CHUNK_SIZE /
-                    (bucketCount - cursor.getFinishedBuckets().size());
+            final int maxResults = InternalConfigurations.PERSISTENCE_CLIENT_SESSIONS_MAX_CHUNK_SIZE / (bucketCount - cursor.getFinishedBuckets().size());
             for (int i = 0; i < bucketCount; i++) {
                 //skip already finished buckets
                 if (!cursor.getFinishedBuckets().contains(i)) {
                     final String lastKey = cursor.getLastKeys().get(i);
                     builder.add(singleWriter.submit(i, (bucketIndex1, queueBuckets, queueIndex) -> {
-                        return localPersistence.getAllClientsChunk(
-                                MatchAllPersistenceFilter.INSTANCE, bucketIndex1, lastKey, maxResults);
+                        return localPersistence.getAllClientsChunk(MatchAllPersistenceFilter.INSTANCE, bucketIndex1, lastKey, maxResults);
                     }));
                 }
             }
@@ -542,17 +491,13 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
             return Futures.transform(Futures.allAsList(builder.build()), allBucketsResult -> {
                 Preconditions.checkNotNull(allBucketsResult, "Iteration result from all buckets cannot be null");
 
-                final ImmutableMap.Builder<Integer, BucketChunkResult<Map<String, ClientSession>>> resultBuilder =
-                        ImmutableMap.builder();
+                final ImmutableMap.Builder<Integer, BucketChunkResult<Map<String, ClientSession>>> resultBuilder = ImmutableMap.builder();
                 for (final BucketChunkResult<Map<String, ClientSession>> bucketResult : allBucketsResult) {
                     resultBuilder.put(bucketResult.getBucketIndex(), bucketResult);
                 }
 
                 for (final Integer finishedBucketId : cursor.getFinishedBuckets()) {
-                    resultBuilder.put(
-                            finishedBucketId,
-                            new BucketChunkResult<>(Map.of(), true, cursor.getLastKeys().get(finishedBucketId),
-                                    finishedBucketId));
+                    resultBuilder.put(finishedBucketId, new BucketChunkResult<>(Map.of(), true, cursor.getLastKeys().get(finishedBucketId), finishedBucketId));
                 }
 
                 return new MultipleChunkResult<>(resultBuilder.build());

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -282,7 +282,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
                     logMessage,
                     eventLogMessage,
                     null,
-                    reasonString);
+                    null);
         }
         final SettableFuture<Boolean> resultFuture = SettableFuture.create();
         channel.closeFuture().addListener((ChannelFutureListener) future -> {

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -233,7 +233,9 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         final ClientSession session = getSession(clientId, false);
 
         if (session == null) {
-            log.trace("Ignoring forced client disconnect request for client '{}', because client is not connected.");
+            log.trace(
+                    "Ignoring forced client disconnect request for client '{}', because client is not connected.",
+                    clientId);
             return Futures.immediateFuture(false);
         }
         if (preventLwtMessage) {
@@ -246,7 +248,9 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         final Channel channel = channelPersistence.get(clientId);
 
         if (channel == null) {
-            log.trace("Ignoring forced client disconnect request for client '{}', because client is not connected.");
+            log.trace(
+                    "Ignoring forced client disconnect request for client '{}', because client is not connected.",
+                    clientId);
             return Futures.immediateFuture(false);
         }
 

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -224,8 +224,8 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
             final @NotNull String clientId,
             final boolean preventLwtMessage,
             final @NotNull DisconnectSource source,
-            final @NotNull DisconnectReasonCode reasonCode,
-            final @NotNull String reasonString) {
+            final @Nullable DisconnectReasonCode reasonCode,
+            final @Nullable String reasonString) {
 
         Preconditions.checkNotNull(clientId, "Parameter clientId cannot be null");
         Preconditions.checkNotNull(source, "Disconnect source cannot be null");
@@ -432,7 +432,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
 
                 if (sessionExists) {
                     final ListenableFuture<Boolean> disconnectClientFuture =
-                            forceDisconnectClient(clientId, false, disconnectSource, null, null);
+                            forceDisconnectClient(clientId, false, disconnectSource);
                     resultFuture.setFuture(disconnectClientFuture);
                 } else {
                     resultFuture.set(null);

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -295,6 +295,12 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         return resultFuture;
     }
 
+    @Override
+    public @NotNull ListenableFuture<Boolean> forceDisconnectClient(
+            final @NotNull String clientId, final boolean preventLwtMessage, final @NotNull DisconnectSource source) {
+        return forceDisconnectClient(clientId, preventLwtMessage, source, null, null);
+    }
+
     @NotNull
     public ListenableFuture<Void> cleanClientData(@NotNull final String clientId) {
 
@@ -317,12 +323,6 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
                     return clientSessions;
                 });
         return FutureUtils.combineSetResults(Futures.allAsList(futures));
-    }
-
-    @Override
-    public @NotNull ListenableFuture<Boolean> forceDisconnectClient(
-            final @NotNull String clientId, final boolean preventLwtMessage, final @NotNull DisconnectSource source) {
-        return forceDisconnectClient(clientId, preventLwtMessage, source, null, null);
     }
 
     @Nullable

--- a/src/test/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImplTest.java
@@ -45,7 +45,7 @@ public class ModifiableInboundDisconnectPacketImplTest {
     @Test
     public void test_modify_packet() {
         packet = new ModifiableInboundDisconnectPacketImpl(configurationService, original, 5);
-        packet.setReasonCode(DisconnectReasonCode.BAD_AUTHENTICATION_METHOD);
+        packet.setReasonCode(DisconnectReasonCode.QUOTA_EXCEEDED);
         assertTrue(packet.isModified());
 
         packet = new ModifiableInboundDisconnectPacketImpl(configurationService, original, 5);

--- a/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.services.exception.RateLimitExceededException;
 import com.hivemq.extension.sdk.api.services.session.ClientService;
 import com.hivemq.extension.sdk.api.services.session.SessionInformation;
@@ -240,6 +241,16 @@ public class ClientServiceImplTest {
     public void test_disconnect_client_prevent_lwt_true_success() throws Throwable {
         when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION)).thenReturn(Futures.immediateFuture(true));
         assertEquals(true, clientService.disconnectClient(clientId, true).get());
+    }
+
+    @Test(timeout = 20000)
+    public void test_disconnect_with_reason_Code() throws Throwable {
+        when(clientSessionPersistence.forceDisconnectClient(
+                clientId, true, EXTENSION, DisconnectReasonCode.NORMAL_DISCONNECTION,
+                "Disconnecting Normally")).thenReturn(Futures.immediateFuture(true));
+        assertEquals(
+                true, clientService.disconnectClient(clientId, true, DisconnectReasonCode.NORMAL_DISCONNECTION,
+                        "Disconnecting Normally").get());
     }
 
     @Test(timeout = 20000)

--- a/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
@@ -32,6 +32,7 @@ import com.hivemq.extensions.iteration.FetchCallback;
 import com.hivemq.extensions.services.PluginServiceRateLimitService;
 import com.hivemq.extensions.services.executor.GlobalManagedPluginExecutorService;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
+import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 import com.hivemq.persistence.clientsession.ChunkCursor;
 import com.hivemq.persistence.clientsession.ClientSession;
 import com.hivemq.persistence.clientsession.ClientSessionPersistence;
@@ -139,7 +140,7 @@ public class ClientServiceImplTest {
     @Test(expected = ExecutionException.class)
     public void test_disconnect_prevent_lwt_failed() throws Throwable {
 
-        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION)).thenReturn(Futures.immediateFailedFuture(TestException.INSTANCE));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(Futures.immediateFailedFuture(TestException.INSTANCE));
         clientService.disconnectClient(clientId, true).get();
 
     }
@@ -147,7 +148,7 @@ public class ClientServiceImplTest {
     @Test(expected = ExecutionException.class)
     public void test_disconnect_do_not_prevent_lwt_failed() throws Throwable {
 
-        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION)).thenReturn(Futures.immediateFailedFuture(TestException.INSTANCE));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(Futures.immediateFailedFuture(TestException.INSTANCE));
         clientService.disconnectClient(clientId).get();
 
     }
@@ -215,38 +216,38 @@ public class ClientServiceImplTest {
 
     @Test(timeout = 20000)
     public void test_disconnect_client_do_not_prevent_lwt_null_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION)).thenReturn(Futures.immediateFuture(null));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(null));
         assertEquals(null, clientService.disconnectClient(clientId).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_do_not_prevent_lwt_true_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION)).thenReturn(Futures.immediateFuture(true));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(true));
         assertEquals(true, clientService.disconnectClient(clientId).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_do_not_prevent_lwt_false_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION)).thenReturn(Futures.immediateFuture(false));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(false));
         assertEquals(false, clientService.disconnectClient(clientId).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_prevent_lwt_null_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION)).thenReturn(Futures.immediateFuture(null));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(null));
         assertEquals(null, clientService.disconnectClient(clientId, true).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_prevent_lwt_true_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION)).thenReturn(Futures.immediateFuture(true));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(true));
         assertEquals(true, clientService.disconnectClient(clientId, true).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_with_reason_Code() throws Throwable {
         when(clientSessionPersistence.forceDisconnectClient(
-                clientId, true, EXTENSION, DisconnectReasonCode.NORMAL_DISCONNECTION,
+                clientId, true, EXTENSION, Mqtt5DisconnectReasonCode.NORMAL_DISCONNECTION,
                 "Disconnecting Normally")).thenReturn(Futures.immediateFuture(true));
         assertEquals(
                 true, clientService.disconnectClient(clientId, true, DisconnectReasonCode.NORMAL_DISCONNECTION,
@@ -255,7 +256,7 @@ public class ClientServiceImplTest {
 
     @Test(timeout = 20000)
     public void test_disconnect_client_prevent_lwt_false_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION)).thenReturn(Futures.immediateFuture(false));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(false));
         assertEquals(false, clientService.disconnectClient(clientId, true).get());
     }
 

--- a/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
@@ -139,11 +139,11 @@ public class ClientServiceImplTest {
         }
     }
 
-
     @Test(expected = ExecutionException.class)
     public void test_disconnect_prevent_lwt_failed() throws Throwable {
 
-        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(Futures.immediateFailedFuture(TestException.INSTANCE));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(
+                Futures.immediateFailedFuture(TestException.INSTANCE));
         clientService.disconnectClient(clientId, true).get();
 
     }
@@ -151,7 +151,8 @@ public class ClientServiceImplTest {
     @Test(expected = ExecutionException.class)
     public void test_disconnect_do_not_prevent_lwt_failed() throws Throwable {
 
-        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(Futures.immediateFailedFuture(TestException.INSTANCE));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(
+                Futures.immediateFailedFuture(TestException.INSTANCE));
         clientService.disconnectClient(clientId).get();
 
     }
@@ -159,7 +160,8 @@ public class ClientServiceImplTest {
     @Test(expected = ExecutionException.class)
     public void test_invalidate_session_request_failed() throws Throwable {
 
-        when(clientSessionPersistence.invalidateSession(clientId, EXTENSION)).thenReturn(Futures.immediateFailedFuture(TestException.INSTANCE));
+        when(clientSessionPersistence.invalidateSession(clientId, EXTENSION)).thenReturn(
+                Futures.immediateFailedFuture(TestException.INSTANCE));
         clientService.invalidateSession(clientId).get();
 
     }
@@ -219,31 +221,36 @@ public class ClientServiceImplTest {
 
     @Test(timeout = 20000)
     public void test_disconnect_client_do_not_prevent_lwt_null_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(null));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(
+                Futures.immediateFuture(null));
         assertEquals(null, clientService.disconnectClient(clientId).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_do_not_prevent_lwt_true_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(true));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(
+                Futures.immediateFuture(true));
         assertEquals(true, clientService.disconnectClient(clientId).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_do_not_prevent_lwt_false_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(false));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, false, EXTENSION, null, null)).thenReturn(
+                Futures.immediateFuture(false));
         assertEquals(false, clientService.disconnectClient(clientId).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_prevent_lwt_null_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(null));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(
+                Futures.immediateFuture(null));
         assertEquals(null, clientService.disconnectClient(clientId, true).get());
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_prevent_lwt_true_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(true));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(
+                Futures.immediateFuture(true));
         assertEquals(true, clientService.disconnectClient(clientId, true).get());
     }
 
@@ -262,14 +269,23 @@ public class ClientServiceImplTest {
         final EmbeddedChannel channel = new EmbeddedChannel();
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
         when(clientSessionPersistence.getSession(eq("client"), anyBoolean())).thenReturn(new ClientSession(true, 0));
-        @NotNull final CompletableFuture<Boolean> clientFuture =
-                clientService.disconnectClient("client", true, DisconnectReasonCode.BAD_AUTHENTICATION_METHOD,
-                        "reason-string");
+        clientService.disconnectClient("client", true, DisconnectReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
+                "reason-string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_disconnect_with_client_reason_code() {
+        final EmbeddedChannel channel = new EmbeddedChannel();
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+        when(clientSessionPersistence.getSession(eq("client"), anyBoolean())).thenReturn(new ClientSession(true, 0));
+        clientService.disconnectClient("client", true, DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE,
+                "reason-string");
     }
 
     @Test(timeout = 20000)
     public void test_disconnect_client_prevent_lwt_false_success() throws Throwable {
-        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(Futures.immediateFuture(false));
+        when(clientSessionPersistence.forceDisconnectClient(clientId, true, EXTENSION, null, null)).thenReturn(
+                Futures.immediateFuture(false));
         assertEquals(false, clientService.disconnectClient(clientId, true).get());
     }
 
@@ -287,7 +303,8 @@ public class ClientServiceImplTest {
 
     @Test(timeout = 20000)
     public void test_invalidate_session_false_success() throws Throwable {
-        when(clientSessionPersistence.invalidateSession(clientId, EXTENSION)).thenReturn(Futures.immediateFuture(false));
+        when(clientSessionPersistence.invalidateSession(clientId, EXTENSION)).thenReturn(
+                Futures.immediateFuture(false));
         assertEquals(false, clientService.invalidateSession(clientId).get());
     }
 
@@ -341,10 +358,11 @@ public class ClientServiceImplTest {
 
         final CountDownLatch latch = new CountDownLatch(1);
         final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final ClientServiceImpl.AllClientsItemCallback itemCallback = new ClientServiceImpl.AllClientsItemCallback(executor, (context, value) -> {
-            items.add(value);
-            latch.countDown();
-        });
+        final ClientServiceImpl.AllClientsItemCallback itemCallback =
+                new ClientServiceImpl.AllClientsItemCallback(executor, (context, value) -> {
+                    items.add(value);
+                    latch.countDown();
+                });
 
         final ListenableFuture<Boolean> onItems = itemCallback.onItems(List.of(
                 new SessionInformationImpl("client", 1, true),
@@ -363,9 +381,10 @@ public class ClientServiceImplTest {
     public void test_item_callback_abort() throws Exception {
 
         final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final ClientServiceImpl.AllClientsItemCallback itemCallback = new ClientServiceImpl.AllClientsItemCallback(executor, (context, value) -> {
-            context.abortIteration();
-        });
+        final ClientServiceImpl.AllClientsItemCallback itemCallback =
+                new ClientServiceImpl.AllClientsItemCallback(executor, (context, value) -> {
+                    context.abortIteration();
+                });
 
         final ListenableFuture<Boolean> onItems = itemCallback.onItems(List.of(
                 new SessionInformationImpl("client", 1, true),
@@ -382,9 +401,10 @@ public class ClientServiceImplTest {
     public void test_item_callback_exception() throws Throwable {
 
         final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final ClientServiceImpl.AllClientsItemCallback itemCallback = new ClientServiceImpl.AllClientsItemCallback(executor, (context, value) -> {
-            throw new RuntimeException("test-exception");
-        });
+        final ClientServiceImpl.AllClientsItemCallback itemCallback =
+                new ClientServiceImpl.AllClientsItemCallback(executor, (context, value) -> {
+                    throw new RuntimeException("test-exception");
+                });
 
         final ListenableFuture<Boolean> onItems = itemCallback.onItems(List.of(
                 new SessionInformationImpl("client", 1, true),
@@ -400,7 +420,6 @@ public class ClientServiceImplTest {
 
         executor.shutdownNow();
     }
-
 
     @Test(timeout = 10000)
     public void test_iteration_started() throws Exception {
@@ -435,17 +454,19 @@ public class ClientServiceImplTest {
     @Test
     public void test_test_fetch_callback_conversion() {
 
-        final ClientServiceImpl.AllClientsFetchCallback fetchCallback = new ClientServiceImpl.AllClientsFetchCallback(null);
+        final ClientServiceImpl.AllClientsFetchCallback fetchCallback =
+                new ClientServiceImpl.AllClientsFetchCallback(null);
 
-        final ChunkResult<ChunkCursor, SessionInformation> chunkResult = fetchCallback.convertToChunkResult(new MultipleChunkResult<Map<String, ClientSession>>(
-                Map.of(
-                        1, new BucketChunkResult<>(Map.of(
-                                "client1", new ClientSession(true, 10)), true, "client1", 1),
-                        2, new BucketChunkResult<>(Map.of(
-                                "client2", new ClientSession(true, 10),
-                                "client3", new ClientSession(true, 10))
-                                , false, "client3", 2)
-                )));
+        final ChunkResult<ChunkCursor, SessionInformation> chunkResult =
+                fetchCallback.convertToChunkResult(new MultipleChunkResult<Map<String, ClientSession>>(
+                        Map.of(
+                                1, new BucketChunkResult<>(Map.of(
+                                        "client1", new ClientSession(true, 10)), true, "client1", 1),
+                                2, new BucketChunkResult<>(Map.of(
+                                        "client2", new ClientSession(true, 10),
+                                        "client3", new ClientSession(true, 10))
+                                        , false, "client3", 2)
+                        )));
 
         assertTrue(chunkResult.getCursor().getFinishedBuckets().contains(1));
         assertFalse(chunkResult.getCursor().getFinishedBuckets().contains(2));


### PR DESCRIPTION
**Motivation**

The possibility of specifying a reason for disconnecting a client through an extension.

Resolves <https://github.com/hivemq/hivemq-community-edition/issues/63>

**Changes**

Added:

- disconnectClient method in ClientService with additional parameters 
- forciblyDisconnect method in ClientSessionPersistence with additional parameters
