### PR TITLE
Feature/unsubscribe inbound interceptor

### DIFF
--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/AsyncOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/AsyncOutput.java
@@ -28,7 +28,7 @@ import java.time.Duration;
  * @since 4.0.0
  */
 @DoNotImplement
-public interface AsyncOutput<T> {
+public interface AsyncOutput<T> extends SimpleAsyncOutput<T> {
 
     /**
      * If the timeout is expired before {@link Async#resume()} is called then the outcome is
@@ -43,15 +43,4 @@ public interface AsyncOutput<T> {
      * @since 4.0.0
      */
     @NotNull Async<T> async(@NotNull Duration timeout, @NotNull TimeoutFallback fallback);
-
-    /**
-     * If the timeout is expired before {@link Async#resume()} is called then the outcome is handled as failed.
-     * <p>
-     * Do not call this method more than once. If an async method is called multiple times an exception is thrown.
-     *
-     * @param timeout Timeout that HiveMQ waits for the result of the async operation.
-     * @throws UnsupportedOperationException If async is called more than once.
-     * @since 4.0.0
-     */
-    @NotNull Async<T> async(@NotNull Duration timeout);
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/SimpleAsyncOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/SimpleAsyncOutput.java
@@ -1,0 +1,27 @@
+package com.hivemq.extension.sdk.api.async;
+
+import com.hivemq.extension.sdk.api.annotations.DoNotImplement;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+import java.time.Duration;
+
+/**
+ * Enables an output object to be processed in a non-blocking way.
+ *
+ * @author Yannick Weber
+ */
+@DoNotImplement
+public interface SimpleAsyncOutput<T> {
+
+    /**
+     * If the timeout is expired before {@link Async#resume()} is called then the outcome is handled as failed.
+     * <p>
+     * Do not call this method more than once. If an async method is called multiple times an exception is thrown.
+     *
+     * @param timeout Timeout that HiveMQ waits for the result of the async operation.
+     * @throws UnsupportedOperationException If async is called more than once.
+     * @since 4.0.0
+     */
+    @NotNull Async<T> async(@NotNull Duration timeout);
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
@@ -23,6 +23,7 @@ import com.hivemq.extension.sdk.api.interceptor.Interceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.auth.ModifiableDefaultPermissions;
 
 import java.util.List;
@@ -70,6 +71,15 @@ public interface ClientContext {
     void addSubscribeInboundInterceptor(@NotNull SubscribeInboundInterceptor subscribeInboundInterceptor);
 
     /**
+     * Adds an {@link UnsubscribeInboundInterceptor} for this client. <br> Subsequent adding of the same interceptor
+     * will be ignoretd.
+     *
+     * @param unsubscribeInboundInterceptor The implementation of an UnsubscribeInboundInterceptor.
+     * @throws NullPointerException If the interceptor is null.
+     */
+    void addUnsubscribeInboundInterceptor(@NotNull UnsubscribeInboundInterceptor unsubscribeInboundInterceptor);
+
+    /**
      * Removes an {@link PublishInboundInterceptor} for this client. <br>
      * Nothing happens if the interceptor that should be removed, has not been added in the first place.
      *
@@ -78,7 +88,6 @@ public interface ClientContext {
      * @since 4.0.0
      */
     void removePublishInboundInterceptor(@NotNull PublishInboundInterceptor publishInboundInterceptor);
-
 
     /**
      * Removes an {@link PublishOutboundInterceptor} for this client. <br>
@@ -99,6 +108,15 @@ public interface ClientContext {
      * @since 4.2.0
      */
     void removeSubscribeInboundInterceptor(@NotNull SubscribeInboundInterceptor subscribeInboundInterceptor);
+
+    /**
+     * Removes an {@link UnsubscribeInboundInterceptor} for this client. <br> Nothing happens if the interceptor that
+     * should be removed, has not been added in the first place.
+     *
+     * @param unsubscribeInboundInterceptor The implementation of an UnsubscribeInboundInterceptor.
+     * @throws NullPointerException If the interceptors is null.
+     */
+    void removeUnsubscribeInboundInterceptor(@NotNull UnsubscribeInboundInterceptor unsubscribeInboundInterceptor);
 
     /**
      * Returns all {@link Interceptor} which are registered for this client.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/UnsubscribeInboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/UnsubscribeInboundInterceptor.java
@@ -1,0 +1,31 @@
+package com.hivemq.extension.sdk.api.interceptor.unsubscribe;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.Interceptor;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundInput;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundOutput;
+
+/**
+ * Interface for the inbound UNSUBSCRIBE interception.
+ * <p>
+ * Interceptors are always called by the same Thread for all messages from the same client.
+ * <p>
+ * If the same instance is shared between multiple clients it can be called in different Threads and must therefore be
+ * thread-safe.
+ * <p>
+ *
+ * @author Robin Atherton
+ */
+public interface UnsubscribeInboundInterceptor extends Interceptor {
+
+    /**
+     * When a {@link UnsubscribeInboundInterceptor} is set through any extension, this method gets called for every
+     * inbound UNSUBSCRIBE packet from any client.
+     *
+     * @param unsubscribeInboundInput  The {@link UnsubscribeInboundInput} parameter.
+     * @param unsubscribeInboundOutput The {@link UnsubscribeInboundOutput} parameter.
+     */
+    void onInboundUnsubscribe(
+            @NotNull UnsubscribeInboundInput unsubscribeInboundInput,
+            @NotNull UnsubscribeInboundOutput unsubscribeInboundOutput);
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundInput.java
@@ -1,0 +1,25 @@
+package com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter;
+
+import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.UnsubscribePacket;
+import com.hivemq.extension.sdk.api.parameter.ClientBasedInput;
+
+/**
+ * This is the input parameter of any {@link UnsubscribeInboundInterceptor} providing UNSUBSCRIBE, connection and client
+ * based information.
+ *
+ * @author Robin Atherton
+ */
+public interface UnsubscribeInboundInput extends ClientBasedInput {
+
+    /**
+     * The unmodifiable UNSUBSCRIBE packet that was intercepted.
+     *
+     * @return An unmodifiable {@link UnsubscribePacket}.
+     */
+    @NotNull
+    @Immutable UnsubscribePacket getUnsubscribePacket();
+
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundOutput.java
@@ -2,14 +2,24 @@ package com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.async.AsyncOutput;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
 
+/**
+ * This is the output parameter of any {@link UnsubscribeInboundInterceptor} providing methods to define the outcome of
+ * UNSUBSCRIBE interception.
+ * <p>
+ * It can be used to modify an inbound UNSUBSCRIBE packet.
+ * <p>
+ *
+ * @author Robin Atherton
+ */
 public interface UnsubscribeInboundOutput extends AsyncOutput<UnsubscribeInboundOutput> {
 
     /**
      * Use this Object to make any changes to the inbound UNSUBSCRIBE.
      *
-     * @return a modifiable unsubscribe packet.
+     * @return a {@link ModifiableUnsubscribePacket}.
      */
     @NotNull ModifiableUnsubscribePacket getUnsubscribePacket();
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundOutput.java
@@ -1,9 +1,12 @@
 package com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.async.Async;
 import com.hivemq.extension.sdk.api.async.AsyncOutput;
 import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
+
+import java.time.Duration;
 
 /**
  * This is the output parameter of any {@link UnsubscribeInboundInterceptor} providing methods to define the outcome of
@@ -22,5 +25,18 @@ public interface UnsubscribeInboundOutput extends AsyncOutput<UnsubscribeInbound
      * @return a {@link ModifiableUnsubscribePacket}.
      */
     @NotNull ModifiableUnsubscribePacket getUnsubscribePacket();
+
+    /**
+     * If the timeout is expired before {@link Async#resume()} is called then the outcome is handled as failed. In that
+     * case an unmodified UNSUBSCRIBE is forwarded to the server and all changes made by this interceptor are
+     * discarded.
+     * <p>
+     * Do not call this method more than once. If an async method is called multiple times an exception is thrown.
+     *
+     * @param timeout Timeout that HiveMQ waits for the result of the async operation.
+     * @throws UnsupportedOperationException If async is called more than once.
+     * @since 4.3.0
+     */
+    @NotNull Async<UnsubscribeInboundOutput> async(@NotNull Duration timeout);
 
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundOutput.java
@@ -1,4 +1,16 @@
 package com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter;
 
-public interface UnsubscribeInboundOutput {
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.async.AsyncOutput;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
+
+public interface UnsubscribeInboundOutput extends AsyncOutput<UnsubscribeInboundOutput> {
+
+    /**
+     * Use this Object to make any changes to the inbound UNSUBSCRIBE.
+     *
+     * @return a modifiable unsubscribe packet.
+     */
+    @NotNull ModifiableUnsubscribePacket getUnsubscribePacket();
+
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/unsubscribe/parameter/UnsubscribeInboundOutput.java
@@ -1,0 +1,4 @@
+package com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter;
+
+public interface UnsubscribeInboundOutput {
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
@@ -37,20 +37,6 @@ public interface ModifiableUnsubscribePacket extends UnsubscribePacket {
     void removeTopics(@NotNull String... topics);
 
     /**
-     * Adds one or more topics to the UNSUBSCRIBE packet.
-     *
-     * @param topics one or more topics to be added.
-     */
-    void addTopics(String... topics);
-
-    /**
-     * Removes one or more topics from the UNSUBSCRIBE packet.
-     *
-     * @param topics one or more topics to be removed.
-     */
-    void removeTopics(String... topics);
-
-    /**
      * Gets the modifiable {@link ModifiableUserProperties} of the UNSUBSCRIBE packet.
      */
     @Override

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
@@ -1,0 +1,26 @@
+package com.hivemq.extension.sdk.api.packets.unsubscribe;
+
+import com.hivemq.extension.sdk.api.packets.general.ModifiableUserProperties;
+import com.hivemq.extension.sdk.api.packets.general.UserProperties;
+
+import java.util.List;
+
+/**
+ * A copy of an {@link UnsubscribePacket} that can be modified for onward delivery.
+ *
+ * @author Robin Atherton
+ */
+public interface ModifiableUnsubscribePacket {
+
+    /**
+     * @return the list of topics to be unsubscribed from.
+     */
+    List<String> getTopics();
+
+    /**
+     * Get the modifiable {@link UserProperties} of the UNSUBSCRIBE packet.
+     *
+     * @return the modifiable user properties.
+     */
+    ModifiableUserProperties getUserProperties();
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
@@ -16,22 +16,25 @@ public interface ModifiableUnsubscribePacket extends UnsubscribePacket {
      * Sets the list of Topics to be unsubscribed from.
      *
      * @param topics the list of Topics to unsubscribe from.
+     * @throws NullPointerException If the passed topic filter is <null>.
      */
-    void setTopics(List<String> topics);
+    void setTopics(@NotNull List<String> topics);
 
     /**
      * Adds one or more topics to the UNSUBSCRIBE packet.
      *
      * @param topics one or more topics to be added.
+     * @throws NullPointerException If the passed topic or topics is <null>.
      */
-    void addTopics(String... topics);
+    void addTopics(@NotNull String... topics);
 
     /**
      * Removes one or more topics from the UNSUBSCRIBE packet.
      *
      * @param topics one or more topics to be removed.
+     * @throws NullPointerException If the passed topic or topics is <null>.
      */
-    void removeTopics(String... topics);
+    void removeTopics(@NotNull String... topics);
 
     /**
      * Gets the modifiable {@link ModifiableUserProperties} of the UNSUBSCRIBE packet.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
@@ -1,7 +1,7 @@
 package com.hivemq.extension.sdk.api.packets.unsubscribe;
 
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.packets.general.ModifiableUserProperties;
-import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 
 import java.util.List;
 
@@ -10,17 +10,25 @@ import java.util.List;
  *
  * @author Robin Atherton
  */
-public interface ModifiableUnsubscribePacket {
+public interface ModifiableUnsubscribePacket extends UnsubscribePacket {
 
     /**
-     * @return the list of topics to be unsubscribed from.
-     */
-    List<String> getTopics();
-
-    /**
-     * Get the modifiable {@link UserProperties} of the UNSUBSCRIBE packet.
+     * Sets the list of Topics to be unsubscribed from.
      *
-     * @return the modifiable user properties.
+     * @param topics the list of Topics to unsubscribe from.
      */
-    ModifiableUserProperties getUserProperties();
+    void setTopics(List<String> topics);
+
+    /**
+     * Gets the modifiable {@link ModifiableUserProperties} of the UNSUBSCRIBE packet.
+     */
+    @Override
+    @NotNull ModifiableUserProperties getUserProperties();
+
+    /**
+     * Used to check if an UNSUBSCRIBE package has been modified.
+     *
+     * @return true if the UNSUBSCRIBE package has been modified, false if it has not.
+     */
+    boolean isModified();
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
@@ -37,6 +37,20 @@ public interface ModifiableUnsubscribePacket extends UnsubscribePacket {
     void removeTopics(@NotNull String... topics);
 
     /**
+     * Adds one or more topics to the UNSUBSCRIBE packet.
+     *
+     * @param topics one or more topics to be added.
+     */
+    void addTopics(String... topics);
+
+    /**
+     * Removes one or more topics from the UNSUBSCRIBE packet.
+     *
+     * @param topics one or more topics to be removed.
+     */
+    void removeTopics(String... topics);
+
+    /**
      * Gets the modifiable {@link ModifiableUserProperties} of the UNSUBSCRIBE packet.
      */
     @Override

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/ModifiableUnsubscribePacket.java
@@ -20,6 +20,20 @@ public interface ModifiableUnsubscribePacket extends UnsubscribePacket {
     void setTopics(List<String> topics);
 
     /**
+     * Adds one or more topics to the UNSUBSCRIBE packet.
+     *
+     * @param topics one or more topics to be added.
+     */
+    void addTopics(String... topics);
+
+    /**
+     * Removes one or more topics from the UNSUBSCRIBE packet.
+     *
+     * @param topics one or more topics to be removed.
+     */
+    void removeTopics(String... topics);
+
+    /**
      * Gets the modifiable {@link ModifiableUserProperties} of the UNSUBSCRIBE packet.
      */
     @Override

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
@@ -1,5 +1,6 @@
 package com.hivemq.extension.sdk.api.packets.unsubscribe;
 
+import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 
@@ -15,9 +16,13 @@ import java.util.List;
 public interface UnsubscribePacket {
 
     /**
+     * Gets the list of topics to be unsubscribed from.
+     *
      * @return the list of topics to be unsubscribed from.
      */
-    @NotNull List<String> getTopics();
+    @Immutable
+    @NotNull
+    List<String> getTopics();
 
     /**
      * Get the unmodifiable {@link UserProperties} of the UNSUBSCRIBE packet.
@@ -25,4 +30,9 @@ public interface UnsubscribePacket {
      * @return user properties.
      */
     UserProperties getUserProperties();
+
+    /**
+     * @return the packet identifier.
+     */
+    int getPacketIdentifier();
 }

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
@@ -21,15 +21,14 @@ public interface UnsubscribePacket {
      * @return the list of topics to be unsubscribed from.
      */
     @Immutable
-    @NotNull
-    List<String> getTopics();
+    @NotNull List<String> getTopicFilters();
 
     /**
      * Get the unmodifiable {@link UserProperties} of the UNSUBSCRIBE packet.
      *
      * @return user properties.
      */
-    UserProperties getUserProperties();
+    @NotNull UserProperties getUserProperties();
 
     /**
      * @return the packet identifier.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
@@ -1,0 +1,28 @@
+package com.hivemq.extension.sdk.api.packets.unsubscribe;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.general.UserProperties;
+
+import java.util.List;
+
+/**
+ * Represents an UNSUBSCRIBE packet.
+ * <p>
+ * Contains all values of an MQTT 5 UNSUBSCRIBE, but will also be used to represent an MQTT 3 SUBSCRIBE.
+ *
+ * @author Robin Atherton
+ */
+public interface UnsubscribePacket {
+
+    /**
+     * @return the list of topics to be unsubscribed from.
+     */
+    @NotNull List<String> getTopics();
+
+    /**
+     * Get the unmodifiable {@link UserProperties} of the UNSUBSCRIBE packet.
+     *
+     * @return user properties.
+     */
+    UserProperties getUserProperties();
+}

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
@@ -21,7 +21,7 @@ public interface UnsubscribePacket {
      * @return the list of topics to be unsubscribed from.
      */
     @Immutable
-    @NotNull List<String> getTopicFilters();
+    @NotNull List<String> getTopics();
 
     /**
      * Get the unmodifiable {@link UserProperties} of the UNSUBSCRIBE packet.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
@@ -21,7 +21,7 @@ public interface UnsubscribePacket {
      * @return the list of topics to be unsubscribed from.
      */
     @Immutable
-    @NotNull List<String> getTopics();
+    @NotNull List<String> getTopicFilters();
 
     /**
      * Get the unmodifiable {@link UserProperties} of the UNSUBSCRIBE packet.

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/unsubscribe/UnsubscribePacket.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * Represents an UNSUBSCRIBE packet.
  * <p>
- * Contains all values of an MQTT 5 UNSUBSCRIBE, but will also be used to represent an MQTT 3 SUBSCRIBE.
+ * Contains all values of an MQTT 5 UNSUBSCRIBE, but will also be used to represent an MQTT 3 UNSUBSCRIBE.
  *
  * @author Robin Atherton
  */
@@ -31,6 +31,8 @@ public interface UnsubscribePacket {
     @NotNull UserProperties getUserProperties();
 
     /**
+     * Gets the packet identifier.
+     *
      * @return the packet identifier.
      */
     int getPacketIdentifier();

--- a/src/main/java/com/hivemq/bootstrap/netty/ChannelDependencies.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/ChannelDependencies.java
@@ -25,10 +25,6 @@ import com.hivemq.codec.encoder.MQTTMessageEncoder;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.RestrictionsConfigurationService;
 import com.hivemq.extensions.handler.*;
-import com.hivemq.extensions.handler.ClientLifecycleEventHandler;
-import com.hivemq.extensions.handler.IncomingPublishHandler;
-import com.hivemq.extensions.handler.IncomingSubscribeHandler;
-import com.hivemq.extensions.handler.PluginInitializerHandler;
 import com.hivemq.logging.EventLog;
 import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.metrics.handler.MetricsInitializer;
@@ -165,6 +161,9 @@ public class ChannelDependencies {
     @NotNull
     private final ConnackOutboundInterceptorHandler connackOutboundInterceptorHandler;
 
+    @NotNull
+    private final UnsubscribeInboundInterceptorHandler unsubscribeInboundInterceptorHandler;
+
     @Inject
     public ChannelDependencies(
             @NotNull final Provider<MetricsInitializer> statisticsInitializer,
@@ -201,7 +200,8 @@ public class ChannelDependencies {
             @NotNull final Provider<PublishMessageExpiryHandler> publishMessageExpiryHandlerProvider,
             @NotNull final PublishOutboundInterceptorHandler publishOutboundInterceptorHandler,
             @NotNull final ConnectInboundInterceptorHandler connectInboundInterceptorHandler,
-            @NotNull final ConnackOutboundInterceptorHandler connackOutboundInterceptorHandler) {
+            @NotNull final ConnackOutboundInterceptorHandler connackOutboundInterceptorHandler,
+            @NotNull final UnsubscribeInboundInterceptorHandler unsubscribeInboundInterceptorHandler) {
 
 
         this.statisticsInitializer = statisticsInitializer;
@@ -239,6 +239,7 @@ public class ChannelDependencies {
         this.publishOutboundInterceptorHandler = publishOutboundInterceptorHandler;
         this.connectInboundInterceptorHandler = connectInboundInterceptorHandler;
         this.connackOutboundInterceptorHandler = connackOutboundInterceptorHandler;
+        this.unsubscribeInboundInterceptorHandler = unsubscribeInboundInterceptorHandler;
     }
 
     @NotNull
@@ -414,5 +415,10 @@ public class ChannelDependencies {
     @NotNull
     public ConnackOutboundInterceptorHandler getConnackOutboundInterceptorHandler() {
         return connackOutboundInterceptorHandler;
+    }
+
+    @NotNull
+    public UnsubscribeInboundInterceptorHandler getUnsubscribeInboundInterceptorHandler() {
+        return unsubscribeInboundInterceptorHandler;
     }
 }

--- a/src/main/java/com/hivemq/bootstrap/netty/ChannelHandlerNames.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/ChannelHandlerNames.java
@@ -83,7 +83,6 @@ public class ChannelHandlerNames {
     public static final String MQTT_AUTH_HANDLER = "mqtt_auth_handler";
     public static final String AUTH_IN_PROGRESS_MESSAGE_HANDLER = "auth_in_progress_message_handler";
 
-    public static final String INBOUND_UNSUBSCRIBE_INTERCEPTOR_HANDLER = "inbound_unsubscribe_interceptor_handler";
 
 
     /* *************
@@ -116,6 +115,8 @@ public class ChannelHandlerNames {
     public static final String PUBLISH_OUTBOUND_INTERCEPTOR_HANDLER = "publish_outbound_interceptor_handler";
     public static final String CONNECT_INBOUND_INTERCEPTOR_HANDLER = "connect_inbound_interceptor_handler";
     public static final String CONNACK_OUTBOUND_INTERCEPTOR_HANDLER = "connack_outbound_interceptor_handler";
+    public static final String UNSUBSCRIBE_INBOUND_INTERCEPTOR_HANDLER = "inbound_unsubscribe_interceptor_handler";
+
 
     /* *************
      *     Misc    *

--- a/src/main/java/com/hivemq/bootstrap/netty/ChannelHandlerNames.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/ChannelHandlerNames.java
@@ -83,6 +83,8 @@ public class ChannelHandlerNames {
     public static final String MQTT_AUTH_HANDLER = "mqtt_auth_handler";
     public static final String AUTH_IN_PROGRESS_MESSAGE_HANDLER = "auth_in_progress_message_handler";
 
+    public static final String INBOUND_UNSUBSCRIBE_INTERCEPTOR_HANDLER = "inbound_unsubscribe_interceptor_handler";
+
 
     /* *************
      *   Outgoing  *

--- a/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
@@ -127,6 +127,10 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
         ch.pipeline().addLast(MQTT_SUBSCRIBE_HANDLER, channelDependencies.getSubscribeHandler());
         ch.pipeline().addLast(MQTT_PUBLISH_USER_EVENT_HANDLER, channelDependencies.getPublishUserEventReceivedHandler());
 
+        ch.pipeline()
+                .addLast(
+                        INBOUND_UNSUBSCRIBE_INTERCEPTOR_HANDLER,
+                        channelDependencies.getUnsubscribeInboundInterceptorHandler());
         ch.pipeline().addLast(MQTT_UNSUBSCRIBE_HANDLER, channelDependencies.getUnsubscribeHandler());
         ch.pipeline().addLast(STATISTICS_INITIALIZER, channelDependencies.getStatisticsInitializer());
 

--- a/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
@@ -91,7 +91,7 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
         ch.pipeline().addLast(CONNECT_INBOUND_INTERCEPTOR_HANDLER, channelDependencies.getConnectInboundInterceptorHandler());
         ch.pipeline()
                 .addLast(
-                        INBOUND_UNSUBSCRIBE_INTERCEPTOR_HANDLER,
+                        UNSUBSCRIBE_INBOUND_INTERCEPTOR_HANDLER,
                         channelDependencies.getUnsubscribeInboundInterceptorHandler());
 
         ch.pipeline().addLast(CLIENT_LIFECYCLE_EVENT_HANDLER, channelDependencies.getClientLifecycleEventHandler());

--- a/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
@@ -89,6 +89,11 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
 
         //Must be after decoder
         ch.pipeline().addLast(CONNECT_INBOUND_INTERCEPTOR_HANDLER, channelDependencies.getConnectInboundInterceptorHandler());
+        ch.pipeline()
+                .addLast(
+                        INBOUND_UNSUBSCRIBE_INTERCEPTOR_HANDLER,
+                        channelDependencies.getUnsubscribeInboundInterceptorHandler());
+
         ch.pipeline().addLast(CLIENT_LIFECYCLE_EVENT_HANDLER, channelDependencies.getClientLifecycleEventHandler());
 
         ch.pipeline().addLast(PUBLISH_OUTBOUND_INTERCEPTOR_HANDLER, channelDependencies.getPublishOutboundInterceptorHandler());
@@ -127,10 +132,6 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
         ch.pipeline().addLast(MQTT_SUBSCRIBE_HANDLER, channelDependencies.getSubscribeHandler());
         ch.pipeline().addLast(MQTT_PUBLISH_USER_EVENT_HANDLER, channelDependencies.getPublishUserEventReceivedHandler());
 
-        ch.pipeline()
-                .addLast(
-                        INBOUND_UNSUBSCRIBE_INTERCEPTOR_HANDLER,
-                        channelDependencies.getUnsubscribeInboundInterceptorHandler());
         ch.pipeline().addLast(MQTT_UNSUBSCRIBE_HANDLER, channelDependencies.getUnsubscribeHandler());
         ch.pipeline().addLast(STATISTICS_INITIALIZER, channelDependencies.getStatisticsInitializer());
 

--- a/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
@@ -20,8 +20,9 @@ import com.hivemq.annotations.Immutable;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
-import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.auth.ModifiableDefaultPermissions;
 import com.hivemq.extensions.HiveMQExtension;
 import com.hivemq.extensions.HiveMQExtensions;
@@ -69,6 +70,10 @@ public class ClientContextImpl {
         addInterceptor(interceptor);
     }
 
+    public void addUnsubscribeInboundInterceptor(@NotNull final UnsubscribeInboundInterceptor interceptor) {
+        addInterceptor(interceptor);
+    }
+
     public void removePublishInboundInterceptor(@NotNull final PublishInboundInterceptor interceptor) {
         removeInterceptor(interceptor);
     }
@@ -82,6 +87,10 @@ public class ClientContextImpl {
     }
 
     public void removeSubscribeInboundInterceptor(@NotNull final SubscribeInboundInterceptor interceptor) {
+        removeInterceptor(interceptor);
+    }
+
+    public void removeUnsubscribeInboundInterceptor(@NotNull final UnsubscribeInboundInterceptor interceptor) {
         removeInterceptor(interceptor);
     }
 
@@ -165,6 +174,28 @@ public class ClientContextImpl {
                 .filter(this::hasPluginForClassloader)
                 .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
                 .map(interceptor -> (SubscribeInboundInterceptor) interceptor)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @NotNull
+    @Immutable
+    public List<UnsubscribeInboundInterceptor> getUnsubscribeInboundInterceptorsForPlugin(
+            @NotNull final IsolatedPluginClassloader pluginClassloader) {
+        return interceptorList.stream()
+                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
+                .filter(interceptor -> interceptor instanceof UnsubscribeInboundInterceptor)
+                .map(interceptor -> (UnsubscribeInboundInterceptor) interceptor)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @NotNull
+    @Immutable
+    public List<UnsubscribeInboundInterceptor> getUnsubscribeInboundInterceptors() {
+        return interceptorList.stream()
+                .filter(interceptor -> interceptor instanceof UnsubscribeInboundInterceptor)
+                .filter(this::hasPluginForClassloader)
+                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
+                .map(interceptor -> (UnsubscribeInboundInterceptor) interceptor)
                 .collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
@@ -67,8 +67,7 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     }
 
     @Override
-    public void addUnsubscribeInboundInterceptor(
-            final @NotNull UnsubscribeInboundInterceptor interceptor) {
+    public void addUnsubscribeInboundInterceptor(final @NotNull UnsubscribeInboundInterceptor interceptor) {
         clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
@@ -88,8 +87,7 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     }
 
     @Override
-    public void removeUnsubscribeInboundInterceptor(
-            final @NotNull UnsubscribeInboundInterceptor interceptor) {
+    public void removeUnsubscribeInboundInterceptor(final @NotNull UnsubscribeInboundInterceptor interceptor) {
         clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 

--- a/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
@@ -23,6 +23,7 @@ import com.hivemq.extension.sdk.api.interceptor.Interceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.publish.PublishOutboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.subscribe.SubscribeInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.packets.auth.ModifiableDefaultPermissions;
 import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
 import com.hivemq.extensions.executor.task.AbstractOutput;
@@ -43,8 +44,9 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     @NotNull
     private final ClientContextImpl clientContext;
 
-    public ClientContextPluginImpl(final @NotNull IsolatedPluginClassloader pluginClassloader,
-                                   final @NotNull ClientContextImpl clientContext) {
+    public ClientContextPluginImpl(
+            final @NotNull IsolatedPluginClassloader pluginClassloader,
+            final @NotNull ClientContextImpl clientContext) {
         this.pluginClassloader = pluginClassloader;
         this.clientContext = clientContext;
     }
@@ -65,6 +67,12 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
     }
 
     @Override
+    public void addUnsubscribeInboundInterceptor(
+            final @NotNull UnsubscribeInboundInterceptor interceptor) {
+        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+    }
+
+    @Override
     public void removePublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
         clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
@@ -76,6 +84,12 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
 
     @Override
     public void removeSubscribeInboundInterceptor(final @NotNull SubscribeInboundInterceptor interceptor) {
+        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+    }
+
+    @Override
+    public void removeUnsubscribeInboundInterceptor(
+            final @NotNull UnsubscribeInboundInterceptor interceptor) {
         clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 

--- a/src/main/java/com/hivemq/extensions/executor/task/AbstractSimpleAsyncOutput.java
+++ b/src/main/java/com/hivemq/extensions/executor/task/AbstractSimpleAsyncOutput.java
@@ -1,0 +1,78 @@
+package com.hivemq.extensions.executor.task;
+
+import com.google.common.util.concurrent.SettableFuture;
+import com.hivemq.annotations.NotNull;
+import com.hivemq.annotations.Nullable;
+import com.hivemq.extension.sdk.api.async.Async;
+import com.hivemq.extension.sdk.api.async.SimpleAsyncOutput;
+import com.hivemq.extension.sdk.api.async.TimeoutFallback;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author Yannick Weber
+ */
+public class AbstractSimpleAsyncOutput<T> implements PluginTaskOutput, SimpleAsyncOutput<T> {
+
+    protected final @NotNull PluginOutPutAsyncer asyncer;
+
+    private final @NotNull AtomicBoolean async = new AtomicBoolean(false);
+    private final @NotNull AtomicBoolean called = new AtomicBoolean(false);
+    private final @NotNull AtomicBoolean timedOut = new AtomicBoolean(false);
+    private final @NotNull SettableFuture<Boolean> asyncFuture = SettableFuture.create();
+
+    public AbstractSimpleAsyncOutput(final @NotNull PluginOutPutAsyncer asyncer) {
+        this.asyncer = asyncer;
+    }
+
+    @Override
+    public @NotNull Async<T> async(final @NotNull Duration timeout) {
+        checkCalled();
+        //noinspection unchecked: this cast is safe since this implements AsyncOutput and PluginTaskOutput
+        return (Async<T>) asyncer.asyncify(this, timeout);
+    }
+
+    private void checkCalled() {
+        if (!called.compareAndSet(false, true)) {
+            throw new UnsupportedOperationException("async must not be called more than once");
+        }
+    }
+
+    @Override
+    public boolean isAsync() {
+        return async.get();
+    }
+
+    @Override
+    public void markAsAsync() {
+        async.set(true);
+    }
+
+    @Override
+    public boolean isTimedOut() {
+        return timedOut.get();
+    }
+
+    @Override
+    public void markAsTimedOut() {
+        timedOut.set(true);
+    }
+
+    public void resetAsyncStatus() {
+        timedOut.set(false);
+        async.set(false);
+        called.set(false);
+    }
+
+    @Override
+    public @Nullable SettableFuture<Boolean> getAsyncFuture() {
+        return asyncFuture;
+    }
+
+    @Override
+    public @NotNull TimeoutFallback getTimeoutFallback() {
+        return TimeoutFallback.FAILURE;
+    }
+}

--- a/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
@@ -1,8 +1,234 @@
 package com.hivemq.extensions.handler;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import com.hivemq.annotations.Nullable;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
+import com.hivemq.extensions.HiveMQExtension;
+import com.hivemq.extensions.HiveMQExtensions;
+import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
+import com.hivemq.extensions.client.ClientContextImpl;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.task.PluginInOutTask;
+import com.hivemq.extensions.executor.task.PluginInOutTaskContext;
+import com.hivemq.extensions.interceptor.unsubscribe.parameter.UnsubscribeInboundInputImpl;
+import com.hivemq.extensions.interceptor.unsubscribe.parameter.UnsubscribeInboundOutputImpl;
+import com.hivemq.extensions.packets.unsubscribe.UnsubscribePacketImpl;
+import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * @author Robin Atherton
  */
-public class UnsubscribeInboundInterceptorHandler {
+public class UnsubscribeInboundInterceptorHandler extends ChannelInboundHandlerAdapter {
 
+    private static final Logger log = LoggerFactory.getLogger(UnsubscribeInboundInterceptorHandler.class);
+
+    private final @NotNull FullConfigurationService configurationService;
+
+    private final @NotNull PluginOutPutAsyncer asyncer;
+
+    private final @NotNull HiveMQExtensions hiveMQExtensions;
+
+    private final @NotNull PluginTaskExecutorService pluginTaskExecutorService;
+
+    @Inject
+    public UnsubscribeInboundInterceptorHandler(
+            @NotNull final FullConfigurationService configurationService,
+            @NotNull final PluginOutPutAsyncer asyncer,
+            @NotNull final HiveMQExtensions hiveMQExtensions,
+            @NotNull final PluginTaskExecutorService pluginTaskExecutorService) {
+        this.configurationService = configurationService;
+        this.asyncer = asyncer;
+        this.hiveMQExtensions = hiveMQExtensions;
+        this.pluginTaskExecutorService = pluginTaskExecutorService;
+    }
+
+    @Override
+    public void channelRead(final @NotNull ChannelHandlerContext ctx, final Object msg) throws Exception {
+        if (!(msg instanceof UNSUBSCRIBE)) {
+            super.channelRead(ctx, msg);
+            return;
+        }
+
+        final UNSUBSCRIBE unsubscribe = (UNSUBSCRIBE) msg;
+
+        final Channel channel = ctx.channel();
+        if (!channel.isActive()) {
+            return;
+        }
+
+        final String clientId = channel.attr(ChannelAttributes.CLIENT_ID).get();
+        if (clientId == null) {
+            return;
+        }
+
+        final ClientContextImpl clientContext = channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).get();
+        if (clientContext == null || clientContext.getUnsubscribeInboundInterceptors().isEmpty()) {
+            super.channelRead(ctx, msg);
+            return;
+        }
+
+        final List<UnsubscribeInboundInterceptor> unsubscribeInboundInterceptors =
+                clientContext.getUnsubscribeInboundInterceptors();
+
+        final UnsubscribeInboundInputImpl input =
+                new UnsubscribeInboundInputImpl(new UnsubscribePacketImpl(unsubscribe), clientId, channel);
+
+        final UnsubscribeInboundOutputImpl output =
+                new UnsubscribeInboundOutputImpl(asyncer, configurationService, unsubscribe);
+
+        final SettableFuture<Void> interceptorFuture = SettableFuture.create();
+        final UnsubscribeInboundInterceptorContext interceptorContext =
+                new UnsubscribeInboundInterceptorContext(UnsubscribeInboundInterceptorTask.class, clientId, input,
+                        output, interceptorFuture, unsubscribeInboundInterceptors.size());
+
+        for (final UnsubscribeInboundInterceptor interceptor : unsubscribeInboundInterceptors) {
+            if (interceptorFuture.isDone()) {
+                break;
+            }
+
+            final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
+                    (IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
+            if (extension == null) {
+                interceptorContext.increment();
+                continue;
+            }
+
+            final UnsubscribeInboundInterceptorTask interceptorTask =
+                    new UnsubscribeInboundInterceptorTask(interceptor, interceptorFuture, extension.getId());
+            pluginTaskExecutorService.handlePluginInOutTaskExecution(
+                    interceptorContext, input, output, interceptorTask);
+        }
+
+        final UnsubscribeInterceptorFutureCallback callback =
+                new UnsubscribeInterceptorFutureCallback(ctx, output, unsubscribe);
+        Futures.addCallback(interceptorFuture, callback, ctx.executor());
+
+    }
+
+    private static class UnsubscribeInboundInterceptorContext
+            extends PluginInOutTaskContext<UnsubscribeInboundOutputImpl> {
+
+        private final @NotNull UnsubscribeInboundInputImpl input;
+        private final @NotNull UnsubscribeInboundOutputImpl output;
+        private final @NotNull SettableFuture<Void> interceptorFuture;
+        private final int intereceptorCount;
+        private final @NotNull AtomicInteger counter;
+
+        UnsubscribeInboundInterceptorContext(
+                @NotNull final Class<?> taskClazz,
+                @NotNull final String identifier,
+                @NotNull final UnsubscribeInboundInputImpl input,
+                @NotNull final UnsubscribeInboundOutputImpl output,
+                @NotNull final SettableFuture<Void> interceptorFuture, final int intereceptorCount) {
+            super(taskClazz, identifier);
+            this.input = input;
+            this.output = output;
+            this.interceptorFuture = interceptorFuture;
+            this.intereceptorCount = intereceptorCount;
+            this.counter = new AtomicInteger(0);
+        }
+
+        @Override
+        public void pluginPost(
+                final @NotNull UnsubscribeInboundOutputImpl pluginOutput) {
+            if (pluginOutput.getUnsubscribePacket().isModified()) {
+                input.updateUnsubscribe(pluginOutput.getUnsubscribePacket());
+                output.update(pluginOutput.getUnsubscribePacket());
+            }
+            increment();
+        }
+
+        public void increment() {
+            if (counter.incrementAndGet() == intereceptorCount) {
+                interceptorFuture.set(null);
+            }
+        }
+    }
+
+    private static class UnsubscribeInboundInterceptorTask
+            implements PluginInOutTask<UnsubscribeInboundInputImpl, UnsubscribeInboundOutputImpl> {
+
+        private final @NotNull UnsubscribeInboundInterceptor interceptor;
+        private final @NotNull SettableFuture<Void> interceptorFuture;
+        private final @NotNull String extensionId;
+
+        UnsubscribeInboundInterceptorTask(
+                @NotNull final UnsubscribeInboundInterceptor interceptor,
+                @NotNull final SettableFuture<Void> interceptorFuture,
+                @NotNull final String extensionId) {
+            this.interceptor = interceptor;
+            this.interceptorFuture = interceptorFuture;
+            this.extensionId = extensionId;
+        }
+
+        @Override
+        public UnsubscribeInboundOutputImpl apply(
+                final @NotNull UnsubscribeInboundInputImpl input,
+                final @NotNull UnsubscribeInboundOutputImpl output) {
+            try {
+                if (!interceptorFuture.isDone()) {
+                    interceptor.onInboundUnsubscribe(input, output);
+                }
+            } catch (final Throwable e) {
+                log.warn(
+                        "Uncaught exception was thrown from extension with id \"{}\" on inbound unsubscribe request interception." +
+                                "Extensions are responsible for their own exception handling.", extensionId);
+                final UNSUBSCRIBE unsubscribe = UNSUBSCRIBE.createUnsubscribeFrom(input.getUnsubscribePacket());
+                output.update(unsubscribe);
+            }
+            return output;
+        }
+
+        @Override
+        public @NotNull ClassLoader getPluginClassLoader() {
+            return interceptor.getClass().getClassLoader();
+        }
+    }
+
+    private static class UnsubscribeInterceptorFutureCallback implements FutureCallback<Void> {
+
+        private final UnsubscribeInboundOutputImpl output;
+        private final UNSUBSCRIBE unsubscribe;
+        private final @NotNull ChannelHandlerContext ctx;
+
+        UnsubscribeInterceptorFutureCallback(
+                final @NotNull ChannelHandlerContext ctx,
+                final @NotNull UnsubscribeInboundOutputImpl output,
+                final @NotNull UNSUBSCRIBE unsubscribe) {
+            this.output = output;
+            this.unsubscribe = unsubscribe;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void onSuccess(@Nullable final Void result) {
+            try {
+                final UNSUBSCRIBE finalUnsubscribe = UNSUBSCRIBE.createUnsubscribeFrom(output.getUnsubscribePacket());
+                ctx.fireChannelRead(finalUnsubscribe);
+            } catch (final Exception e) {
+                log.error("Exception while modifying an intercepted UNSUBSCRIBE message.", e);
+                ctx.fireChannelRead(unsubscribe);
+            }
+        }
+
+        @Override
+        public void onFailure(final Throwable t) {
+            ctx.channel().close();
+        }
+    }
 }

--- a/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
@@ -185,7 +185,7 @@ public class UnsubscribeInboundInterceptorHandler extends ChannelInboundHandlerA
                     interceptor.onInboundUnsubscribe(input, output);
                 }
             } catch (final Throwable e) {
-                log.warn(
+                log.debug(
                         "Uncaught exception was thrown from extension with id \"{}\" on inbound unsubscribe request interception." +
                                 "Extensions are responsible for their own exception handling.", extensionId);
                 final UNSUBSCRIBE unsubscribe = UNSUBSCRIBE.createUnsubscribeFrom(input.getUnsubscribePacket());

--- a/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
@@ -198,6 +198,7 @@ public class UnsubscribeInboundInterceptorHandler extends ChannelInboundHandlerA
                 log.debug(
                         "Uncaught exception was thrown from extension with id \"{}\" on inbound unsubscribe request interception." +
                                 "Extensions are responsible for their own exception handling.", extensionId);
+                log.debug("Original Exception:" + e);
                 final UNSUBSCRIBE unsubscribe = UNSUBSCRIBE.createUnsubscribeFrom(input.getUnsubscribePacket());
                 output.update(unsubscribe);
             }
@@ -220,9 +221,9 @@ public class UnsubscribeInboundInterceptorHandler extends ChannelInboundHandlerA
                 final @NotNull ChannelHandlerContext ctx,
                 final @NotNull UnsubscribeInboundOutputImpl output,
                 final @NotNull UNSUBSCRIBE unsubscribe) {
+            this.ctx = ctx;
             this.output = output;
             this.unsubscribe = unsubscribe;
-            this.ctx = ctx;
         }
 
         @Override

--- a/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
@@ -21,18 +21,22 @@ import com.hivemq.extensions.packets.unsubscribe.UnsubscribePacketImpl;
 import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
 import com.hivemq.util.ChannelAttributes;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Robin Atherton
  */
+@ChannelHandler.Sharable
+@Singleton
 public class UnsubscribeInboundInterceptorHandler extends ChannelInboundHandlerAdapter {
 
     private static final Logger log = LoggerFactory.getLogger(UnsubscribeInboundInterceptorHandler.class);

--- a/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
@@ -1,0 +1,8 @@
+package com.hivemq.extensions.handler;
+
+/**
+ * @author Robin Atherton
+ */
+public class UnsubscribeInboundInterceptorHandler {
+
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImpl.java
@@ -4,7 +4,6 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
 import com.hivemq.extension.sdk.api.client.parameter.ConnectionInformation;
 import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundInput;
-import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
 import com.hivemq.extension.sdk.api.packets.unsubscribe.UnsubscribePacket;
 import com.hivemq.extensions.PluginInformationUtil;
 import com.hivemq.extensions.executor.task.PluginTaskInput;
@@ -52,7 +51,7 @@ public class UnsubscribeInboundInputImpl implements Supplier<UnsubscribeInboundI
         return this;
     }
 
-    public void updateUnsubscribe(final @NotNull ModifiableUnsubscribePacket unsubscribePacket) {
+    public void updateUnsubscribe(final @NotNull UnsubscribePacket unsubscribePacket) {
         this.unsubscribePacket = new UnsubscribePacketImpl(unsubscribePacket);
     }
 }

--- a/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImpl.java
@@ -1,0 +1,58 @@
+package com.hivemq.extensions.interceptor.unsubscribe.parameter;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
+import com.hivemq.extension.sdk.api.client.parameter.ConnectionInformation;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundInput;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.UnsubscribePacket;
+import com.hivemq.extensions.PluginInformationUtil;
+import com.hivemq.extensions.executor.task.PluginTaskInput;
+import com.hivemq.extensions.packets.unsubscribe.UnsubscribePacketImpl;
+import io.netty.channel.Channel;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Robin Atherton
+ */
+public class UnsubscribeInboundInputImpl implements Supplier<UnsubscribeInboundInputImpl>, UnsubscribeInboundInput,
+        PluginTaskInput {
+
+    private final @NotNull ConnectionInformation connectionInformation;
+    private final @NotNull ClientInformation clientInformation;
+    private @NotNull UnsubscribePacket unsubscribePacket;
+
+    public UnsubscribeInboundInputImpl(
+            final @NotNull UnsubscribePacket unsubscribePacket,
+            final @NotNull String clientId,
+            final @NotNull Channel channel) {
+        this.unsubscribePacket = unsubscribePacket;
+        this.connectionInformation = PluginInformationUtil.getAndSetConnectionInformation(channel);
+        this.clientInformation = PluginInformationUtil.getAndSetClientInformation(channel, clientId);
+    }
+
+    @Override
+    public @NotNull ConnectionInformation getConnectionInformation() {
+        return connectionInformation;
+    }
+
+    @Override
+    public @NotNull ClientInformation getClientInformation() {
+        return clientInformation;
+    }
+
+    @Override
+    public @NotNull UnsubscribePacket getUnsubscribePacket() {
+        return unsubscribePacket;
+    }
+
+    @Override
+    public @NotNull UnsubscribeInboundInputImpl get() {
+        return this;
+    }
+
+    public void updateUnsubscribe(final @NotNull ModifiableUnsubscribePacket unsubscribePacket) {
+        this.unsubscribePacket = new UnsubscribePacketImpl(unsubscribePacket);
+    }
+}

--- a/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundOutputImpl.java
@@ -35,13 +35,10 @@ public class UnsubscribeInboundOutputImpl extends AbstractAsyncOutput<Unsubscrib
     }
 
     @Override
-    public UnsubscribeInboundOutputImpl get() {
+    public @NotNull UnsubscribeInboundOutputImpl get() {
         return this;
     }
 
-    public void update(final @NotNull ModifiableUnsubscribePacketImpl unsubscribePacket) {
-        this.unsubscribePacket = unsubscribePacket;
-    }
 
     public void update(final @NotNull UNSUBSCRIBE unsubscribe) {
         this.unsubscribePacket = new ModifiableUnsubscribePacketImpl(configurationService, unsubscribe);

--- a/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundOutputImpl.java
@@ -1,7 +1,51 @@
 package com.hivemq.extensions.interceptor.unsubscribe.parameter;
 
+import com.hivemq.annotations.NotNull;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundOutput;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.task.AbstractAsyncOutput;
+import com.hivemq.extensions.executor.task.PluginTaskOutput;
+import com.hivemq.extensions.packets.unsubscribe.ModifiableUnsubscribePacketImpl;
+import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
+
+import java.util.function.Supplier;
+
 /**
  * @author Robin Atherton
  */
-public class UnsubscribeInboundOutputImpl {
+public class UnsubscribeInboundOutputImpl extends AbstractAsyncOutput<UnsubscribeInboundOutput>
+        implements UnsubscribeInboundOutput, PluginTaskOutput, Supplier<UnsubscribeInboundOutputImpl> {
+
+    private final @NotNull FullConfigurationService configurationService;
+    private @NotNull ModifiableUnsubscribePacketImpl unsubscribePacket;
+
+    public UnsubscribeInboundOutputImpl(
+            final @NotNull PluginOutPutAsyncer asyncer,
+            final @NotNull FullConfigurationService configurationService,
+            final @NotNull UNSUBSCRIBE unsubscribe) {
+        super(asyncer);
+        this.configurationService = configurationService;
+        this.unsubscribePacket = new ModifiableUnsubscribePacketImpl(configurationService, unsubscribe);
+    }
+
+    @Override
+    public @NotNull ModifiableUnsubscribePacketImpl getUnsubscribePacket() {
+        return this.unsubscribePacket;
+    }
+
+    @Override
+    public UnsubscribeInboundOutputImpl get() {
+        return this;
+    }
+
+    public void update(final @NotNull ModifiableUnsubscribePacketImpl unsubscribePacket) {
+        this.unsubscribePacket = unsubscribePacket;
+    }
+
+    public void update(final @NotNull UNSUBSCRIBE unsubscribe) {
+        this.unsubscribePacket = new ModifiableUnsubscribePacketImpl(configurationService, unsubscribe);
+    }
+
+
 }

--- a/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundOutputImpl.java
@@ -1,0 +1,7 @@
+package com.hivemq.extensions.interceptor.unsubscribe.parameter;
+
+/**
+ * @author Robin Atherton
+ */
+public class UnsubscribeInboundOutputImpl {
+}

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
@@ -1,0 +1,48 @@
+package com.hivemq.extensions.packets.unsubscribe;
+
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.general.ModifiableUserProperties;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
+import com.hivemq.extensions.packets.general.ModifiableUserPropertiesImpl;
+import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
+
+import java.util.List;
+
+/**
+ * @author Robin Atherton
+ */
+public class ModifiableUnsubscribePacketImpl implements ModifiableUnsubscribePacket {
+
+    private final @NotNull ModifiableUserPropertiesImpl userProperties;
+    private final @NotNull List<String> topics;
+
+    private final boolean modified = false;
+
+    public ModifiableUnsubscribePacketImpl(
+            final @NotNull FullConfigurationService fullConfigurationService, final @NotNull
+            UNSUBSCRIBE unsubscribe) {
+
+        this.topics = unsubscribe.getTopics();
+
+        this.userProperties = new ModifiableUserPropertiesImpl(
+                unsubscribe.getUserProperties().getPluginUserProperties(),
+                fullConfigurationService.securityConfiguration().validateUTF8());
+    }
+
+    @Override
+    public List<String> getTopics() {
+        return this.topics;
+    }
+
+    @Override
+    public ModifiableUserProperties getUserProperties() {
+        return this.userProperties;
+    }
+
+    public synchronized boolean isModified() {
+        //TODO
+        return true;
+    }
+
+}

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
@@ -15,9 +15,10 @@ import java.util.List;
 public class ModifiableUnsubscribePacketImpl implements ModifiableUnsubscribePacket {
 
     private final @NotNull ModifiableUserPropertiesImpl userProperties;
-    private final @NotNull List<String> topics;
+    private @NotNull List<String> topics;
+    private final int packetIdentifier;
 
-    private final boolean modified = false;
+    private boolean modified = false;
 
     public ModifiableUnsubscribePacketImpl(
             final @NotNull FullConfigurationService fullConfigurationService, final @NotNull
@@ -28,6 +29,9 @@ public class ModifiableUnsubscribePacketImpl implements ModifiableUnsubscribePac
         this.userProperties = new ModifiableUserPropertiesImpl(
                 unsubscribe.getUserProperties().getPluginUserProperties(),
                 fullConfigurationService.securityConfiguration().validateUTF8());
+
+        this.packetIdentifier = unsubscribe.getPacketIdentifier();
+
     }
 
     @Override
@@ -36,13 +40,23 @@ public class ModifiableUnsubscribePacketImpl implements ModifiableUnsubscribePac
     }
 
     @Override
+    public void setTopics(final List<String> topics) {
+        this.topics = topics;
+        this.modified = true;
+    }
+
+    @Override
     public ModifiableUserProperties getUserProperties() {
         return this.userProperties;
     }
 
-    public synchronized boolean isModified() {
-        //TODO
-        return true;
+    @Override
+    public int getPacketIdentifier() {
+        return this.packetIdentifier;
+    }
+
+    public boolean isModified() {
+        return modified;
     }
 
 }

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
@@ -48,20 +48,23 @@ public class ModifiableUnsubscribePacketImpl implements ModifiableUnsubscribePac
 
     @Override
     public void addTopics(final String... topics) {
-        if (topics.length == 1) {
+        if (topics.length >= 1) {
             this.topics.add(Arrays.toString(topics));
         } else {
             this.topics.addAll(Arrays.asList(topics));
         }
+        this.modified = true;
+
     }
 
     @Override
     public void removeTopics(final String... topics) {
-        if (topics.length == 1) {
+        if (topics.length >= 1) {
             this.topics.remove(Arrays.toString(topics));
         } else {
             this.topics.removeAll(Arrays.asList(topics));
         }
+        this.modified = true;
     }
 
     @Override

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
@@ -34,7 +34,7 @@ public class ModifiableUnsubscribePacketImpl implements ModifiableUnsubscribePac
     }
 
     @Override
-    public ImmutableList<String> getTopics() {
+    public ImmutableList<String> getTopicFilters() {
         return this.topics;
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
@@ -34,7 +34,7 @@ public class ModifiableUnsubscribePacketImpl implements ModifiableUnsubscribePac
     }
 
     @Override
-    public ImmutableList<String> getTopicFilters() {
+    public ImmutableList<String> getTopics() {
         return this.topics;
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImpl.java
@@ -7,6 +7,7 @@ import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePac
 import com.hivemq.extensions.packets.general.ModifiableUserPropertiesImpl;
 import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -43,6 +44,24 @@ public class ModifiableUnsubscribePacketImpl implements ModifiableUnsubscribePac
     public void setTopics(final List<String> topics) {
         this.topics = topics;
         this.modified = true;
+    }
+
+    @Override
+    public void addTopics(final String... topics) {
+        if (topics.length == 1) {
+            this.topics.add(Arrays.toString(topics));
+        } else {
+            this.topics.addAll(Arrays.asList(topics));
+        }
+    }
+
+    @Override
+    public void removeTopics(final String... topics) {
+        if (topics.length == 1) {
+            this.topics.remove(Arrays.toString(topics));
+        } else {
+            this.topics.removeAll(Arrays.asList(topics));
+        }
     }
 
     @Override

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
@@ -24,13 +24,13 @@ public class UnsubscribePacketImpl implements UnsubscribePacket {
     }
 
     public UnsubscribePacketImpl(final ModifiableUnsubscribePacket unsubscribe) {
-        this.topics = unsubscribe.getTopics();
+        this.topics = unsubscribe.getTopicFilters();
         this.userProperties = unsubscribe.getUserProperties();
         this.packetIdentifier = unsubscribe.getPacketIdentifier();
     }
 
     @Override
-    public @NotNull List<String> getTopics() {
+    public @NotNull List<String> getTopicFilters() {
         return this.topics;
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
@@ -1,0 +1,39 @@
+package com.hivemq.extensions.packets.unsubscribe;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.general.UserProperties;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.UnsubscribePacket;
+import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
+
+import java.util.List;
+
+/**
+ * @author Robin Atherton
+ */
+public class UnsubscribePacketImpl implements UnsubscribePacket {
+
+    private final @NotNull List<String> topics;
+    private final @NotNull UserProperties userProperties;
+
+    public UnsubscribePacketImpl(final UNSUBSCRIBE unsubscribe) {
+        this.topics = unsubscribe.getTopics();
+        this.userProperties = unsubscribe.getUserProperties().getPluginUserProperties();
+    }
+
+    public UnsubscribePacketImpl(final ModifiableUnsubscribePacket unsubscribe) {
+        this.topics = unsubscribe.getTopics();
+        this.userProperties = unsubscribe.getUserProperties();
+    }
+
+    @Override
+    public @NotNull List<String> getTopics() {
+        return this.topics;
+    }
+
+    @Override
+    public UserProperties getUserProperties() {
+        return this.userProperties;
+    }
+
+}

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
@@ -24,13 +24,13 @@ public class UnsubscribePacketImpl implements UnsubscribePacket {
     }
 
     public UnsubscribePacketImpl(final ModifiableUnsubscribePacket unsubscribe) {
-        this.topics = unsubscribe.getTopicFilters();
+        this.topics = unsubscribe.getTopics();
         this.userProperties = unsubscribe.getUserProperties();
         this.packetIdentifier = unsubscribe.getPacketIdentifier();
     }
 
     @Override
-    public @NotNull List<String> getTopicFilters() {
+    public @NotNull List<String> getTopics() {
         return this.topics;
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
@@ -2,7 +2,6 @@ package com.hivemq.extensions.packets.unsubscribe;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
-import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
 import com.hivemq.extension.sdk.api.packets.unsubscribe.UnsubscribePacket;
 import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
 
@@ -23,7 +22,7 @@ public class UnsubscribePacketImpl implements UnsubscribePacket {
         this.packetIdentifier = unsubscribe.getPacketIdentifier();
     }
 
-    public UnsubscribePacketImpl(final ModifiableUnsubscribePacket unsubscribe) {
+    public UnsubscribePacketImpl(final UnsubscribePacket unsubscribe) {
         this.topics = unsubscribe.getTopics();
         this.userProperties = unsubscribe.getUserProperties();
         this.packetIdentifier = unsubscribe.getPacketIdentifier();
@@ -35,7 +34,7 @@ public class UnsubscribePacketImpl implements UnsubscribePacket {
     }
 
     @Override
-    public UserProperties getUserProperties() {
+    public @NotNull UserProperties getUserProperties() {
         return this.userProperties;
     }
 

--- a/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/unsubscribe/UnsubscribePacketImpl.java
@@ -15,15 +15,18 @@ public class UnsubscribePacketImpl implements UnsubscribePacket {
 
     private final @NotNull List<String> topics;
     private final @NotNull UserProperties userProperties;
+    private final int packetIdentifier;
 
     public UnsubscribePacketImpl(final UNSUBSCRIBE unsubscribe) {
         this.topics = unsubscribe.getTopics();
         this.userProperties = unsubscribe.getUserProperties().getPluginUserProperties();
+        this.packetIdentifier = unsubscribe.getPacketIdentifier();
     }
 
     public UnsubscribePacketImpl(final ModifiableUnsubscribePacket unsubscribe) {
         this.topics = unsubscribe.getTopics();
         this.userProperties = unsubscribe.getUserProperties();
+        this.packetIdentifier = unsubscribe.getPacketIdentifier();
     }
 
     @Override
@@ -34,6 +37,11 @@ public class UnsubscribePacketImpl implements UnsubscribePacket {
     @Override
     public UserProperties getUserProperties() {
         return this.userProperties;
+    }
+
+    @Override
+    public int getPacketIdentifier() {
+        return this.packetIdentifier;
     }
 
 }

--- a/src/main/java/com/hivemq/mqtt/message/unsubscribe/UNSUBSCRIBE.java
+++ b/src/main/java/com/hivemq/mqtt/message/unsubscribe/UNSUBSCRIBE.java
@@ -76,7 +76,7 @@ public class UNSUBSCRIBE extends MqttMessageWithUserProperties implements Mqtt3U
         }
         final Mqtt5UserProperties mqtt5UserProperties = Mqtt5UserProperties.of(userPropertyBuilder.build());
 
-        final ImmutableList<String> topics = ImmutableList.copyOf(packet.getTopics());
+        final ImmutableList<String> topics = ImmutableList.copyOf(packet.getTopicFilters());
 
         return new UNSUBSCRIBE(topics, packet.getPacketIdentifier(), mqtt5UserProperties);
     }

--- a/src/main/java/com/hivemq/mqtt/message/unsubscribe/UNSUBSCRIBE.java
+++ b/src/main/java/com/hivemq/mqtt/message/unsubscribe/UNSUBSCRIBE.java
@@ -20,9 +20,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.hivemq.annotations.Immutable;
 import com.hivemq.annotations.NotNull;
+import com.hivemq.extension.sdk.api.packets.general.UserProperty;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.UnsubscribePacket;
 import com.hivemq.mqtt.message.MessageType;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttMessageWithUserProperties;
+import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 
 import java.util.List;
 
@@ -63,6 +66,19 @@ public class UNSUBSCRIBE extends MqttMessageWithUserProperties implements Mqtt3U
 
         this.topics = topicFilters;
         setPacketIdentifier(packetIdentifier);
+    }
+
+    public static UNSUBSCRIBE createUnsubscribeFrom(final @NotNull UnsubscribePacket packet) {
+
+        final ImmutableList.Builder<MqttUserProperty> userPropertyBuilder = ImmutableList.builder();
+        for (final UserProperty userProperty : packet.getUserProperties().asList()) {
+            userPropertyBuilder.add(new MqttUserProperty(userProperty.getName(), userProperty.getValue()));
+        }
+        final Mqtt5UserProperties mqtt5UserProperties = Mqtt5UserProperties.of(userPropertyBuilder.build());
+
+        final ImmutableList<String> topics = ImmutableList.copyOf(packet.getTopics());
+
+        return new UNSUBSCRIBE(topics, packet.getPacketIdentifier(), mqtt5UserProperties);
     }
 
     /**

--- a/src/main/java/com/hivemq/mqtt/message/unsubscribe/UNSUBSCRIBE.java
+++ b/src/main/java/com/hivemq/mqtt/message/unsubscribe/UNSUBSCRIBE.java
@@ -76,7 +76,7 @@ public class UNSUBSCRIBE extends MqttMessageWithUserProperties implements Mqtt3U
         }
         final Mqtt5UserProperties mqtt5UserProperties = Mqtt5UserProperties.of(userPropertyBuilder.build());
 
-        final ImmutableList<String> topics = ImmutableList.copyOf(packet.getTopicFilters());
+        final ImmutableList<String> topics = ImmutableList.copyOf(packet.getTopics());
 
         return new UNSUBSCRIBE(topics, packet.getPacketIdentifier(), mqtt5UserProperties);
     }

--- a/src/main/java/com/hivemq/mqtt/message/unsubscribe/UNSUBSCRIBE.java
+++ b/src/main/java/com/hivemq/mqtt/message/unsubscribe/UNSUBSCRIBE.java
@@ -68,7 +68,7 @@ public class UNSUBSCRIBE extends MqttMessageWithUserProperties implements Mqtt3U
         setPacketIdentifier(packetIdentifier);
     }
 
-    public static UNSUBSCRIBE createUnsubscribeFrom(final @NotNull UnsubscribePacket packet) {
+    public static @NotNull UNSUBSCRIBE createUnsubscribeFrom(final @NotNull UnsubscribePacket packet) {
 
         final ImmutableList.Builder<MqttUserProperty> userPropertyBuilder = ImmutableList.builder();
         for (final UserProperty userProperty : packet.getUserProperties().asList()) {

--- a/src/test/java/com/hivemq/bootstrap/netty/ChannelDependenciesTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/ChannelDependenciesTest.java
@@ -23,10 +23,6 @@ import com.hivemq.codec.encoder.EncoderFactory;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.RestrictionsConfigurationService;
 import com.hivemq.extensions.handler.*;
-import com.hivemq.extensions.handler.ClientLifecycleEventHandler;
-import com.hivemq.extensions.handler.IncomingPublishHandler;
-import com.hivemq.extensions.handler.IncomingSubscribeHandler;
-import com.hivemq.extensions.handler.PluginInitializerHandler;
 import com.hivemq.logging.EventLog;
 import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.metrics.handler.MetricsInitializer;
@@ -169,6 +165,9 @@ public class ChannelDependenciesTest {
     @Mock
     private ConnackOutboundInterceptorHandler connackOutboundInterceptorHandler;
 
+    @Mock
+    private UnsubscribeInboundInterceptorHandler unsubscribeInboundInterceptorHandler;
+
     @Before
     public void setUp() throws Exception {
 
@@ -209,7 +208,8 @@ public class ChannelDependenciesTest {
                 () -> publishMessageExpiryHandler,
                 publishOutboundInterceptorHandler,
                 connectInterceptorHandler,
-                connackOutboundInterceptorHandler);
+                connackOutboundInterceptorHandler,
+                unsubscribeInboundInterceptorHandler);
 
     }
 

--- a/src/test/java/com/hivemq/bootstrap/netty/ChannelDependenciesTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/ChannelDependenciesTest.java
@@ -250,5 +250,6 @@ public class ChannelDependenciesTest {
         assertNotNull(channelDependencies.getIncomingSubscribeHandler());
         assertNotNull(channelDependencies.getConnectInboundInterceptorHandler());
         assertNotNull(channelDependencies.getConnackOutboundInterceptorHandler());
+        assertNotNull(channelDependencies.getUnsubscribeInboundInterceptorHandler());
     }
 }

--- a/src/test/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandlerTest.java
@@ -1,0 +1,184 @@
+package com.hivemq.extensions.handler;
+
+import com.google.common.collect.ImmutableList;
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundInput;
+import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundOutput;
+import com.hivemq.extension.sdk.api.packets.unsubscribe.ModifiableUnsubscribePacket;
+import com.hivemq.extensions.HiveMQExtension;
+import com.hivemq.extensions.HiveMQExtensions;
+import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
+import com.hivemq.extensions.client.ClientContextImpl;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.extensions.executor.PluginOutputAsyncerImpl;
+import com.hivemq.extensions.executor.PluginTaskExecutorService;
+import com.hivemq.extensions.executor.PluginTaskExecutorServiceImpl;
+import com.hivemq.extensions.executor.task.PluginTaskExecutor;
+import com.hivemq.extensions.packets.general.ModifiableDefaultPermissionsImpl;
+import com.hivemq.mqtt.message.ProtocolVersion;
+import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
+import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import util.TestConfigurationBootstrap;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+public class UnsubscribeInboundInterceptorHandlerTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private HiveMQExtension extension;
+
+    @Mock
+    private HiveMQExtensions extensions;
+
+    @Mock
+    private ClientContextImpl clientContext;
+
+    @Mock
+    private FullConfigurationService configurationService;
+
+    private PluginTaskExecutor executor;
+    private EmbeddedChannel channel;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        executor = new PluginTaskExecutor(new AtomicLong());
+        executor.postConstruct();
+
+        channel = new EmbeddedChannel();
+        channel.attr(ChannelAttributes.CLIENT_ID).set("client");
+        channel.attr(ChannelAttributes.REQUEST_RESPONSE_INFORMATION).set(true);
+        channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
+        when(extension.getId()).thenReturn("extension");
+
+        configurationService = new TestConfigurationBootstrap().getFullConfigurationService();
+        final PluginOutPutAsyncer asyncer = new PluginOutputAsyncerImpl(Mockito.mock(ShutdownHooks.class));
+        final PluginTaskExecutorService pluginTaskExecutorService = new PluginTaskExecutorServiceImpl(() -> executor);
+
+        final UnsubscribeInboundInterceptorHandler handler =
+                new UnsubscribeInboundInterceptorHandler(configurationService, asyncer, extensions,
+                        pluginTaskExecutorService);
+        channel.pipeline().addFirst(handler);
+    }
+
+    @After
+    public void tearDown() {
+        executor.stop();
+        channel.close();
+    }
+
+    @Test
+    public void test_simple_intercept() throws Exception {
+        final ClientContextImpl clientContext =
+                new ClientContextImpl(extensions, new ModifiableDefaultPermissionsImpl());
+
+        final UnsubscribeInboundInterceptor interceptor =
+                getIsolatedInboundInterceptor("SimpleUnsubscribeTestInterceptor");
+        clientContext.addUnsubscribeInboundInterceptor(interceptor);
+
+        channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
+
+        when(extensions.getExtensionForClassloader(any(IsolatedPluginClassloader.class))).thenReturn(extension);
+
+        channel.writeInbound(testUnsubscribe());
+        UNSUBSCRIBE unsubscribe = channel.readInbound();
+        while (unsubscribe == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            unsubscribe = channel.readInbound();
+        }
+        Assert.assertNotNull(unsubscribe);
+    }
+
+    @Test
+    public void test_modifying_topics() throws Exception {
+        final ClientContextImpl clientContext =
+                new ClientContextImpl(extensions, new ModifiableDefaultPermissionsImpl());
+
+        final UnsubscribeInboundInterceptor interceptor =
+                getIsolatedInboundInterceptor("ModifyUnsubscribeTestInterceptor");
+        clientContext.addUnsubscribeInboundInterceptor(interceptor);
+
+        channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
+        channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
+
+        when(extensions.getExtensionForClassloader(any(IsolatedPluginClassloader.class))).thenReturn(extension);
+
+        channel.writeInbound(testUnsubscribe());
+        UNSUBSCRIBE unsubscribe = channel.readInbound();
+        while (unsubscribe == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            unsubscribe = channel.readInbound();
+        }
+        assertEquals(Collections.singletonList("not topics"), unsubscribe.getTopics());
+    }
+
+    private @NotNull UNSUBSCRIBE testUnsubscribe() {
+        return new UNSUBSCRIBE(ImmutableList.of("topics"), 1, Mqtt5UserProperties.NO_USER_PROPERTIES);
+    }
+
+    private UnsubscribeInboundInterceptor getIsolatedInboundInterceptor(final @NotNull String name) throws Exception {
+        final JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
+                .addClass("com.hivemq.extensions.handler.UnsubscribeInboundInterceptorHandlerTest$" + name);
+
+        final File jarFile = temporaryFolder.newFile();
+        javaArchive.as(ZipExporter.class).exportTo(jarFile, true);
+
+        final IsolatedPluginClassloader
+                cl =
+                new IsolatedPluginClassloader(new URL[]{jarFile.toURI().toURL()}, this.getClass().getClassLoader());
+
+        final Class<?> interceptorClass =
+                cl.loadClass("com.hivemq.extensions.handler.UnsubscribeInboundInterceptorHandlerTest$" + name);
+
+        return (UnsubscribeInboundInterceptor) interceptorClass.newInstance();
+    }
+
+    public static class SimpleUnsubscribeTestInterceptor implements UnsubscribeInboundInterceptor {
+
+        @Override
+        public void onInboundUnsubscribe(
+                final @NotNull UnsubscribeInboundInput input,
+                final @NotNull UnsubscribeInboundOutput output) {
+            System.out.println("Intercepting UNSUBSCRIBE at:" + System.currentTimeMillis());
+        }
+    }
+
+    public static class ModifyUnsubscribeTestInterceptor implements UnsubscribeInboundInterceptor {
+
+        @Override
+        public void onInboundUnsubscribe(
+                final @NotNull UnsubscribeInboundInput input,
+                final @NotNull UnsubscribeInboundOutput output) {
+            final ModifiableUnsubscribePacket packet = output.getUnsubscribePacket();
+            packet.setTopics(Collections.singletonList("not topics"));
+        }
+    }
+
+}

--- a/src/test/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandlerTest.java
@@ -100,9 +100,9 @@ public class UnsubscribeInboundInterceptorHandlerTest {
     @Test(timeout = 5000)
     public void test_client_id_not_set() {
         channel.attr(ChannelAttributes.CLIENT_ID).set(null);
-        channel.writeOutbound(testUnsubscribe());
+        channel.writeInbound(testUnsubscribe());
         channel.runPendingTasks();
-        assertNull(channel.readOutbound());
+        assertNull(channel.readInbound());
     }
 
 
@@ -194,6 +194,7 @@ public class UnsubscribeInboundInterceptorHandlerTest {
                 final @NotNull UnsubscribeInboundOutput output) {
             final ModifiableUnsubscribePacket packet = output.getUnsubscribePacket();
             packet.setTopics(Collections.singletonList("not topics"));
+            isTriggered.set(true);
         }
     }
 

--- a/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImplTest.java
@@ -1,5 +1,41 @@
 package com.hivemq.extensions.interceptor.unsubscribe.parameter;
 
+import com.google.common.collect.ImmutableList;
+import com.hivemq.extension.sdk.api.packets.general.MqttVersion;
+import com.hivemq.extensions.packets.unsubscribe.UnsubscribePacketImpl;
+import com.hivemq.mqtt.message.ProtocolVersion;
+import com.hivemq.mqtt.message.QoS;
+import com.hivemq.mqtt.message.mqtt5.Mqtt5RetainHandling;
+import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
+import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
+import com.hivemq.mqtt.message.subscribe.Topic;
+import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
+import com.hivemq.util.ChannelAttributes;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
 public class UnsubscribeInboundInputImplTest {
 
+    @Test
+    public void test_construction() {
+        final ImmutableList<String> topicFilters =
+                ImmutableList.of(
+                        new Topic("topic", QoS.AT_LEAST_ONCE, false, false, Mqtt5RetainHandling.SEND, null).toString());
+        final UNSUBSCRIBE unsubscribe =
+                new UNSUBSCRIBE(topicFilters, 1, Mqtt5UserProperties.of(MqttUserProperty.of("Prop", "Value")));
+
+        final UnsubscribePacketImpl unsubscribePacket = new UnsubscribePacketImpl(unsubscribe);
+        final EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+        embeddedChannel.attr(ChannelAttributes.CLIENT_ID).set("client");
+
+        final UnsubscribeInboundInputImpl client =
+                new UnsubscribeInboundInputImpl(unsubscribePacket, "client", embeddedChannel);
+
+        assertEquals(client.getClientInformation().getClientId(), "client");
+        assertEquals(client.getConnectionInformation().getMqttVersion(), MqttVersion.V_5);
+    }
 }

--- a/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImplTest.java
@@ -16,7 +16,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-
+/**
+ * @author Robin Atherton
+ */
 public class UnsubscribeInboundInputImplTest {
 
     @Test

--- a/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImplTest.java
@@ -1,0 +1,5 @@
+package com.hivemq.extensions.interceptor.unsubscribe.parameter;
+
+public class UnsubscribeInboundInputImplTest {
+
+}

--- a/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundInputImplTest.java
@@ -13,8 +13,10 @@ import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
 import com.hivemq.util.ChannelAttributes;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Test;
+import util.TestMessageUtil;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * @author Robin Atherton
@@ -40,4 +42,44 @@ public class UnsubscribeInboundInputImplTest {
         assertEquals(client.getClientInformation().getClientId(), "client");
         assertEquals(client.getConnectionInformation().getMqttVersion(), MqttVersion.V_5);
     }
+
+    @Test(expected = NullPointerException.class)
+    public void test_client_id_null() {
+        final UnsubscribePacketImpl unsubscribePacket =
+                new UnsubscribePacketImpl(TestMessageUtil.createFullMqtt5Unsubscribe());
+        final UnsubscribeInboundInputImpl input =
+                new UnsubscribeInboundInputImpl(unsubscribePacket, null, new EmbeddedChannel());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_channel_null() {
+        final UnsubscribePacketImpl unsubscribePacket =
+                new UnsubscribePacketImpl(TestMessageUtil.createFullMqtt5Unsubscribe());
+        final UnsubscribeInboundInputImpl input = new UnsubscribeInboundInputImpl(unsubscribePacket, "client", null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_packet_null() {
+        final UnsubscribeInboundInputImpl input =
+                new UnsubscribeInboundInputImpl(null, "client", new EmbeddedChannel());
+    }
+
+    @Test
+    public void test_update() {
+        final EmbeddedChannel embeddedChannel = new EmbeddedChannel();
+        embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+
+        final UnsubscribePacketImpl unsubscribePacket1 =
+                new UnsubscribePacketImpl(TestMessageUtil.createFullMqtt5Unsubscribe());
+        final UnsubscribePacketImpl unsubscribePacket2 =
+                new UnsubscribePacketImpl(TestMessageUtil.createFullMqtt5Unsubscribe());
+
+        final UnsubscribeInboundInputImpl input =
+                new UnsubscribeInboundInputImpl(unsubscribePacket1, "client1", embeddedChannel);
+        input.updateUnsubscribe(unsubscribePacket2);
+
+        assertNotSame(unsubscribePacket1, input.getUnsubscribePacket());
+        assertNotSame(unsubscribePacket2, input.getUnsubscribePacket());
+    }
+
 }

--- a/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundOutputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/unsubscribe/parameter/UnsubscribeInboundOutputImplTest.java
@@ -1,0 +1,37 @@
+package com.hivemq.extensions.interceptor.unsubscribe.parameter;
+
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import util.TestConfigurationBootstrap;
+import util.TestMessageUtil;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Robin Atherton
+ */
+public class UnsubscribeInboundOutputImplTest {
+
+    private UnsubscribeInboundOutputImpl unsubscribeInboundOutput;
+
+    private FullConfigurationService config;
+
+    @Mock
+    private PluginOutPutAsyncer pluginOutPutAsyncer;
+
+    private UNSUBSCRIBE unsubscribe;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        config = new TestConfigurationBootstrap().getFullConfigurationService();
+        unsubscribe = TestMessageUtil.createFullMqtt5Unsubscribe();
+        unsubscribeInboundOutput = new UnsubscribeInboundOutputImpl(pluginOutPutAsyncer, config, unsubscribe);
+        assertEquals(unsubscribeInboundOutput, unsubscribeInboundOutput.get());
+    }
+
+}

--- a/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
@@ -31,6 +31,11 @@ public class ModifiableUnsubscribePacketImplTest {
         modifiableUnsubscribePacket.addTopics("Test");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void remove_non_existing_topic() {
+        modifiableUnsubscribePacket.removeTopics("Test123");
+    }
+
     @Test
     public void test_add_topics_different() {
         final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
@@ -64,7 +69,6 @@ public class ModifiableUnsubscribePacketImplTest {
         modifiableUnsubscribePacket.setTopics(topics);
         assertEquals("Test3", topics.get(2));
     }
-
     private ModifiableUnsubscribePacketImpl testUnsubscribePacket() {
         final ImmutableList<String> topics = ImmutableList.of("Test", "Test/Topic");
         final @NotNull Mqtt5UserProperties props =

--- a/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
@@ -28,33 +28,33 @@ public class ModifiableUnsubscribePacketImplTest {
 
     @Test
     public void test_add_topics_same() {
-        final int sizeBefore = modifiableUnsubscribePacket.getTopicFilters().size();
+        final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
         modifiableUnsubscribePacket.addTopics("Test");
-        final int sizeAfter = modifiableUnsubscribePacket.getTopicFilters().size();
+        final int sizeAfter = modifiableUnsubscribePacket.getTopics().size();
         assertEquals(sizeAfter, sizeBefore);
     }
 
     @Test
     public void test_add_topics_different() {
-        final int sizeBefore = modifiableUnsubscribePacket.getTopicFilters().size();
+        final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
         modifiableUnsubscribePacket.addTopics("Test/Different");
-        final int sizeAfter = modifiableUnsubscribePacket.getTopicFilters().size();
+        final int sizeAfter = modifiableUnsubscribePacket.getTopics().size();
         assertNotEquals(sizeAfter, sizeBefore);
     }
 
     @Test
     public void remove_existing_topic() {
-        final int sizeBefore = modifiableUnsubscribePacket.getTopicFilters().size();
+        final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
         modifiableUnsubscribePacket.removeTopics("Test");
-        final int sizeAfter = modifiableUnsubscribePacket.getTopicFilters().size();
+        final int sizeAfter = modifiableUnsubscribePacket.getTopics().size();
         assertNotEquals(sizeAfter, sizeBefore);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void remove_non_existent_topic() {
-        final int sizeBefore = modifiableUnsubscribePacket.getTopicFilters().size();
+        final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
         modifiableUnsubscribePacket.removeTopics("Non Existing  ");
-        final int sizeAfter = modifiableUnsubscribePacket.getTopicFilters().size();
+        final int sizeAfter = modifiableUnsubscribePacket.getTopics().size();
         assertNotEquals(sizeAfter, sizeBefore);
     }
 

--- a/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
@@ -12,8 +12,7 @@ import util.TestConfigurationBootstrap;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 /**
  * @author Robin Atherton
@@ -29,38 +28,32 @@ public class ModifiableUnsubscribePacketImplTest {
         modifiableUnsubscribePacket = testUnsubscribePacket();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_add_topics_same() {
         modifiableUnsubscribePacket.addTopics("Test");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void remove_non_existing_topic() {
-        modifiableUnsubscribePacket.removeTopics("Test123");
+        assertEquals(2, modifiableUnsubscribePacket.getTopics().size());
+        assertFalse(modifiableUnsubscribePacket.isModified());
     }
 
     @Test
     public void test_add_topics_different() {
-        final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
         modifiableUnsubscribePacket.addTopics("Test/Different");
-        final int sizeAfter = modifiableUnsubscribePacket.getTopics().size();
-        assertNotEquals(sizeAfter, sizeBefore);
+        assertEquals(3, modifiableUnsubscribePacket.getTopics().size());
+        assertTrue(modifiableUnsubscribePacket.isModified());
     }
 
     @Test
     public void remove_existing_topic() {
-        final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
         modifiableUnsubscribePacket.removeTopics("Test");
-        final int sizeAfter = modifiableUnsubscribePacket.getTopics().size();
-        assertNotEquals(sizeAfter, sizeBefore);
+        assertEquals(1, modifiableUnsubscribePacket.getTopics().size());
+        assertTrue(modifiableUnsubscribePacket.isModified());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void remove_non_existent_topic() {
-        final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
-        modifiableUnsubscribePacket.removeTopics("Non Existing  ");
-        final int sizeAfter = modifiableUnsubscribePacket.getTopics().size();
-        assertNotEquals(sizeAfter, sizeBefore);
+        modifiableUnsubscribePacket.removeTopics("Non Existing");
+        assertEquals(2, modifiableUnsubscribePacket.getTopics().size());
+        assertFalse(modifiableUnsubscribePacket.isModified());
     }
 
     @Test
@@ -69,8 +62,13 @@ public class ModifiableUnsubscribePacketImplTest {
         topics.add("Test1");
         topics.add("Test2");
         topics.add("Test3");
+        modifiableUnsubscribePacket.addTopics("Test1");
+        modifiableUnsubscribePacket.addTopics("Test2");
+        modifiableUnsubscribePacket.addTopics("Test3");
+        assertEquals(5, modifiableUnsubscribePacket.getTopics().size());
         modifiableUnsubscribePacket.setTopics(topics);
-        assertEquals("Test3", topics.get(2));
+        assertEquals(3, modifiableUnsubscribePacket.getTopics().size());
+
     }
 
     private ModifiableUnsubscribePacketImpl testUnsubscribePacket() {

--- a/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
@@ -1,0 +1,79 @@
+package com.hivemq.extensions.packets.unsubscribe;
+
+import com.google.common.collect.ImmutableList;
+import com.hivemq.annotations.NotNull;
+import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
+import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
+import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
+import org.junit.Before;
+import org.junit.Test;
+import util.TestConfigurationBootstrap;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ModifiableUnsubscribePacketImplTest {
+
+    private FullConfigurationService configurationService;
+    private ModifiableUnsubscribePacketImpl modifiableUnsubscribePacket;
+
+    @Before
+    public void setUp() throws Exception {
+        configurationService = new TestConfigurationBootstrap().getFullConfigurationService();
+        modifiableUnsubscribePacket = testUnsubscribePacket();
+    }
+
+    @Test
+    public void test_add_topics_same() {
+        final int sizeBefore = modifiableUnsubscribePacket.getTopicFilters().size();
+        modifiableUnsubscribePacket.addTopics("Test");
+        final int sizeAfter = modifiableUnsubscribePacket.getTopicFilters().size();
+        assertEquals(sizeAfter, sizeBefore);
+    }
+
+    @Test
+    public void test_add_topics_different() {
+        final int sizeBefore = modifiableUnsubscribePacket.getTopicFilters().size();
+        modifiableUnsubscribePacket.addTopics("Test/Different");
+        final int sizeAfter = modifiableUnsubscribePacket.getTopicFilters().size();
+        assertNotEquals(sizeAfter, sizeBefore);
+    }
+
+    @Test
+    public void remove_existing_topic() {
+        final int sizeBefore = modifiableUnsubscribePacket.getTopicFilters().size();
+        modifiableUnsubscribePacket.removeTopics("Test");
+        final int sizeAfter = modifiableUnsubscribePacket.getTopicFilters().size();
+        assertNotEquals(sizeAfter, sizeBefore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void remove_non_existent_topic() {
+        final int sizeBefore = modifiableUnsubscribePacket.getTopicFilters().size();
+        modifiableUnsubscribePacket.removeTopics("Non Existing  ");
+        final int sizeAfter = modifiableUnsubscribePacket.getTopicFilters().size();
+        assertNotEquals(sizeAfter, sizeBefore);
+    }
+
+    @Test
+    public void set_topics() {
+        final ArrayList<String> topics = new ArrayList<>();
+        topics.add("Test1");
+        topics.add("Test2");
+        topics.add("Test3");
+        modifiableUnsubscribePacket.setTopics(topics);
+        assertEquals("Test3", topics.get(2));
+    }
+
+    private ModifiableUnsubscribePacketImpl testUnsubscribePacket() {
+        final ImmutableList<String> topics = ImmutableList.of("Test", "Test/Topic");
+        final @NotNull Mqtt5UserProperties props =
+                Mqtt5UserProperties.builder().add(MqttUserProperty.of("Test", "TestValue")).build();
+        final UNSUBSCRIBE unsubscribe = new UNSUBSCRIBE(topics, 1, props);
+        return new ModifiableUnsubscribePacketImpl(configurationService, unsubscribe);
+    }
+
+}

--- a/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
@@ -15,6 +15,9 @@ import java.util.ArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+/**
+ * @author Robin Atherton
+ */
 public class ModifiableUnsubscribePacketImplTest {
 
     private FullConfigurationService configurationService;
@@ -69,6 +72,7 @@ public class ModifiableUnsubscribePacketImplTest {
         modifiableUnsubscribePacket.setTopics(topics);
         assertEquals("Test3", topics.get(2));
     }
+
     private ModifiableUnsubscribePacketImpl testUnsubscribePacket() {
         final ImmutableList<String> topics = ImmutableList.of("Test", "Test/Topic");
         final @NotNull Mqtt5UserProperties props =

--- a/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/unsubscribe/ModifiableUnsubscribePacketImplTest.java
@@ -26,12 +26,9 @@ public class ModifiableUnsubscribePacketImplTest {
         modifiableUnsubscribePacket = testUnsubscribePacket();
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void test_add_topics_same() {
-        final int sizeBefore = modifiableUnsubscribePacket.getTopics().size();
         modifiableUnsubscribePacket.addTopics("Test");
-        final int sizeAfter = modifiableUnsubscribePacket.getTopics().size();
-        assertEquals(sizeAfter, sizeBefore);
     }
 
     @Test


### PR DESCRIPTION
Resolves #45 

Motivation
Makes it possible for extension developers to intercept inbound unsubscribe messages.

Changes
Implemented unsubscribe inbound interceptor.
Extension developers can set, add and remove topics from unsubscribe messages.
