### PR TITLE
Feature/add lwt metrics

### DIFF
--- a/src/main/java/com/hivemq/metrics/HiveMQMetrics.java
+++ b/src/main/java/com/hivemq/metrics/HiveMQMetrics.java
@@ -134,7 +134,7 @@ public class HiveMQMetrics {
      * represents a {@link Counter}, which measures the count of last will testaments.
      */
     public static final HiveMQMetric<Counter> LWT_CURRENT =
-            HiveMQMetric.valueOf("com.hivemq.last-will-testaments.overall.current", Counter.class);
+            HiveMQMetric.valueOf("com.hivemq.will.count", Counter.class);
 
     /**
      * represents a {@link Counter}, which measures the count of last will testaments spread to clients.

--- a/src/main/java/com/hivemq/metrics/HiveMQMetrics.java
+++ b/src/main/java/com/hivemq/metrics/HiveMQMetrics.java
@@ -82,7 +82,6 @@ public class HiveMQMetrics {
     public static final HiveMQMetric<Gauge<Number>> RETAINED_MESSAGES_CURRENT =
             HiveMQMetric.gaugeValue("com.hivemq.messages.retained.current");
 
-
     /**
      * represents a {@link Gauge}, which holds the total amount of read bytes
      *
@@ -91,7 +90,6 @@ public class HiveMQMetrics {
     public static final HiveMQMetric<Gauge<Number>> BYTES_READ_TOTAL =
             HiveMQMetric.gaugeValue("com.hivemq.networking.bytes.read.total");
 
-
     /**
      * represents a {@link Gauge}, which holds total of written bytes
      *
@@ -99,7 +97,6 @@ public class HiveMQMetrics {
      */
     public static final HiveMQMetric<Gauge<Number>> BYTES_WRITE_TOTAL =
             HiveMQMetric.gaugeValue("com.hivemq.networking.bytes.write.total");
-
 
     /**
      * represents a {@link Gauge}, which holds the current total number of connections
@@ -117,7 +114,6 @@ public class HiveMQMetrics {
     public static final HiveMQMetric<Counter> CONNECTIONS_CLOSED_COUNT =
             HiveMQMetric.valueOf("com.hivemq.networking.connections-closed.total.count", Counter.class);
 
-
     /**
      * represents a {@link Counter}, which measures the current count of subscriptions
      *
@@ -133,5 +129,11 @@ public class HiveMQMetrics {
      */
     public static final HiveMQMetric<Gauge<Number>> CLIENT_SESSIONS_CURRENT =
             HiveMQMetric.gaugeValue("com.hivemq.sessions.overall.current");
+
+    /**
+     * represents a {@link Counter}, which measures the current count of last will testaments.
+     */
+    public static final HiveMQMetric<Counter> LWT_CURRENT =
+            HiveMQMetric.valueOf("com.hivemq.last-will-testaments.overall.current", Counter.class);
 }
 

--- a/src/main/java/com/hivemq/metrics/HiveMQMetrics.java
+++ b/src/main/java/com/hivemq/metrics/HiveMQMetrics.java
@@ -140,6 +140,6 @@ public class HiveMQMetrics {
      * represents a {@link Counter}, which measures the count of last will testaments spread to clients.
      */
     public static final HiveMQMetric<Counter> LWT_SENT =
-            HiveMQMetric.valueOf("com.hivemq.last-will-testaments.sent", Counter.class);
+            HiveMQMetric.valueOf("com.hivemq.will.sent.count", Counter.class);
 }
 

--- a/src/main/java/com/hivemq/metrics/HiveMQMetrics.java
+++ b/src/main/java/com/hivemq/metrics/HiveMQMetrics.java
@@ -131,9 +131,15 @@ public class HiveMQMetrics {
             HiveMQMetric.gaugeValue("com.hivemq.sessions.overall.current");
 
     /**
-     * represents a {@link Counter}, which measures the current count of last will testaments.
+     * represents a {@link Counter}, which measures the count of last will testaments.
      */
     public static final HiveMQMetric<Counter> LWT_CURRENT =
             HiveMQMetric.valueOf("com.hivemq.last-will-testaments.overall.current", Counter.class);
+
+    /**
+     * represents a {@link Counter}, which measures the count of last will testaments spread to clients.
+     */
+    public static final HiveMQMetric<Counter> LWT_SENT =
+            HiveMQMetric.valueOf("com.hivemq.last-will-testaments.sent", Counter.class);
 }
 

--- a/src/main/java/com/hivemq/metrics/MetricsHolder.java
+++ b/src/main/java/com/hivemq/metrics/MetricsHolder.java
@@ -43,8 +43,9 @@ public class MetricsHolder {
     private final @NotNull Counter droppedMessageCounter;
 
     private final @NotNull Counter subscriptionCounter;
-
     private final @NotNull Counter closedConnectionsCounter;
+
+    private final @NotNull Counter lastWillTestamentCounter;
 
     public MetricsHolder(final MetricRegistry metricRegistry) {
 
@@ -63,6 +64,8 @@ public class MetricsHolder {
         closedConnectionsCounter = metricRegistry.counter(CONNECTIONS_CLOSED_COUNT.name());
 
         subscriptionCounter = metricRegistry.counter(SUBSCRIPTIONS_CURRENT.name());
+
+        lastWillTestamentCounter = metricRegistry.counter(LWT_CURRENT.name());
     }
 
     public @NotNull MetricRegistry getMetricRegistry() {
@@ -99,5 +102,9 @@ public class MetricsHolder {
 
     public @NotNull Counter getClosedConnectionsCounter() {
         return closedConnectionsCounter;
+    }
+
+    public @NotNull Counter getLastWillTestamentCounter() {
+        return lastWillTestamentCounter;
     }
 }

--- a/src/main/java/com/hivemq/metrics/MetricsHolder.java
+++ b/src/main/java/com/hivemq/metrics/MetricsHolder.java
@@ -46,6 +46,7 @@ public class MetricsHolder {
     private final @NotNull Counter closedConnectionsCounter;
 
     private final @NotNull Counter lastWillTestamentCounter;
+    private final @NotNull Counter lastWillTestamentSentCounter;
 
     public MetricsHolder(final MetricRegistry metricRegistry) {
 
@@ -66,6 +67,8 @@ public class MetricsHolder {
         subscriptionCounter = metricRegistry.counter(SUBSCRIPTIONS_CURRENT.name());
 
         lastWillTestamentCounter = metricRegistry.counter(LWT_CURRENT.name());
+
+        lastWillTestamentSentCounter = metricRegistry.counter(LWT_SENT.name());
     }
 
     public @NotNull MetricRegistry getMetricRegistry() {
@@ -106,5 +109,9 @@ public class MetricsHolder {
 
     public @NotNull Counter getLastWillTestamentCounter() {
         return lastWillTestamentCounter;
+    }
+
+    public Counter getLastWillTestamentSentCounter() {
+        return lastWillTestamentSentCounter;
     }
 }

--- a/src/main/java/com/hivemq/metrics/handler/GlobalMQTTMessageCounter.java
+++ b/src/main/java/com/hivemq/metrics/handler/GlobalMQTTMessageCounter.java
@@ -55,6 +55,10 @@ public class GlobalMQTTMessageCounter extends ChannelDuplexHandler {
 
             if (msg instanceof CONNECT) {
                 metricsHolder.getIncomingConnectCounter().inc();
+
+                if (((CONNECT) msg).getWillPublish() != null) {
+                    metricsHolder.getLastWillTestamentCounter().inc();
+                }
             }
 
             if (msg instanceof PUBLISH) {

--- a/src/main/java/com/hivemq/mqtt/handler/disconnect/DisconnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/disconnect/DisconnectHandler.java
@@ -83,6 +83,7 @@ public class DisconnectHandler extends SimpleChannelInboundHandler<DISCONNECT> {
         log.trace("The client [{}] sent a disconnect message. ", clientId);
         if (msg.getReasonCode() == DISCONNECT_WITH_WILL_MESSAGE) {
             ctx.channel().attr(SEND_WILL).set(true);
+            metricsHolder.getLastWillTestamentCounter().dec();
         } else {
             ctx.channel().attr(SEND_WILL).set(false);
         }

--- a/src/main/java/com/hivemq/mqtt/handler/disconnect/DisconnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/disconnect/DisconnectHandler.java
@@ -83,7 +83,6 @@ public class DisconnectHandler extends SimpleChannelInboundHandler<DISCONNECT> {
         log.trace("The client [{}] sent a disconnect message. ", clientId);
         if (msg.getReasonCode() == DISCONNECT_WITH_WILL_MESSAGE) {
             ctx.channel().attr(SEND_WILL).set(true);
-            metricsHolder.getLastWillTestamentCounter().dec();
         } else {
             ctx.channel().attr(SEND_WILL).set(false);
         }

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -88,7 +88,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.hivemq.extension.sdk.api.auth.parameter.OverloadProtectionThrottlingLevel.*;
+import static com.hivemq.extension.sdk.api.auth.parameter.OverloadProtectionThrottlingLevel.NONE;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -1314,7 +1314,9 @@ public class ConnectHandlerTest {
         when(clientSessionSubscriptionPersistence.getSubscriptions(anyString())).thenReturn(ImmutableSet.of(new Topic("t1", QoS.AT_LEAST_ONCE), new Topic("t2", QoS.AT_MOST_ONCE)));
 
         embeddedChannel.pipeline().addAfter(ChannelHandlerNames.MQTT_CONNECT_HANDLER, ChannelHandlerNames.MQTT_CONNECT_PERSISTENCE_HANDLER,
-                new ConnectPersistenceUpdateHandler(clientSessionPersistence, clientSessionSubscriptionPersistence, mock(MessageIDPools.class), channelPersistence, singleWriterService));
+                new ConnectPersistenceUpdateHandler(
+                        clientSessionPersistence, clientSessionSubscriptionPersistence, mock(MessageIDPools.class),
+                        channelPersistence, singleWriterService, metricsHolder));
 
         ctx = embeddedChannel.pipeline().context(ConnectHandler.class);
 

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectPersistenceUpdateHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectPersistenceUpdateHandlerTest.java
@@ -16,8 +16,10 @@
 
 package com.hivemq.mqtt.handler.connect;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
+import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.mqtt.message.MessageIDPools;
 import com.hivemq.mqtt.message.ProtocolVersion;
 import com.hivemq.mqtt.message.connect.CONNECT;
@@ -84,6 +86,7 @@ public class ConnectPersistenceUpdateHandlerTest {
     @Mock
     ClientSessionSubscriptionPersistence clientSessionSubscriptionPersistence;
 
+    MetricsHolder metricsHolder;
     ConnectPersistenceUpdateHandler persistenceUpdateHandler;
     SingleWriterService singleWriterService = TestSingleWriterFactory.defaultSingleWriter();
 
@@ -99,10 +102,11 @@ public class ConnectPersistenceUpdateHandlerTest {
         when(channel.attr(eq(ChannelAttributes.TAKEN_OVER))).thenReturn(new TestChannelAttribute<Boolean>(false));
         when(channel.attr(eq(ChannelAttributes.AUTHENTICATED_OR_AUTHENTICATION_BYPASSED))).thenReturn(new TestChannelAttribute<Boolean>(true));
 
+        metricsHolder = new MetricsHolder(new MetricRegistry());
         when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyInt(), any(MqttWillPublish.class))).thenReturn(Futures.immediateFuture(null));
         when(ctx.channel()).thenReturn(channel);
         persistenceUpdateHandler = new ConnectPersistenceUpdateHandler(clientSessionPersistence, clientSessionSubscriptionPersistence,
-                messageIDPools, channelPersistence, singleWriterService);
+                messageIDPools, channelPersistence, singleWriterService, metricsHolder);
     }
 
     @Test


### PR DESCRIPTION
**Motivation**

HiveMQ has no metrics for tracking last will testaments.

Resolves <https://github.com/hivemq/hivemq-community-edition/issues/66>

**Changes**

Added
- Metric for clients connecting with a last will testament
- Metric for last will testaments sent out on client disconnect