### PR TITLE
trigger disconnect event on session takeover

### DIFF
--- a/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
@@ -720,7 +720,9 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
                         msg.getClientIdentifier());
 
                 oldClient.attr(ChannelAttributes.TAKEN_OVER).set(true);
-                eventLog.clientWasDisconnected(oldClient, "Another client connected with the same client id");
+                final String reason = "Another client connected with the same client id";
+                eventLog.clientWasDisconnected(oldClient, reason);
+                oldClient.pipeline().fireUserEventTriggered(new OnServerDisconnectEvent(DisconnectedReasonCode.SESSION_TAKEN_OVER, reason, msg.getUserProperties()));
                 if (disconnectFuture != null) {
                     // The disconnect future is not set in case the client is not fully connected yet
                     oldClient.close();

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -607,7 +607,7 @@ public class ConnectHandlerTest {
     }
 
     @Test
-    public void test_client_takeover() {
+    public void test_client_takeover() throws InterruptedException {
 
         final EmbeddedChannel oldChannel = new EmbeddedChannel(new DummyHandler());
 
@@ -620,15 +620,19 @@ public class ConnectHandlerTest {
                 .withClientIdentifier("sameClientId")
                 .build();
 
+        final CountDownLatch eventLatch = new CountDownLatch(1);
+        oldChannel.pipeline().addLast(new TestDisconnectEventHandler(eventLatch));
+
         embeddedChannel.writeInbound(connect1);
 
         assertTrue(embeddedChannel.isOpen());
         assertFalse(oldChannel.isOpen());
         assertTrue(oldChannel.attr(ChannelAttributes.TAKEN_OVER).get());
+        assertTrue(eventLatch.await(5, TimeUnit.SECONDS));
     }
 
     @Test
-    public void test_client_takeover_retry() {
+    public void test_client_takeover_retry() throws InterruptedException {
 
         final SettableFuture<Void> disconnectFuture = SettableFuture.create();
         final EmbeddedChannel oldChannel = new EmbeddedChannel(new DummyHandler());
@@ -644,6 +648,9 @@ public class ConnectHandlerTest {
                 .withClientIdentifier("sameClientId")
                 .build();
 
+        final CountDownLatch eventLatch = new CountDownLatch(1);
+        oldChannel.pipeline().addLast(new TestDisconnectEventHandler(eventLatch));
+
         embeddedChannel.writeInbound(connect1);
 
         assertTrue(oldChannel.isOpen());
@@ -657,6 +664,7 @@ public class ConnectHandlerTest {
         assertTrue(embeddedChannel.isOpen());
         assertFalse(oldChannel.isOpen());
         assertTrue(oldChannel.attr(ChannelAttributes.TAKEN_OVER).get());
+        assertTrue(eventLatch.await(5, TimeUnit.SECONDS));
     }
 
     @Test


### PR DESCRIPTION
**Motivation**

We are using the extension API for logging connects/disconnects. We are especially interested when a session is taken over via the same client id as this should never happen in our setup (indicates a security breach). It seems that no event is generated currently.

**Changes**

Triggers a disconnect event with code `SESSION_TAKEN_OVER` when a session takeover is detected.