### PR TITLE
An MQTT DISCONNECT packet is now sent to the client that  is taken over

### DIFF
--- a/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
@@ -382,7 +382,7 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
                             " characters. This is not allowed.";
             final String eventlogMessage = "Sent CONNECT with Client identifier too long";
             final OnServerDisconnectEvent event = new OnServerDisconnectEvent(DisconnectedReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
-                    ReasonStrings.CONNACK_CLIENT_IDENTIFIER_TOO_LONG, msg.getUserProperties());
+                    ReasonStrings.CONNACK_CLIENT_IDENTIFIER_TOO_LONG, Mqtt5UserProperties.NO_USER_PROPERTIES);
             mqttConnacker.connackError(ctx.channel(), logMessage, eventlogMessage,
                     Mqtt5ConnAckReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
                     Mqtt3ConnAckReturnCode.REFUSED_IDENTIFIER_REJECTED,
@@ -395,7 +395,8 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
     private boolean checkWillPublish(final @NotNull ChannelHandlerContext ctx, final @NotNull CONNECT msg) {
         if (msg.getWillPublish() != null) {
             if (Topics.containsWildcard(msg.getWillPublish().getTopic())) {
-                final OnServerDisconnectEvent event = new OnServerDisconnectEvent(DisconnectedReasonCode.TOPIC_NAME_INVALID, ReasonStrings.CONNACK_NOT_AUTHORIZED_WILL_WILDCARD, msg.getUserProperties());
+                final OnServerDisconnectEvent event = new OnServerDisconnectEvent(DisconnectedReasonCode.TOPIC_NAME_INVALID,
+                        ReasonStrings.CONNACK_NOT_AUTHORIZED_WILL_WILDCARD, Mqtt5UserProperties.NO_USER_PROPERTIES);
                 mqttConnacker.connackError(ctx.channel(),
                         "A client (IP: {}) sent a CONNECT with a wildcard character in the Will Topic (# or +). This is not allowed.",
                         "Sent CONNECT with wildcard character in the Will Topic (#/+)",
@@ -409,7 +410,8 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
             final int maxQos = configurationService.mqttConfiguration().maximumQos().getQosNumber();
             if (willQos > maxQos) {
                 final String reasonString = String.format(ReasonStrings.CONNACK_QOS_NOT_SUPPORTED_WILL, willQos, maxQos);
-                final OnServerDisconnectEvent event = new OnServerDisconnectEvent(DisconnectedReasonCode.QOS_NOT_SUPPORTED, reasonString, msg.getUserProperties());
+                final OnServerDisconnectEvent event = new OnServerDisconnectEvent(DisconnectedReasonCode.QOS_NOT_SUPPORTED, reasonString,
+                        Mqtt5UserProperties.NO_USER_PROPERTIES);
                 mqttConnacker.connackError(ctx.channel(),
                         "A client (IP: {}) sent a CONNECT with a Will QoS higher than the maximum configured QoS. This is not allowed.",
                         "Sent CONNECT with Will QoS (" + willQos + ") higher than the allowed maximum (" + maxQos + ")",
@@ -424,7 +426,8 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
     private boolean checkWillRetained(final @NotNull ChannelHandlerContext ctx, final @NotNull CONNECT msg) {
         if (msg.getWillPublish() != null && msg.getWillPublish().isRetain() &&
                 !configurationService.mqttConfiguration().retainedMessagesEnabled()) {
-            final OnServerDisconnectEvent event = new OnServerDisconnectEvent(DisconnectedReasonCode.RETAIN_NOT_SUPPORTED, ReasonStrings.CONNACK_RETAIN_NOT_SUPPORTED, msg.getUserProperties());
+            final OnServerDisconnectEvent event = new OnServerDisconnectEvent(DisconnectedReasonCode.RETAIN_NOT_SUPPORTED,
+                    ReasonStrings.CONNACK_RETAIN_NOT_SUPPORTED, Mqtt5UserProperties.NO_USER_PROPERTIES);
             mqttConnacker.connackError(ctx.channel(),
                     "A client (IP: {}) sent a CONNECT with Will Retain set to 1 although retain is not available.",
                     "Sent a CONNECT with Will Retain set to 1 although retain is not available",

--- a/src/main/java/com/hivemq/util/ReasonStrings.java
+++ b/src/main/java/com/hivemq/util/ReasonStrings.java
@@ -125,6 +125,8 @@ public class ReasonStrings {
 
     public static final String DISCONNECT_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED = "Disconnecting client. SUBSCRIBE containing subscription identifiers was sent. The broker does not allow this.";
 
+    public static final String DISCONNECT_SESSION_TAKEN_OVER = "Another client connected with the same client id.";
+
     public static final String SUBACK_EXTENSION_PREVENTED = "SUBSCRIBE prevented by an extension.";
 
     private ReasonStrings() {

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -29,6 +29,7 @@ import com.hivemq.extension.sdk.api.auth.SimpleAuthenticator;
 import com.hivemq.extension.sdk.api.auth.parameter.TopicPermission;
 import com.hivemq.extension.sdk.api.packets.auth.DefaultAuthorizationBehaviour;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
+import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.AckReasonCode;
 import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
 import com.hivemq.extensions.client.parameter.AuthenticatorProviderInputFactory;
@@ -696,8 +697,9 @@ public class ConnectHandlerTest {
         assertTrue(oldChannel.isOpen());
         assertTrue(embeddedChannel.isOpen());
 
-        final CONNECT connect1 = new CONNECT.Mqtt3Builder().withProtocolVersion(ProtocolVersion.MQTTv3_1_1)
+        final CONNECT connect1 = new CONNECT.Mqtt5Builder()
                 .withClientIdentifier("sameClientId")
+                .withMqtt5UserProperties(Mqtt5UserProperties.of(new MqttUserProperty("test", "test")))
                 .build();
 
         embeddedChannel.writeInbound(connect1);
@@ -742,7 +744,7 @@ public class ConnectHandlerTest {
         assertTrue(oldChannel.isOpen());
         assertTrue(embeddedChannel.isOpen());
 
-        final CONNECT connect1 = new CONNECT.Mqtt3Builder().withProtocolVersion(ProtocolVersion.MQTTv5)
+        final CONNECT connect1 = new CONNECT.Mqtt5Builder()
                 .withClientIdentifier("sameClientId")
                 .build();
 
@@ -1449,7 +1451,10 @@ public class ConnectHandlerTest {
         @Override
         public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
             if (evt instanceof OnServerDisconnectEvent) {
-                eventLatch.countDown();
+                final UserProperties userProperties = ((OnServerDisconnectEvent) evt).getUserProperties();
+                if (userProperties == null || userProperties.isEmpty()) {
+                    eventLatch.countDown();
+                }
             }
         }
     }


### PR DESCRIPTION
An MQTT DISCONNECT packet is now sent to the client that  is taken over by another client with the same id.

**Motivation**

Resolves #100

**Changes**

- For MQTT 5 clients a disconnect packet is now sent when a session takeover happens
- Triggers a disconnect event with code SESSION_TAKEN_OVER  when a session takeover happens
