### PR TITLE
fixed completable future callback execution.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ dependencies {
 
     testCompile(
             [group: 'junit', name: 'junit', version: '4.12'],
-            [group: 'org.mockito', name: 'mockito-core', version: '1.+'],
+            [group: 'org.mockito', name: 'mockito-core', version: '2.28.2'],
             [group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.9.0'],
             [group: 'net.jodah', name: 'concurrentunit', version: '0.4.2'],
 

--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,6 @@ dependencies {
     testCompile(
             [group: 'junit', name: 'junit', version: '4.12'],
             [group: 'org.mockito', name: 'mockito-core', version: '2.28.2'],
-            [group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.9.0'],
             [group: 'net.jodah', name: 'concurrentunit', version: '0.4.2'],
 
             /*
@@ -220,6 +219,10 @@ dependencies {
             // wiremock
             [group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.8.0'],
     )
+
+    testCompile([group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0']) {
+        exclude group: 'junit', module: 'junit-dep'
+    }
 
     /* We need some HotSpot methods to generate heapdumps from code */
     testCompile files(

--- a/src/main/java/com/hivemq/extensions/ListenableFutureConverter.java
+++ b/src/main/java/com/hivemq/extensions/ListenableFutureConverter.java
@@ -19,10 +19,10 @@ package com.hivemq.extensions;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.hivemq.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 /**
@@ -35,79 +35,101 @@ public class ListenableFutureConverter {
      * This method converts a ListenableFuture to a CompletableFuture
      * with different object types,
      * or the objects needs to be changed.
-     *
+     * <p>
      * objects may be null or not
-     *
      */
     @NotNull
-    public static <T, U> CompletableFuture<U> toCompletable(@NotNull final ListenableFuture<T> listenableFuture, @NotNull final Function<T, U> converter, final boolean nullableResult) {
-        return createCompletable(listenableFuture, converter, nullableResult);
-
+    public static <T, U> CompletableFuture<U> toCompletable(@NotNull final ListenableFuture<T> listenableFuture, @NotNull final Function<T, U> converter, final boolean nullableResult, final @NotNull Executor executor) {
+        return createCompletable(listenableFuture, converter, nullableResult, executor);
     }
 
     /**
      * This method converts a ListenableFuture to a CompletableFuture
      * with different object types,
      * or the objects needs to be changed.
-     *
+     * <p>
      * objects may be null
-     *
      */
     @NotNull
-    public static <T, U> CompletableFuture<U> toCompletable(@NotNull final ListenableFuture<T> listenableFuture, @NotNull final Function<T, U> converter) {
-        return createCompletable(listenableFuture, converter, true);
+    public static <T, U> CompletableFuture<U> toCompletable(@NotNull final ListenableFuture<T> listenableFuture, @NotNull final Function<T, U> converter, final @NotNull Executor executor) {
+        return createCompletable(listenableFuture, converter, true, executor);
 
-    }
-
-    @NotNull
-    public static <T> CompletableFuture<Void> toVoidCompletable(@NotNull final ListenableFuture<T> listenableFuture) {
-        return createCompletable(listenableFuture, result -> null, true);
     }
 
     /**
      * This method converts a ListenableFuture to a CompletableFuture
      * with equal object types,
      * and the object does not need to be changed.
-     *
+     * <p>
      * objects may be null
-     *
      */
-
     @NotNull
-    public static <T> CompletableFuture<T> toCompletable(@NotNull final ListenableFuture<T> listenableFuture) {
-        return createCompletable(listenableFuture, Function.identity(), true);
+    public static <T> CompletableFuture<T> toCompletable(@NotNull final ListenableFuture<T> listenableFuture, final @NotNull Executor executor) {
+        return createCompletable(listenableFuture, Function.identity(), true, executor);
+    }
+
+
+    /**
+     * This method converts any ListenableFuture to a CompletableFuture<Void>
+     */
+    @NotNull
+    public static <T> CompletableFuture<Void> toVoidCompletable(@NotNull final ListenableFuture<T> listenableFuture, final @NotNull Executor executor) {
+        return createCompletable(listenableFuture, result -> null, true, executor);
     }
 
     @NotNull
-    private static <T, U> CompletableFuture<U> createCompletable(@NotNull final ListenableFuture<T> listenableFuture, @NotNull final Function<T, U> converter, final boolean nullableResult) {
+    private static <T, U> CompletableFuture<U> createCompletable(@NotNull final ListenableFuture<T> listenableFuture, @NotNull final Function<T, U> converter, final boolean nullableResult, final @NotNull Executor executor) {
+
+        final ClassLoader callingThreadClassLoader = Thread.currentThread().getContextClassLoader();
         final CompletableFuture<U> completableFuture = new CompletableFuture<>() {
             @Override
             public boolean cancel(final boolean mayInterruptIfRunning) {
                 final boolean cancelled = listenableFuture.cancel(mayInterruptIfRunning);
-                super.cancel(cancelled);
-                return cancelled;
+                final ClassLoader current = Thread.currentThread().getContextClassLoader();
+                try {
+                    Thread.currentThread().setContextClassLoader(callingThreadClassLoader);
+                    super.cancel(cancelled);
+                    return cancelled;
+                } finally {
+                    Thread.currentThread().setContextClassLoader(current);
+                }
             }
         };
 
         Futures.addCallback(listenableFuture, new FutureCallback<>() {
             @Override
             public void onSuccess(final T result) {
+                final ClassLoader current = Thread.currentThread().getContextClassLoader();
                 try {
                     if (nullableResult && result == null) {
+                        Thread.currentThread().setContextClassLoader(callingThreadClassLoader);
                         completableFuture.complete(null);
                     } else {
-                        completableFuture.complete(converter.apply(result));
+                        //apply in current class loader
+                        final U convertedResult = converter.apply(result);
+                        //complete in previous
+                        Thread.currentThread().setContextClassLoader(callingThreadClassLoader);
+                        completableFuture.complete(convertedResult);
                     }
                 } catch (final Throwable throwable) {
+                    Thread.currentThread().setContextClassLoader(callingThreadClassLoader);
                     completableFuture.completeExceptionally(throwable);
+                } finally {
+                    Thread.currentThread().setContextClassLoader(current);
                 }
             }
 
             @Override
             public void onFailure(@NotNull final Throwable ex) {
-                completableFuture.completeExceptionally(ex);
+                final ClassLoader current = Thread.currentThread().getContextClassLoader();
+                try {
+                    Thread.currentThread().setContextClassLoader(callingThreadClassLoader);
+                    completableFuture.completeExceptionally(ex);
+                } finally {
+                    Thread.currentThread().setContextClassLoader(current);
+                }
             }
-        }, MoreExecutors.directExecutor());
+        }, executor);
         return completableFuture;
     }
 

--- a/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
@@ -120,8 +120,7 @@ public class ClientServiceImpl implements ClientService {
         if (pluginServiceRateLimitService.rateLimitExceeded()) {
             return CompletableFuture.failedFuture(PluginServiceRateLimitService.RATE_LIMIT_EXCEEDED_EXCEPTION);
         }
-        return ListenableFutureConverter.toCompletable(
-                clientSessionPersistence.forceDisconnectClient(clientId, preventWillMessage, EXTENSION));
+        return ListenableFutureConverter.toCompletable(clientSessionPersistence.forceDisconnectClient(clientId, preventWillMessage, EXTENSION), managedExtensionExecutorService);
     }
 
     @NotNull
@@ -149,9 +148,9 @@ public class ClientServiceImpl implements ClientService {
                 Exceptions.rethrowError(t);
                 setSessionSettableFuture.setException(t);
             }
-        }, MoreExecutors.directExecutor());
+        }, managedExtensionExecutorService);
 
-        return ListenableFutureConverter.toCompletable(setSessionSettableFuture);
+        return ListenableFutureConverter.toCompletable(setSessionSettableFuture, managedExtensionExecutorService);
     }
 
     @Override
@@ -182,10 +181,8 @@ public class ClientServiceImpl implements ClientService {
 
     static class AllClientsItemCallback implements AsyncIterator.ItemCallback<SessionInformation> {
 
-        private @NotNull
-        final Executor callbackExecutor;
-        private @NotNull
-        final IterationCallback<SessionInformation> callback;
+        private @NotNull final Executor callbackExecutor;
+        private @NotNull final IterationCallback<SessionInformation> callback;
 
         AllClientsItemCallback(
                 @NotNull final Executor callbackExecutor,
@@ -201,29 +198,26 @@ public class ClientServiceImpl implements ClientService {
             final SettableFuture<Boolean> resultFuture = SettableFuture.create();
 
             //this is not a lambda because we want it to be identifiable in a heap-dump
-            callbackExecutor.execute(new Runnable() {
-                @Override
-                public void run() {
+            callbackExecutor.execute(() -> {
 
                     final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
                     try {
                         Thread.currentThread().setContextClassLoader(callback.getClass().getClassLoader());
                         for (final SessionInformation sessionInformation : items) {
 
-                            callback.iterate(iterationContext, sessionInformation);
+                        callback.iterate(iterationContext, sessionInformation);
 
-                            if (iterationContext.isAborted()) {
-                                resultFuture.set(false);
-                                break;
-                            }
+                        if (iterationContext.isAborted()) {
+                            resultFuture.set(false);
+                            break;
                         }
-                    } catch (final Exception e) {
-                        resultFuture.setException(e);
-                    } finally {
-                        Thread.currentThread().setContextClassLoader(contextClassLoader);
                     }
-                    resultFuture.set(true);
+                } catch (final Exception e) {
+                    resultFuture.setException(e);
+                } finally {
+                    Thread.currentThread().setContextClassLoader(contextClassLoader);
                 }
+                resultFuture.set(true);
             });
 
             return resultFuture;

--- a/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/session/ClientServiceImpl.java
@@ -176,7 +176,16 @@ public class ClientServiceImpl implements ClientService {
 
         asyncIterator.fetchAndIterate();
 
-        return asyncIterator.getFinishedFuture();
+        final SettableFuture<Void> settableFuture = SettableFuture.create();
+        asyncIterator.getFinishedFuture().whenComplete((aVoid, throwable) -> {
+            if(throwable != null) {
+                settableFuture.setException(throwable);
+            } else {
+                settableFuture.set(null);
+            }
+        });
+
+        return ListenableFutureConverter.toCompletable(settableFuture, managedExtensionExecutorService);
     }
 
     static class AllClientsItemCallback implements AsyncIterator.ItemCallback<SessionInformation> {

--- a/src/main/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImpl.java
@@ -113,9 +113,9 @@ public class SubscriptionStoreImpl implements SubscriptionStore {
             public void onFailure(final @NotNull Throwable t) {
                 settableFuture.setException(t);
             }
-        }, MoreExecutors.directExecutor());
+        }, managedExtensionExecutorService);
 
-        return ListenableFutureConverter.toCompletable(settableFuture);
+        return ListenableFutureConverter.toCompletable(settableFuture, managedExtensionExecutorService);
     }
 
     @Override
@@ -164,9 +164,9 @@ public class SubscriptionStoreImpl implements SubscriptionStore {
             public void onFailure(final @NotNull Throwable t) {
                 settableFuture.setException(t);
             }
-        }, MoreExecutors.directExecutor());
+        }, managedExtensionExecutorService);
 
-        return ListenableFutureConverter.toCompletable(settableFuture);
+        return ListenableFutureConverter.toCompletable(settableFuture, managedExtensionExecutorService);
     }
 
     @Override
@@ -181,7 +181,7 @@ public class SubscriptionStoreImpl implements SubscriptionStore {
         if (!Topics.isValidToSubscribe(topicFilter)) {
             return CompletableFuture.failedFuture(new InvalidTopicException(topicFilter));
         }
-        return ListenableFutureConverter.toCompletable(subscriptionPersistence.remove(clientID, topicFilter));
+        return ListenableFutureConverter.toCompletable(subscriptionPersistence.remove(clientID, topicFilter), managedExtensionExecutorService);
     }
 
     @Override
@@ -205,7 +205,7 @@ public class SubscriptionStoreImpl implements SubscriptionStore {
         }
 
         if (failedTopics.isEmpty()) {
-            return ListenableFutureConverter.toVoidCompletable(subscriptionPersistence.removeSubscriptions(clientID, ImmutableSet.copyOf(topicFilters)));
+            return ListenableFutureConverter.toVoidCompletable(subscriptionPersistence.removeSubscriptions(clientID, ImmutableSet.copyOf(topicFilters)), managedExtensionExecutorService);
         } else {
             return CompletableFuture.failedFuture(new InvalidTopicException("Topics not valid: " + failedTopics));
         }

--- a/src/main/java/com/hivemq/mqtt/services/InternalPublishService.java
+++ b/src/main/java/com/hivemq/mqtt/services/InternalPublishService.java
@@ -18,7 +18,7 @@ package com.hivemq.mqtt.services;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.hivemq.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
+import com.hivemq.annotations.Nullable;
 import com.hivemq.mqtt.handler.publish.PublishReturnCode;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 

--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -40,7 +40,6 @@ import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 import static com.hivemq.mqtt.handler.publish.PublishStatus.*;

--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -40,6 +40,7 @@ import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 import static com.hivemq.mqtt.handler.publish.PublishStatus.*;

--- a/src/test/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializerTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static com.hivemq.bootstrap.netty.ChannelHandlerNames.*;
+import static com.hivemq.bootstrap.netty.initializer.AbstractChannelInitializer.FIRST_ABSTRACT_HANDLER;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -96,26 +97,14 @@ public class AbstractChannelInitializerTest {
     @Test
     public void test_init_channel() throws Exception {
 
-        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-
         abstractChannelInitializer.initChannel(socketChannel);
 
-        verify(pipeline, atLeastOnce()).addLast(captor.capture(), any(ChannelHandler.class));
-
-        assertTrue(captor.getAllValues().contains(ALL_CHANNELS_GROUP_HANDLER));
-        assertTrue(captor.getAllValues().contains(NEW_CONNECTION_IDLE_HANDLER));
-        assertTrue(captor.getAllValues().contains(NO_CONNECT_IDLE_EVENT_HANDLER));
-        assertTrue(captor.getAllValues().contains(MQTT_MESSAGE_DECODER));
-        assertTrue(captor.getAllValues().contains(MQTT_MESSAGE_DECODER));
-        assertTrue(captor.getAllValues().contains(MQTT_MESSAGE_ENCODER));
-        assertTrue(captor.getAllValues().contains(MQTT_CONNECT_HANDLER));
-        assertTrue(captor.getAllValues().contains(MQTT_DISCONNECT_HANDLER));
-        assertTrue(captor.getAllValues().contains(MQTT_DISCONNECT_HANDLER));
-        assertTrue(captor.getAllValues().contains(MQTT_SUBSCRIBE_HANDLER));
-        assertTrue(captor.getAllValues().contains(MQTT_PUBLISH_USER_EVENT_HANDLER));
-        assertTrue(captor.getAllValues().contains(INCOMING_PUBLISH_HANDLER));
-        assertTrue(captor.getAllValues().contains(MQTT_UNSUBSCRIBE_HANDLER));
-        assertTrue(captor.getAllValues().contains(STATISTICS_INITIALIZER));
+        verify(pipeline).addLast(eq(FIRST_ABSTRACT_HANDLER), any(ChannelHandler.class));
+        verify(pipeline).addLast(eq(MQTT_MESSAGE_DECODER), any(ChannelHandler.class));
+        verify(pipeline).addLast(eq(REMOVE_CONNECT_IDLE_HANDLER), any(ChannelHandler.class));
+        verify(pipeline).addLast(eq(MQTT_MESSAGE_BARRIER), any(ChannelHandler.class));
+        verify(pipeline).addLast(eq(MQTT_SUBSCRIBE_MESSAGE_BARRIER), any(ChannelHandler.class));
+        verify(pipeline).addLast(eq(CHANNEL_INACTIVE_HANDLER), any(ChannelHandler.class));
 
     }
 

--- a/src/test/java/com/hivemq/extensions/ListenableFutureConverterTest.java
+++ b/src/test/java/com/hivemq/extensions/ListenableFutureConverterTest.java
@@ -17,6 +17,7 @@
 package com.hivemq.extensions;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
 import org.junit.Before;
@@ -27,7 +28,11 @@ import org.mockito.MockitoAnnotations;
 import util.TestException;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import static org.junit.Assert.*;
@@ -53,7 +58,7 @@ public class ListenableFutureConverterTest {
 
         final ListenableFuture<Void> voidListenableFuture = SettableFuture.create();
 
-        final CompletableFuture<Void> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture);
+        final CompletableFuture<Void> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, MoreExecutors.directExecutor());
 
         assertFalse(voidCompletableFuture.isCancelled());
         assertFalse(voidListenableFuture.isCancelled());
@@ -70,9 +75,9 @@ public class ListenableFutureConverterTest {
 
         final Function<Void, String> functionMock = Mockito.mock(Function.class);
 
-        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock, false);
+        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock, false, MoreExecutors.directExecutor());
 
-        when(functionMock.apply(any(Void.class))).thenThrow(new RuntimeException("TEST"));
+        when(functionMock.apply(null)).thenThrow(new RuntimeException("TEST"));
 
         voidListenableFuture.set(null);
 
@@ -87,7 +92,7 @@ public class ListenableFutureConverterTest {
 
         final Function<Void, String> functionMock = Mockito.mock(Function.class);
 
-        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock, true);
+        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock, true, MoreExecutors.directExecutor());
 
         //apply must not be called, if result nullable and null
         when(functionMock.apply(any(Void.class))).thenThrow(new RuntimeException("TEST"));
@@ -108,7 +113,7 @@ public class ListenableFutureConverterTest {
 
         final Function<Integer, String> functionMock = x -> "" + x;
 
-        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock, true);
+        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock, true, MoreExecutors.directExecutor());
 
         voidListenableFuture.set(5);
 
@@ -124,7 +129,7 @@ public class ListenableFutureConverterTest {
 
         final SettableFuture<Integer> voidListenableFuture = SettableFuture.create();
 
-        final CompletableFuture<Integer> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture);
+        final CompletableFuture<Integer> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, MoreExecutors.directExecutor());
 
         voidListenableFuture.set(5);
 
@@ -140,7 +145,7 @@ public class ListenableFutureConverterTest {
 
         final SettableFuture<Integer> voidListenableFuture = SettableFuture.create();
 
-        final CompletableFuture<Integer> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture);
+        final CompletableFuture<Integer> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, MoreExecutors.directExecutor());
 
         voidListenableFuture.set(null);
 
@@ -158,7 +163,7 @@ public class ListenableFutureConverterTest {
 
         final Function<Integer, String> functionMock = x -> "" + x;
 
-        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock);
+        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock, MoreExecutors.directExecutor());
 
         voidListenableFuture.set(null);
 
@@ -176,7 +181,7 @@ public class ListenableFutureConverterTest {
 
         final Function<Void, String> functionMock = Mockito.mock(Function.class);
 
-        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock);
+        final CompletableFuture<String> voidCompletableFuture = ListenableFutureConverter.toCompletable(voidListenableFuture, functionMock, MoreExecutors.directExecutor());
 
         voidListenableFuture.setException(TestException.INSTANCE);
 

--- a/src/test/java/com/hivemq/extensions/handler/IncomingPublishHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/IncomingPublishHandlerTest.java
@@ -45,7 +45,6 @@ import com.hivemq.mqtt.message.dropping.MessageDroppedService;
 import com.hivemq.mqtt.message.puback.PUBACK;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.pubrec.PUBREC;
-import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 import com.hivemq.mqtt.message.reason.Mqtt5PubAckReasonCode;
 import com.hivemq.mqtt.message.subscribe.SUBSCRIBE;
 import com.hivemq.util.ChannelAttributes;
@@ -509,7 +508,7 @@ public class IncomingPublishHandlerTest {
         }
 
         assertTrue(dropLatch.await(5, TimeUnit.SECONDS));
-        verify(mqtt3ServerDisconnector).disconnect(eq(channel), anyString(), anyString(), any(Mqtt5DisconnectReasonCode.class), anyString());
+        verify(mqtt3ServerDisconnector).disconnect(eq(channel), anyString(), anyString(), any(), any());
 
     }
 

--- a/src/test/java/com/hivemq/extensions/handler/IncomingSubscribeHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/IncomingSubscribeHandlerTest.java
@@ -355,7 +355,7 @@ public class IncomingSubscribeHandlerTest {
         assertTrue(subackLatch.await(5, TimeUnit.SECONDS));
     }
 
-    @Test(timeout = 500000)
+    @Test(timeout = 5000)
     public void test_read_subscribe_extension_null() throws Exception {
 
         final ClientContextImpl clientContext = new ClientContextImpl(hiveMQExtensions, new ModifiableDefaultPermissionsImpl());

--- a/src/test/java/com/hivemq/extensions/handler/tasks/PublishAuthorizationProcessedTaskTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/tasks/PublishAuthorizationProcessedTaskTest.java
@@ -89,7 +89,7 @@ public class PublishAuthorizationProcessedTaskTest {
         task.onSuccess(output);
 
         verify(mqtt5ServerDisconnector).disconnect(any(), anyString(), anyString(),
-                eq(Mqtt5DisconnectReasonCode.NOT_AUTHORIZED), anyString());
+                eq(Mqtt5DisconnectReasonCode.NOT_AUTHORIZED), eq(null));
     }
 
     @Test
@@ -101,7 +101,7 @@ public class PublishAuthorizationProcessedTaskTest {
         task.onSuccess(output);
 
         verify(mqtt5ServerDisconnector).disconnect(any(), anyString(), anyString(),
-                eq(Mqtt5DisconnectReasonCode.QUOTA_EXCEEDED), anyString());
+                eq(Mqtt5DisconnectReasonCode.QUOTA_EXCEEDED), eq(null));
     }
 
     @Test
@@ -124,7 +124,7 @@ public class PublishAuthorizationProcessedTaskTest {
         output.disconnectClient();
         task.onSuccess(output);
 
-        verify(mqtt3ServerDisconnector).disconnect(any(), anyString(), anyString(), any(), anyString());
+        verify(mqtt3ServerDisconnector).disconnect(any(), anyString(), anyString(), eq(null), eq(null));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class PublishAuthorizationProcessedTaskTest {
         output.disconnectClient();
         task.onSuccess(output);
 
-        verify(mqtt3ServerDisconnector).disconnect(any(), anyString(), anyString(), any(), anyString());
+        verify(mqtt3ServerDisconnector).disconnect(any(), anyString(), anyString(), eq(null), eq(null));
     }
 
     @Test
@@ -305,6 +305,6 @@ public class PublishAuthorizationProcessedTaskTest {
         task.onFailure(new RuntimeException("test"));
 
         verify(mqtt5ServerDisconnector).disconnect(any(), anyString(), anyString(),
-                eq(Mqtt5DisconnectReasonCode.NOT_AUTHORIZED), anyString());
+                eq(Mqtt5DisconnectReasonCode.NOT_AUTHORIZED), eq(null));
     }
 }

--- a/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
@@ -427,9 +427,11 @@ public class ClientServiceImplTest {
         assertEquals(3, chunkResult.getResults().size());
     }
 
-
     @NotNull
-    public GlobalManagedPluginExecutorService getManagedExtensionExecutorService() {
-        return new GlobalManagedPluginExecutorService(mock(ShutdownHooks.class));
+    private GlobalManagedPluginExecutorService getManagedExtensionExecutorService() {
+        final GlobalManagedPluginExecutorService globalManagedPluginExecutorService =
+                new GlobalManagedPluginExecutorService(mock(ShutdownHooks.class));
+        globalManagedPluginExecutorService.postConstruct();
+        return globalManagedPluginExecutorService;
     }
 }

--- a/src/test/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImplTest.java
@@ -903,10 +903,10 @@ public class SubscriptionStoreImplTest {
         }
     }
 
-    @NotNull
-    public GlobalManagedPluginExecutorService getManagedExtensionExecutorService() {
-        final FullConfigurationService fullConfigurationService =
-                new TestConfigurationBootstrap().getFullConfigurationService();
-        return new GlobalManagedPluginExecutorService(mock(ShutdownHooks.class));
+    private GlobalManagedPluginExecutorService getManagedExtensionExecutorService() {
+        final GlobalManagedPluginExecutorService globalManagedPluginExecutorService =
+                new GlobalManagedPluginExecutorService(mock(ShutdownHooks.class));
+        globalManagedPluginExecutorService.postConstruct();
+        return globalManagedPluginExecutorService;
     }
 }

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -150,7 +150,7 @@ public class ConnectHandlerTest {
 
         MockitoAnnotations.initMocks(this);
         when(clientSessionPersistence.isExistent(anyString())).thenReturn(false);
-        when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyInt(), any(MqttWillPublish.class))).thenReturn(Futures.immediateFuture(null));
+        when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyLong(), any())).thenReturn(Futures.immediateFuture(null));
 
         metricsHolder = new MetricsHolder(new MetricRegistry());
         embeddedChannel = new EmbeddedChannel(new DummyHandler());
@@ -1107,6 +1107,8 @@ public class ConnectHandlerTest {
     @Test(timeout = 5000)
     public void test_will_authorization_success() {
         createHandler();
+
+        when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyLong(), any(MqttWillPublish.class))).thenReturn(Futures.immediateFuture(null));
 
         final MqttWillPublish willPublish = new MqttWillPublish.Mqtt5Builder().withTopic("topic")
                 .withQos(QoS.AT_LEAST_ONCE).withPayload(new byte[]{1, 2, 3}).build();

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectPersistenceUpdateHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectPersistenceUpdateHandlerTest.java
@@ -43,9 +43,10 @@ import util.TestSingleWriterFactory;
 import static com.hivemq.mqtt.handler.connect.ConnectPersistenceUpdateHandler.StartConnectPersistence;
 import static com.hivemq.mqtt.message.connect.Mqtt5CONNECT.SESSION_EXPIRY_MAX;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.*;
 
@@ -99,7 +100,8 @@ public class ConnectPersistenceUpdateHandlerTest {
         when(channel.attr(eq(ChannelAttributes.TAKEN_OVER))).thenReturn(new TestChannelAttribute<Boolean>(false));
         when(channel.attr(eq(ChannelAttributes.AUTHENTICATED_OR_AUTHENTICATION_BYPASSED))).thenReturn(new TestChannelAttribute<Boolean>(true));
 
-        when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyInt(), any(MqttWillPublish.class))).thenReturn(Futures.immediateFuture(null));
+        when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyLong(), any(MqttWillPublish.class))).thenReturn(Futures.immediateFuture(null));
+        when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyLong(), eq(null))).thenReturn(Futures.immediateFuture(null));
         when(ctx.channel()).thenReturn(channel);
         persistenceUpdateHandler = new ConnectPersistenceUpdateHandler(clientSessionPersistence, clientSessionSubscriptionPersistence,
                 messageIDPools, channelPersistence, singleWriterService);
@@ -124,7 +126,7 @@ public class ConnectPersistenceUpdateHandlerTest {
 
         when(channel.attr(eq(ChannelAttributes.CLIENT_ID))).thenReturn(new TestChannelAttribute<>("client"));
         when(channel.attr(eq(ChannelAttributes.CLEAN_START))).thenReturn(new TestChannelAttribute<>(true));
-        when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyInt(), any(MqttWillPublish.class))).thenReturn(Futures.immediateFailedFuture(new RuntimeException("test")));
+        when(clientSessionPersistence.clientConnected(anyString(), anyBoolean(), anyLong(), eq(null))).thenReturn(Futures.immediateFailedFuture(new RuntimeException("test")));
 
         final StartConnectPersistence startConnectPersistence = new StartConnectPersistence(connect, true, 1000);
         persistenceUpdateHandler.userEventTriggered(channelHandlerContext, startConnectPersistence);

--- a/src/test/java/com/hivemq/mqtt/services/PublishPollServiceImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/services/PublishPollServiceImplTest.java
@@ -58,7 +58,11 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImplTest.java
@@ -47,7 +47,10 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -111,7 +114,7 @@ public class ClientSessionPersistenceImplTest {
         final ClientSession previousSession = new ClientSession(false, 0);
         when(clientQueuePersistence.removeAllQos0Messages("client", false)).thenReturn(Futures.immediateFuture(null));
         when(subscriptionPersistence.removeAll("client")).thenReturn(Futures.immediateFuture(null));
-        when(localPersistence.disconnect(eq("client"), anyInt(), eq(true), anyInt(), eq(10L))).
+        when(localPersistence.disconnect(eq("client"), anyLong(), eq(true), anyInt(), eq(10L))).
                 thenReturn(previousSession);
         clientSessionPersistence.clientDisconnected("client", true, 10).get();
         verify(pendingWillMessages).addWill("client", previousSession);
@@ -159,7 +162,7 @@ public class ClientSessionPersistenceImplTest {
         final Boolean result = future.get();
         assertTrue(result);
         verify(pendingWillMessages).cancelWill("client");
-        verify(mqtt5ServerDisconnector).disconnect(any(Channel.class), anyString(), anyString(), eq(Mqtt5DisconnectReasonCode.ADMINISTRATIVE_ACTION), anyString());
+        verify(mqtt5ServerDisconnector).disconnect(any(Channel.class), anyString(), anyString(), eq(Mqtt5DisconnectReasonCode.ADMINISTRATIVE_ACTION), any());
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/clientsession/ClientSessionSubscriptionPersistenceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/clientsession/ClientSessionSubscriptionPersistenceImplTest.java
@@ -41,7 +41,13 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyByte;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -79,9 +85,7 @@ public class ClientSessionSubscriptionPersistenceImplTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-
         when(topicTree.addTopic(anyString(), any(Topic.class), anyByte(), anyString())).thenReturn(true);
-
         persistence = new ClientSessionSubscriptionPersistenceImpl(localPersistence, topicTree, sharedSubscriptionService, TestSingleWriterFactory.defaultSingleWriter(), channelPersistence, eventLog, clientSessionLocalPersistence, publishPollService);
     }
 
@@ -93,7 +97,7 @@ public class ClientSessionSubscriptionPersistenceImplTest {
         final Topic topic1 = new Topic("topic1", QoS.AT_MOST_ONCE);
         final Topic topic2 = new Topic("topic2", QoS.AT_MOST_ONCE);
         persistence.addSubscriptions("client", ImmutableSet.of(topic1, topic2)).get();
-        verify(topicTree, times(2)).addTopic(eq("client"), any(Topic.class), anyByte(), anyString());
+        verify(topicTree, times(2)).addTopic(eq("client"), any(Topic.class), anyByte(), any());
         verify(localPersistence).addSubscriptions(eq("client"), anySet(), anyLong(), anyInt());
     }
 
@@ -167,7 +171,7 @@ public class ClientSessionSubscriptionPersistenceImplTest {
         when(channelPersistence.get("client")).thenReturn(embeddedChannel);
         persistence.invalidateSharedSubscriptionCacheAndPoll("client", ImmutableSet.of(new Subscription(new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 2, "group")));
 
-        verify(publishPollService).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), anyInt(), any(Channel.class));
+        verify(publishPollService).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), any(), any(Channel.class));
         verify(sharedSubscriptionService).invalidateSharedSubscriberCache("group/topic");
         verify(sharedSubscriptionService).invalidateSharedSubscriptionCache("client");
 
@@ -179,7 +183,7 @@ public class ClientSessionSubscriptionPersistenceImplTest {
     public void test_remove_subscriptions_responsible() throws ExecutionException, InterruptedException {
 
         persistence.removeSubscriptions("client", ImmutableSet.of("topic1", "topic2")).get();
-        verify(topicTree, times(2)).removeSubscriber(eq("client"), anyString(), anyString());
+        verify(topicTree, times(2)).removeSubscriber(eq("client"), anyString(), any());
     }
 
     @Test(timeout = 60000)

--- a/src/test/java/com/hivemq/persistence/local/xodus/clientsession/ClientSessionXodusLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/clientsession/ClientSessionXodusLocalPersistenceTest.java
@@ -370,7 +370,7 @@ public class ClientSessionXodusLocalPersistenceTest {
     @Test
     public void test_disconnected_send_will() {
 
-        when(payloadPersistence.getPayloadOrNull(anyInt())).thenReturn(new byte[]{});
+        when(payloadPersistence.getPayloadOrNull(anyLong())).thenReturn(new byte[]{});
 
         final String client1 = TestBucketUtil.getId(1, BUCKET_COUNT);
 


### PR DESCRIPTION
**Motivation**

* Static context like Builders and Services must be available in any callback.

**Changes**

* CompletableFutures callbacks are now executed in a specific executor.
* The context classloader of the initial calling Thread is now used as context classloader of completable future completion.
* Updated Mockito version to 2.28.2.