### PR TITLE
Correct CONNACKv5 reason code BAD_USERNAME_OR_PASSWORD

### DIFF
--- a/src/main/java/com/hivemq/extensions/packets/general/ReasonCodeUtil.java
+++ b/src/main/java/com/hivemq/extensions/packets/general/ReasonCodeUtil.java
@@ -48,7 +48,7 @@ public class ReasonCodeUtil {
             case CLIENT_IDENTIFIER_NOT_VALID:
                 return Mqtt5ConnAckReasonCode.CLIENT_IDENTIFIER_NOT_VALID;
             case BAD_USER_NAME_OR_PASSWORD:
-                return Mqtt5ConnAckReasonCode.BAD_AUTHENTICATION_METHOD;
+                return Mqtt5ConnAckReasonCode.BAD_USER_NAME_OR_PASSWORD;
             case SERVER_UNAVAILABLE:
                 return Mqtt5ConnAckReasonCode.SERVER_UNAVAILABLE;
             case SERVER_BUSY:


### PR DESCRIPTION
Addresses issue https://github.com/hivemq/hivemq-community-edition/issues/119

**Motivation**

Resolves #119 

**Changes**
Add correct reason code enum for BAD_USER_NAME_OR_PASSWORD
There is no test file for this class 