### PR TITLE
Message expiry check now allow max message expiry

### DIFF
--- a/src/main/java/com/hivemq/extensions/services/builder/PluginBuilderUtil.java
+++ b/src/main/java/com/hivemq/extensions/services/builder/PluginBuilderUtil.java
@@ -42,7 +42,7 @@ public class PluginBuilderUtil {
     }
 
     public static void checkMessageExpiryInterval(final long messageExpiryInterval, final long maxMessageExpiryInterval) {
-        checkArgument(messageExpiryInterval < maxMessageExpiryInterval,
+        checkArgument(messageExpiryInterval <= maxMessageExpiryInterval,
                 "Message expiry interval " + messageExpiryInterval + " not allowed. Maximum = " + maxMessageExpiryInterval);
         checkArgument(messageExpiryInterval > 0,
                 "Message expiry interval must be bigger than 0 was " + messageExpiryInterval + ".");

--- a/src/test/java/com/hivemq/extensions/services/builder/PublishBuilderImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/builder/PublishBuilderImplTest.java
@@ -65,6 +65,17 @@ public class PublishBuilderImplTest {
         new PublishBuilderImpl(configurationService).messageExpiryInterval(11);
     }
 
+    @Test
+    public void test_custom_max_message_expiry_value_validation() {
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+        new PublishBuilderImpl(configurationService).messageExpiryInterval(10);
+    }
+
+    @Test
+    public void test_max_message_expiry_value_validation() {
+        new PublishBuilderImpl(configurationService).messageExpiryInterval(4_294_967_296L);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void test_message_expiry_less_than_zero() {
         new PublishBuilderImpl(configurationService).messageExpiryInterval(-1);

--- a/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
@@ -87,6 +87,17 @@ public class RetainedPublishBuilderImplTest {
         new RetainedPublishBuilderImpl(configurationService).messageExpiryInterval(11);
     }
 
+    @Test
+    public void test_custom_max_message_expiry_value_validation() {
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+        new RetainedPublishBuilderImpl(configurationService).messageExpiryInterval(10);
+    }
+
+    @Test
+    public void test_max_message_expiry_value_validation() {
+        new RetainedPublishBuilderImpl(configurationService).messageExpiryInterval(4_294_967_296L);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void test_message_expiry_less_than_zero() {
         retainedPublishBuilder.messageExpiryInterval(-1);
@@ -281,14 +292,17 @@ public class RetainedPublishBuilderImplTest {
 
     @Test
     public void test_minimum() {
-        final RetainedPublish retainedPublish = retainedPublishBuilder.topic("topic").payload(ByteBuffer.wrap("payload".getBytes())).build();
+        final RetainedPublish retainedPublish =
+                retainedPublishBuilder.topic("topic").payload(ByteBuffer.wrap("payload".getBytes())).build();
 
         assertEquals(Qos.AT_MOST_ONCE, retainedPublish.getQos());
         assertEquals("topic", retainedPublish.getTopic());
         assertArrayEquals("payload".getBytes(), retainedPublish.getPayload().get().array());
         assertEquals(Optional.empty(), retainedPublish.getPayloadFormatIndicator());
         assertTrue(retainedPublish.getMessageExpiryInterval().isPresent());
-        assertEquals(configurationService.mqttConfiguration().maxMessageExpiryInterval(), retainedPublish.getMessageExpiryInterval().get().longValue());
+        assertEquals(
+                configurationService.mqttConfiguration().maxMessageExpiryInterval(),
+                retainedPublish.getMessageExpiryInterval().get().longValue());
         assertEquals(Optional.empty(), retainedPublish.getResponseTopic());
         assertEquals(Optional.empty(), retainedPublish.getCorrelationData());
         assertEquals(Optional.empty(), retainedPublish.getContentType());
@@ -374,7 +388,6 @@ public class RetainedPublishBuilderImplTest {
                     new MqttUserProperty("name2", "val")));
         }
     }
-
 
     private class TestPublish implements Publish {
 


### PR DESCRIPTION
**Motivation**
Message expiry check now allow max message expiry.

Resolves #103

**Changes**
PluginBuilderUtil.checkMessageExpiryInterval now also allows a value that is equal to configured or default max message expiry.