### PR TITLE
Feature/Add convenience methods to get byte-array from ByteBuffers 

### DIFF
--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
@@ -17,6 +17,7 @@
 package com.hivemq.extension.sdk.api.packets.connack;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.connect.ConnackReasonCode;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
@@ -240,5 +241,12 @@ public interface ConnackPacket {
      */
     @NotNull
     Optional<ByteBuffer> getAuthenticationData();
+
+    /**
+     * Convenience method to retrieve authentication data as a byte array.
+     *
+     * @return the authentication data as a byte array.
+     */
+    @Nullable byte[] getAuthenticationDataAsArray();
 
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
@@ -245,8 +245,8 @@ public interface ConnackPacket {
     /**
      * Convenience method to retrieve authentication data as a byte array.
      *
-     * @return the authentication data as a byte array.
+     * @return the authentication data as a an optional byte array.
      */
-    @Nullable byte[] getAuthenticationDataAsArray();
+    @Nullable Optional<byte[]> getAuthenticationDataAsByteArray();
 
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
@@ -242,7 +242,7 @@ public interface ConnackPacket {
     Optional<ByteBuffer> getAuthenticationData();
 
     /**
-     * If this property is present, the {@link ByteBuffer} contains the data used for the extended authentication.
+     * If this property is present, the byte array contains the data used for the extended authentication.
      * The contents of this data are defined by the authentication method.
      * <p>
      * For an MQTT 3 client this {@link Optional} for the MQTT 5 property will always be empty.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connack/ConnackPacket.java
@@ -17,7 +17,6 @@
 package com.hivemq.extension.sdk.api.packets.connack;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.connect.ConnackReasonCode;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
@@ -243,10 +242,13 @@ public interface ConnackPacket {
     Optional<ByteBuffer> getAuthenticationData();
 
     /**
-     * Convenience method to retrieve authentication data as a byte array.
+     * If this property is present, the {@link ByteBuffer} contains the data used for the extended authentication.
+     * The contents of this data are defined by the authentication method.
+     * <p>
+     * For an MQTT 3 client this {@link Optional} for the MQTT 5 property will always be empty.
      *
      * @return the authentication data as a an optional byte array.
      */
-    @Nullable Optional<byte[]> getAuthenticationDataAsByteArray();
+    @NotNull Optional<byte[]> getAuthenticationDataAsByteArray();
 
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -187,7 +187,7 @@ public interface ConnectPacket {
      * For an MQTT 3 client this property can be set in the {@link ConnectInboundInterceptor}.
      *
      * @return An {@link Optional} that contains the authentication data if as an array if present.
-    ≥     */
+     */
     @NotNull Optional<byte[]> getAuthenticationDataAsByteArray();
 
     /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -19,10 +19,10 @@ package com.hivemq.extension.sdk.api.packets.connect;
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.general.MqttVersion;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.services.publish.Publish;
-import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptor;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
@@ -181,6 +181,17 @@ public interface ConnectPacket {
     @NotNull Optional<ByteBuffer> getAuthenticationData();
 
     /**
+     * If this property is present it contains the {@link ByteBuffer}s data in array format.
+     * The contents of this data are defined by the authentication method.
+     * <p>
+     * For an MQTT 3 client this property can be set in the {@link ConnectInboundInterceptor}.
+     *
+     * @return An {@link Optional} that contains the authentication data if as an array if present.
+     * @since 4.3.0
+     */
+    @NotNull Optional<byte[]> getAuthenticationDataAsByteArray();
+
+    /**
      * The user properties from the CONNECT packet.
      * <p>
      * For an MQTT 3 client this property can be set in the {@link ConnectInboundInterceptor}.
@@ -205,4 +216,12 @@ public interface ConnectPacket {
      * @since 4.0.0
      */
     @NotNull Optional<ByteBuffer> getPassword();
+
+    /**
+     * Returns the password of the client, if it is present, as a byte array.
+     *
+     * @return An {@link Optional} that contains the password as a byte array if present.
+     * @since 4.3.0
+     */
+    @NotNull Optional<byte[]> getPasswordAsByteArray();
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -187,8 +187,7 @@ public interface ConnectPacket {
      * For an MQTT 3 client this property can be set in the {@link ConnectInboundInterceptor}.
      *
      * @return An {@link Optional} that contains the authentication data if as an array if present.
-     * @since 4.3.0
-     */
+    ≥     */
     @NotNull Optional<byte[]> getAuthenticationDataAsByteArray();
 
     /**
@@ -221,7 +220,6 @@ public interface ConnectPacket {
      * Returns the password of the client, if it is present, as a byte array.
      *
      * @return An {@link Optional} that contains the password as a byte array if present.
-     * @since 4.3.0
      */
     @NotNull Optional<byte[]> getPasswordAsByteArray();
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -181,7 +181,7 @@ public interface ConnectPacket {
     @NotNull Optional<ByteBuffer> getAuthenticationData();
 
     /**
-     * If this property is present it contains the {@link ByteBuffer}s data in array format.
+     * If this property is present it contains the byte arrays data.
      * The contents of this data are defined by the authentication method.
      * <p>
      * For an MQTT 3 client this property can be set in the {@link ConnectInboundInterceptor}.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiablePublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiablePublishPacket.java
@@ -104,6 +104,13 @@ public interface ModifiablePublishPacket extends PublishPacket {
     void setCorrelationData(@Nullable ByteBuffer correlationData);
 
     /**
+     * Sets the correlation data
+     *
+     * @param correlationData The new correlation data for the publish.
+     */
+    void setCorrelationData(byte[] correlationData);
+
+    /**
      * Sets the content type.
      *
      * @param contentType The new content type for the publish.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiablePublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiablePublishPacket.java
@@ -104,7 +104,7 @@ public interface ModifiablePublishPacket extends PublishPacket {
     void setCorrelationData(@Nullable ByteBuffer correlationData);
 
     /**
-     * Sets the correlation data
+     * Sets the correlation data.
      *
      * @param correlationData The new correlation data for the publish.
      */

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiablePublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiablePublishPacket.java
@@ -108,7 +108,7 @@ public interface ModifiablePublishPacket extends PublishPacket {
      *
      * @param correlationData The new correlation data for the publish.
      */
-    void setCorrelationData(byte[] correlationData);
+    void setCorrelationData(@Nullable byte[] correlationData);
 
     /**
      * Sets the content type.
@@ -128,6 +128,14 @@ public interface ModifiablePublishPacket extends PublishPacket {
      * @since 4.0.0
      */
     void setPayload(@NotNull ByteBuffer payload);
+
+    /**
+     * Sets the payload.
+     *
+     * @param payload The new payload for the publish as a byte array.
+     * @throws NullPointerException If payload is null.
+     */
+    void setPayload(@NotNull byte[] payload);
 
     /**
      * Get the modifiable {@link UserProperties} of the PUBLISH packet.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -124,8 +124,9 @@ public interface PublishPacket {
      * Convenience method to retrieve correlation data as a byte array.
      *
      * @return the correlation data as a byte array.
+     * @since 4.3.0
      */
-    Optional<byte[]> getCorrelationDataAsArray();
+    Optional<byte[]> getCorrelationDataAsByteArray();
 
     /**
      * The list of subscription identifiers for PUBLISH.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -19,7 +19,6 @@ package com.hivemq.extension.sdk.api.packets.publish;
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 
@@ -126,7 +125,7 @@ public interface PublishPacket {
      *
      * @return the correlation data as a byte array.
      */
-    @Nullable byte[] getCorrelationDataAsArray();
+    Optional<byte[]> getCorrelationDataAsArray();
 
     /**
      * The list of subscription identifiers for PUBLISH.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -121,12 +121,13 @@ public interface PublishPacket {
     @NotNull Optional<@Immutable ByteBuffer> getCorrelationData();
 
     /**
-     * Convenience method to retrieve correlation data as a byte array.
+     * If this property is present, this is the correlation data.
+     * <p>
+     * For an MQTT 3 PUBLISH this MQTT 5 property will always be empty.
      *
-     * @return the correlation data as a byte array.
-     * @since 4.3.0
+     * @return An {@link Optional} that contains the correlation data as an array if present.
      */
-    Optional<byte[]> getCorrelationDataAsByteArray();
+    @NotNull Optional<byte[]> getCorrelationDataAsByteArray();
 
     /**
      * The list of subscription identifiers for PUBLISH.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -19,6 +19,7 @@ package com.hivemq.extension.sdk.api.packets.publish;
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 
@@ -119,6 +120,13 @@ public interface PublishPacket {
      * @since 4.0.0
      */
     @NotNull Optional<@Immutable ByteBuffer> getCorrelationData();
+
+    /**
+     * Convenience method to retrieve correlation data as a byte array.
+     *
+     * @return the correlation data as a byte array.
+     */
+    @Nullable byte[] getCorrelationDataAsArray();
 
     /**
      * The list of subscription identifiers for PUBLISH.

--- a/src/main/java/com/hivemq/extensions/packets/connack/ConnackPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connack/ConnackPacketImpl.java
@@ -159,11 +159,11 @@ public class ConnackPacketImpl implements ConnackPacket {
 
     @Nullable
     @Override
-    public byte[] getAuthenticationDataAsArray() {
+    public Optional<byte[]> getAuthenticationDataAsByteArray() {
         if (authenticationData != null) {
-            return authenticationData.array();
+            return Optional.of(authenticationData.array());
         } else {
-            return null;
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/connack/ConnackPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connack/ConnackPacketImpl.java
@@ -157,9 +157,8 @@ public class ConnackPacketImpl implements ConnackPacket {
         return Optional.ofNullable(authenticationData);
     }
 
-    @Nullable
     @Override
-    public Optional<byte[]> getAuthenticationDataAsByteArray() {
+    public @NotNull Optional<byte[]> getAuthenticationDataAsByteArray() {
         if (authenticationData != null) {
             return Optional.of(authenticationData.array());
         } else {

--- a/src/main/java/com/hivemq/extensions/packets/connack/ConnackPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connack/ConnackPacketImpl.java
@@ -157,6 +157,16 @@ public class ConnackPacketImpl implements ConnackPacket {
         return Optional.ofNullable(authenticationData);
     }
 
+    @Nullable
+    @Override
+    public byte[] getAuthenticationDataAsArray() {
+        if (authenticationData != null) {
+            return authenticationData.array();
+        } else {
+            return null;
+        }
+    }
+
     @NotNull
     @Override
     public UserProperties getUserProperties() {

--- a/src/main/java/com/hivemq/extensions/packets/connect/ConnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/ConnectPacketImpl.java
@@ -117,8 +117,9 @@ public class ConnectPacketImpl implements ConnectPacket {
         return Optional.of(ByteBuffer.wrap(authData));
     }
 
+    @NotNull
     @Override
-    public @NotNull Optional<byte[]> getAuthenticationDataAsByteArray() {
+    public Optional<byte[]> getAuthenticationDataAsByteArray() {
         final byte[] authData = connect.getAuthData();
         if (authData == null) {
             return Optional.empty();

--- a/src/main/java/com/hivemq/extensions/packets/connect/ConnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/ConnectPacketImpl.java
@@ -117,6 +117,15 @@ public class ConnectPacketImpl implements ConnectPacket {
         return Optional.of(ByteBuffer.wrap(authData));
     }
 
+    @Override
+    public @NotNull Optional<byte[]> getAuthenticationDataAsByteArray() {
+        final byte[] authData = connect.getAuthData();
+        if (authData == null) {
+            return Optional.empty();
+        }
+        return Optional.of(authData);
+    }
+
     @NotNull
     @Override
     public UserProperties getUserProperties() {
@@ -137,5 +146,15 @@ public class ConnectPacketImpl implements ConnectPacket {
             return Optional.empty();
         }
         return Optional.of(ByteBuffer.wrap(password));
+    }
+
+    @NotNull
+    @Override
+    public Optional<byte[]> getPasswordAsByteArray() {
+        final byte[] password = connect.getPassword();
+        if (password == null) {
+            return Optional.empty();
+        }
+        return Optional.of(password);
     }
 }

--- a/src/main/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImpl.java
@@ -247,6 +247,7 @@ public class ModifiableConnectPacketImpl implements ModifiableConnectPacket {
         modified = true;
     }
 
+
     @Override
     public synchronized void setUserName(final @Nullable String userName) {
         if (Objects.equals(this.userName, userName)) {
@@ -352,6 +353,14 @@ public class ModifiableConnectPacketImpl implements ModifiableConnectPacket {
     }
 
     @Override
+    public @NotNull Optional<byte[]> getAuthenticationDataAsByteArray() {
+        if (authData == null) {
+            return Optional.empty();
+        }
+        return Optional.of(authData.array());
+    }
+
+    @Override
     public @NotNull ModifiableUserPropertiesImpl getUserProperties() {
         return userProperties;
     }
@@ -367,5 +376,13 @@ public class ModifiableConnectPacketImpl implements ModifiableConnectPacket {
             return Optional.empty();
         }
         return Optional.of(password.asReadOnlyBuffer());
+    }
+
+    @Override
+    public @NotNull Optional<byte[]> getPasswordAsByteArray() {
+        if (password == null) {
+            return Optional.empty();
+        }
+        return Optional.of(password.array());
     }
 }

--- a/src/main/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImpl.java
@@ -247,7 +247,6 @@ public class ModifiableConnectPacketImpl implements ModifiableConnectPacket {
         modified = true;
     }
 
-
     @Override
     public synchronized void setUserName(final @Nullable String userName) {
         if (Objects.equals(this.userName, userName)) {

--- a/src/main/java/com/hivemq/extensions/packets/connect/WillPublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/WillPublishPacketImpl.java
@@ -26,6 +26,7 @@ import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -185,6 +186,14 @@ public class WillPublishPacketImpl implements WillPublishPacket {
             return Optional.empty();
         }
         return Optional.of(correlationData.asReadOnlyBuffer());
+    }
+
+    @Override
+    public @Nullable byte[] getCorrelationDataAsArray() {
+        if (correlationData == null) {
+            return null;
+        }
+        return Arrays.copyOf(correlationData.array(), correlationData.array().length);
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/packets/connect/WillPublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/WillPublishPacketImpl.java
@@ -26,7 +26,6 @@ import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -189,11 +188,11 @@ public class WillPublishPacketImpl implements WillPublishPacket {
     }
 
     @Override
-    public @Nullable byte[] getCorrelationDataAsArray() {
+    public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
         if (correlationData == null) {
-            return null;
+            return Optional.empty();
         }
-        return Arrays.copyOf(correlationData.array(), correlationData.array().length);
+        return Optional.of(correlationData.array());
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
@@ -264,7 +264,7 @@ public class ModifiableOutboundPublishImpl implements ModifiableOutboundPublish 
             return Optional.empty();
         } else {
             final byte[] bytesArray = new byte[correlationData.remaining()];
-            correlationData.get(bytesArray, 0, bytesArray.length);
+            correlationData.asReadOnlyBuffer().clear().get(bytesArray);
             return Optional.of(bytesArray);
         }
     }

--- a/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
@@ -260,7 +260,7 @@ public class ModifiableOutboundPublishImpl implements ModifiableOutboundPublish 
 
     @Override
     public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
-        if (correlationData == null) {
+        if (publish.getCorrelationData() == null) {
             return Optional.empty();
         } else {
             return Optional.of(publish.getCorrelationData());

--- a/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
@@ -260,10 +260,12 @@ public class ModifiableOutboundPublishImpl implements ModifiableOutboundPublish 
 
     @Override
     public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
-        if (publish.getCorrelationData() == null) {
+        if (correlationData == null) {
             return Optional.empty();
         } else {
-            return Optional.of(publish.getCorrelationData());
+            final byte[] bytesArray = new byte[correlationData.remaining()];
+            correlationData.get(bytesArray, 0, bytesArray.length);
+            return Optional.of(bytesArray);
         }
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
@@ -33,6 +33,7 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.util.Topics;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -256,6 +257,15 @@ public class ModifiableOutboundPublishImpl implements ModifiableOutboundPublish 
     @Override
     public @NotNull Optional<ByteBuffer> getCorrelationData() {
         return Optional.ofNullable(correlationData);
+    }
+
+    @Override
+    public @Nullable byte[] getCorrelationDataAsArray() {
+        if (correlationData != null) {
+            return Arrays.copyOf(correlationData.array(), correlationData.array().length);
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImpl.java
@@ -33,7 +33,6 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.util.Topics;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -260,11 +259,11 @@ public class ModifiableOutboundPublishImpl implements ModifiableOutboundPublish 
     }
 
     @Override
-    public @Nullable byte[] getCorrelationDataAsArray() {
-        if (correlationData != null) {
-            return Arrays.copyOf(correlationData.array(), correlationData.array().length);
+    public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
+        if (correlationData == null) {
+            return Optional.empty();
         } else {
-            return null;
+            return Optional.of(publish.getCorrelationData());
         }
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/publish/ModifiablePublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/ModifiablePublishPacketImpl.java
@@ -323,11 +323,11 @@ public class ModifiablePublishPacketImpl implements ModifiablePublishPacket {
     }
 
     @Override
-    public @Nullable byte[] getCorrelationDataAsArray() {
-        if (correlationDataBytes == null) {
-            return null;
+    public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
+        if (correlationData == null) {
+            return Optional.empty();
         } else {
-            return Arrays.copyOf(correlationDataBytes, correlationDataBytes.length);
+            return Optional.of(correlationDataBytes);
         }
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/publish/PublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/PublishPacketImpl.java
@@ -17,7 +17,6 @@
 package com.hivemq.extensions.packets.publish;
 
 import com.hivemq.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
@@ -100,12 +99,13 @@ public class PublishPacketImpl implements PublishPacket {
     }
 
     @Override
-    public @Nullable byte[] getCorrelationDataAsArray() {
-        @Nullable final byte[] correlationData = publish.getCorrelationData();
+    public Optional<byte[]> getCorrelationDataAsArray() {
+        final byte[] correlationData = publish.getCorrelationData();
         if (correlationData == null) {
-            return null;
+            return Optional.empty();
         } else {
-            return Arrays.copyOf(correlationData, correlationData.length);
+            final byte[] bytes = Arrays.copyOf(correlationData, correlationData.length);
+            return Optional.of(bytes);
         }
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/publish/PublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/PublishPacketImpl.java
@@ -17,6 +17,7 @@
 package com.hivemq.extensions.packets.publish;
 
 import com.hivemq.annotations.NotNull;
+import com.hivemq.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
@@ -24,7 +25,6 @@ import com.hivemq.extension.sdk.api.packets.publish.PublishPacket;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -99,13 +99,12 @@ public class PublishPacketImpl implements PublishPacket {
     }
 
     @Override
-    public Optional<byte[]> getCorrelationDataAsArray() {
-        final byte[] correlationData = publish.getCorrelationData();
+    public Optional<byte[]> getCorrelationDataAsByteArray() {
+        @Nullable final byte[] correlationData = publish.getCorrelationData();
         if (correlationData == null) {
             return Optional.empty();
         } else {
-            final byte[] bytes = Arrays.copyOf(correlationData, correlationData.length);
-            return Optional.of(bytes);
+            return Optional.of(correlationData);
         }
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/publish/PublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/PublishPacketImpl.java
@@ -17,6 +17,7 @@
 package com.hivemq.extensions.packets.publish;
 
 import com.hivemq.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
@@ -24,6 +25,7 @@ import com.hivemq.extension.sdk.api.packets.publish.PublishPacket;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -95,6 +97,16 @@ public class PublishPacketImpl implements PublishPacket {
             return Optional.empty();
         }
         return Optional.of(ByteBuffer.wrap(correlationData).asReadOnlyBuffer());
+    }
+
+    @Override
+    public @Nullable byte[] getCorrelationDataAsArray() {
+        @Nullable final byte[] correlationData = publish.getCorrelationData();
+        if (correlationData == null) {
+            return null;
+        } else {
+            return Arrays.copyOf(correlationData, correlationData.length);
+        }
     }
 
     @Override

--- a/src/main/java/com/hivemq/extensions/packets/publish/PublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/PublishPacketImpl.java
@@ -17,7 +17,6 @@
 package com.hivemq.extensions.packets.publish;
 
 import com.hivemq.annotations.NotNull;
-import com.hivemq.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
@@ -99,12 +98,11 @@ public class PublishPacketImpl implements PublishPacket {
     }
 
     @Override
-    public Optional<byte[]> getCorrelationDataAsByteArray() {
-        @Nullable final byte[] correlationData = publish.getCorrelationData();
-        if (correlationData == null) {
+    public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
+        if (publish.getCorrelationData() == null) {
             return Optional.empty();
         } else {
-            return Optional.of(correlationData);
+            return Optional.of(publish.getCorrelationData());
         }
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/publish/WillPublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/WillPublishPacketImpl.java
@@ -17,6 +17,7 @@
 package com.hivemq.extensions.packets.publish;
 
 import com.hivemq.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
@@ -25,6 +26,7 @@ import com.hivemq.mqtt.message.connect.MqttWillPublish;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -96,6 +98,15 @@ public class WillPublishPacketImpl implements PublishPacket {
             return Optional.empty();
         }
         return Optional.of(ByteBuffer.wrap(correlationData).asReadOnlyBuffer());
+    }
+
+    @Override
+    public @Nullable byte[] getCorrelationDataAsArray() {
+        final byte[] correlationData = publish.getCorrelationData();
+        if (correlationData == null) {
+            return null;
+        }
+        return Arrays.copyOf(correlationData, correlationData.length);
     }
 
     @Override

--- a/src/main/java/com/hivemq/extensions/packets/publish/WillPublishPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/publish/WillPublishPacketImpl.java
@@ -17,7 +17,6 @@
 package com.hivemq.extensions.packets.publish;
 
 import com.hivemq.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
@@ -26,7 +25,6 @@ import com.hivemq.mqtt.message.connect.MqttWillPublish;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -101,12 +99,12 @@ public class WillPublishPacketImpl implements PublishPacket {
     }
 
     @Override
-    public @Nullable byte[] getCorrelationDataAsArray() {
+    public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
         final byte[] correlationData = publish.getCorrelationData();
         if (correlationData == null) {
-            return null;
+            return Optional.empty();
         }
-        return Arrays.copyOf(correlationData, correlationData.length);
+        return Optional.of(correlationData);
     }
 
     @Override

--- a/src/test/java/com/hivemq/extensions/packets/connack/ModifiableConnackPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/connack/ModifiableConnackPacketImplTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import util.TestConfigurationBootstrap;
 import util.TestMessageUtil;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.Assert.*;
 
 /**
@@ -38,12 +40,15 @@ public class ModifiableConnackPacketImplTest {
     private ModifiableConnackPacketImpl modifiableConnackPacket;
     private FullConfigurationService fullConfigurationService;
     private CONNACK fullMqtt5Connack;
+    private CONNACK empty;
 
     @Before
     public void setUp() throws Exception {
         fullConfigurationService = new TestConfigurationBootstrap().getFullConfigurationService();
         fullMqtt5Connack = TestMessageUtil.createFullMqtt5Connack();
         modifiableConnackPacket = new ModifiableConnackPacketImpl(fullConfigurationService, fullMqtt5Connack, true);
+        empty = TestMessageUtil.createConnackWithoutAuthData();
+
     }
 
     @Test(expected = IllegalStateException.class)
@@ -151,6 +156,12 @@ public class ModifiableConnackPacketImplTest {
     public void test_add_user_prop() {
         modifiableConnackPacket.getUserProperties().addUserProperty("user", "prop");
         assertTrue(modifiableConnackPacket.isModified());
+    }
+
+    @Test
+    public void test_passwordArray() {
+        assertArrayEquals("auth data".getBytes(StandardCharsets.UTF_8), fullMqtt5Connack.getAuthData());
+        assertNull(empty.getAuthData());
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/packets/publish/ModifiablePublishPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/publish/ModifiablePublishPacketImplTest.java
@@ -377,7 +377,7 @@ public class ModifiablePublishPacketImplTest {
     @Test
     public void test_change_CorrelationData_null() {
 
-        modifiablePublishPacket.setCorrelationData(null);
+        modifiablePublishPacket.setCorrelationData((ByteBuffer) null);
 
         final PUBLISH mergePublishPacket = PUBLISHFactory.mergePublishPacket(modifiablePublishPacket, origin);
 
@@ -394,7 +394,7 @@ public class ModifiablePublishPacketImplTest {
 
         modifiablePublishPacket = new ModifiablePublishPacketImpl(configurationService, TestMessageUtil.createMqtt5Publish());
 
-        modifiablePublishPacket.setCorrelationData(null);
+        modifiablePublishPacket.setCorrelationData((ByteBuffer) null);
 
         final PUBLISH mergePublishPacket = PUBLISHFactory.mergePublishPacket(modifiablePublishPacket, origin);
 

--- a/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
@@ -18,6 +18,7 @@ package com.hivemq.extensions.services.builder;
 
 import com.hivemq.annotations.NotNull;
 import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
@@ -39,6 +40,7 @@ import util.TestConfigurationBootstrap;
 import util.TestMessageUtil;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -346,6 +348,12 @@ public class RetainedPublishBuilderImplTest {
         @Override
         public Optional<ByteBuffer> getCorrelationData() {
             return Optional.of(ByteBuffer.wrap("correlation_data".getBytes()));
+        }
+
+        @Override
+        public @Nullable byte[] getCorrelationDataAsArray() {
+            final byte[] correlationBytes = "correlation_data".getBytes();
+            return Arrays.copyOf(correlationBytes, correlationBytes.length);
         }
 
         @Override

--- a/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
@@ -18,7 +18,6 @@ package com.hivemq.extensions.services.builder;
 
 import com.hivemq.annotations.NotNull;
 import com.hivemq.configuration.service.FullConfigurationService;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
@@ -40,7 +39,6 @@ import util.TestConfigurationBootstrap;
 import util.TestMessageUtil;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -351,9 +349,9 @@ public class RetainedPublishBuilderImplTest {
         }
 
         @Override
-        public @Nullable byte[] getCorrelationDataAsArray() {
+        public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
             final byte[] correlationBytes = "correlation_data".getBytes();
-            return Arrays.copyOf(correlationBytes, correlationBytes.length);
+            return Optional.of(correlationBytes);
         }
 
         @Override

--- a/src/test/java/com/hivemq/extensions/services/builder/WillPublishBuilderImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/builder/WillPublishBuilderImplTest.java
@@ -18,6 +18,7 @@ package com.hivemq.extensions.services.builder;
 
 import com.hivemq.annotations.NotNull;
 import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.connect.WillPublishPacket;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
@@ -38,6 +39,7 @@ import util.TestConfigurationBootstrap;
 import util.TestMessageUtil;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -387,6 +389,12 @@ public class WillPublishBuilderImplTest {
         }
 
         @Override
+        public @Nullable byte[] getCorrelationDataAsArray() {
+            final byte[] correlationBytes = "correlation_data".getBytes();
+            return Arrays.copyOf(correlationBytes, correlationBytes.length);
+        }
+
+        @Override
         public List<Integer> getSubscriptionIdentifiers() {
             return null;
         }
@@ -463,6 +471,11 @@ public class WillPublishBuilderImplTest {
         @Override
         public Optional<ByteBuffer> getCorrelationData() {
             return Optional.empty();
+        }
+
+        @Override
+        public @Nullable byte[] getCorrelationDataAsArray() {
+            return null;
         }
 
         @Override

--- a/src/test/java/com/hivemq/extensions/services/builder/WillPublishBuilderImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/builder/WillPublishBuilderImplTest.java
@@ -18,7 +18,6 @@ package com.hivemq.extensions.services.builder;
 
 import com.hivemq.annotations.NotNull;
 import com.hivemq.configuration.service.FullConfigurationService;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.connect.WillPublishPacket;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
@@ -39,7 +38,6 @@ import util.TestConfigurationBootstrap;
 import util.TestMessageUtil;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -389,9 +387,9 @@ public class WillPublishBuilderImplTest {
         }
 
         @Override
-        public @Nullable byte[] getCorrelationDataAsArray() {
+        public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
             final byte[] correlationBytes = "correlation_data".getBytes();
-            return Arrays.copyOf(correlationBytes, correlationBytes.length);
+            return Optional.of(correlationBytes);
         }
 
         @Override
@@ -474,7 +472,7 @@ public class WillPublishBuilderImplTest {
         }
 
         @Override
-        public @Nullable byte[] getCorrelationDataAsArray() {
+        public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
             return null;
         }
 

--- a/src/test/java/com/hivemq/extensions/services/builder/WillPublishBuilderImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/builder/WillPublishBuilderImplTest.java
@@ -473,7 +473,8 @@ public class WillPublishBuilderImplTest {
 
         @Override
         public @NotNull Optional<byte[]> getCorrelationDataAsByteArray() {
-            return null;
+            final byte[] correlationBytes = "correlation_data".getBytes();
+            return Optional.of(correlationBytes);
         }
 
         @Override

--- a/src/test/java/util/TestMessageUtil.java
+++ b/src/test/java/util/TestMessageUtil.java
@@ -297,6 +297,30 @@ public class TestMessageUtil {
                 .build();
     }
 
+    public static CONNACK createConnackWithoutAuthData() {
+        return new CONNACK.Mqtt5Builder()
+                .withReasonCode(Mqtt5ConnAckReasonCode.SUCCESS)
+                .withReasonString("success")
+                .withUserProperties(TEST_USER_PROPERTIES)
+                .withSessionPresent(true)
+                .withSessionExpiryInterval(720)
+                .withServerKeepAlive(120)
+                .withAssignedClientIdentifier("assigned")
+                .withAuthMethod("auth method")
+                .withAuthData(null)
+                .withReceiveMaximum(100)
+                .withTopicAliasMaximum(5)
+                .withMaximumPacketSize(100)
+                .withMaximumQoS(QoS.AT_LEAST_ONCE)
+                .withRetainAvailable(true)
+                .withWildcardSubscriptionAvailable(true)
+                .withSubscriptionIdentifierAvailable(true)
+                .withSharedSubscriptionAvailable(true)
+                .withResponseInformation("response")
+                .withServerReference("server")
+                .build();
+    }
+
     public static SUBSCRIBE createFullMqtt5Subscribe() {
         final ImmutableList.Builder<Topic> topicBuilder = new ImmutableList.Builder<>();
         topicBuilder.add(new Topic(topics.get(0), QoS.AT_MOST_ONCE, true, true, Mqtt5RetainHandling.DO_NOT_SEND, 1));


### PR DESCRIPTION
**Motivation**

Make it possible to retrieve certain information from packets as byte arrays in addition to the already existing ByteBufffer methods.

Resolves <https://github.com/hivemq/hivemq-community-edition/issues/64>

**Changes**
Added byte array methods to:

- authenticationData in the ConnackPacket
- correlationData in the PublishPacket