### PR TITLE
Fix static code analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ stages:
 jobs:
   include:
     - stage: test
-      script: ./gradlew test
-    - stage: build
-      script: ./gradlew packaging
+      script: ./gradlew check javadoc packaging
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ stages:
 jobs:
   include:
     - stage: test
-      script: ./gradlew check javadoc packaging
+      script: ./gradlew test license forbiddenApis javadoc packaging
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/HEADER
+++ b/HEADER
@@ -1,15 +1,13 @@
-/*
- * Copyright 2019 dc-square GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+Copyright 2019 dc-square GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.4' apply false
-    id 'com.github.hierynomus.license' version '0.15.0' apply false
+    id 'com.github.hierynomus.license' version '0.14.0' apply false
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'org.owasp.dependencycheck' version '5.2.0' apply false
     id 'com.github.spotbugs' version '1.6.9' apply false
@@ -479,7 +479,9 @@ downloadLicenses {
 allprojects {
     license {
         header file("${rootDir}/HEADER")
-        exclude '*'
+        mapping {
+            java = 'SLASHSTAR_STYLE'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.4' apply false
-    id 'com.github.hierynomus.license' version '0.14.0' apply false
+    id 'com.github.hierynomus.license' version '0.15.0' apply false
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'org.owasp.dependencycheck' version '5.2.0' apply false
     id 'com.github.spotbugs' version '1.6.9' apply false

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/ExtensionMain.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/ExtensionMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api;
 
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/DoNotImplement.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/DoNotImplement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.annotations;
 
 import java.lang.annotation.Documented;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/Experimental.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/Experimental.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.annotations;
 
 import java.lang.annotation.Documented;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/Immutable.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/Immutable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.annotations;
 
 import java.lang.annotation.Documented;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/NotNull.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/NotNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.annotations;
 
 import java.lang.annotation.*;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/Nullable.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/Nullable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.annotations;
 
 import java.lang.annotation.*;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/ThreadSafe.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/annotations/ThreadSafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.annotations;
 
 import java.lang.annotation.*;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/Async.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/Async.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.async;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/AsyncOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/AsyncOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.async;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/SimpleAsyncOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/SimpleAsyncOutput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.async;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/TimeoutFallback.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/async/TimeoutFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.async;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/Authenticator.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/Authenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/Authorizer.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/Authorizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/PublishAuthorizer.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/PublishAuthorizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/SimpleAuthenticator.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/SimpleAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/SubscriptionAuthorizer.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/SubscriptionAuthorizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/AuthenticatorProviderInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/AuthenticatorProviderInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 import com.hivemq.extension.sdk.api.client.parameter.ServerInformation;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/AuthorizerProviderInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/AuthorizerProviderInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/PublishAuthorizerInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/PublishAuthorizerInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/PublishAuthorizerOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/PublishAuthorizerOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 import com.hivemq.extension.sdk.api.packets.connect.ConnectPacket;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SimpleAuthOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SubscriptionAuthorizerInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SubscriptionAuthorizerInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SubscriptionAuthorizerOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/SubscriptionAuthorizerOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/TopicPermission.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/auth/parameter/TopicPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.auth.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/ClientContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ClientInformation.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ClientInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ConnectionAttributeStore.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ConnectionAttributeStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ConnectionInformation.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ConnectionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.packets.general.MqttVersion;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/InitializerInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/InitializerInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/Listener.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ListenerType.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ListenerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ProxyInformation.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ProxyInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ServerInformation.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/ServerInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/TlsInformation.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/client/parameter/TlsInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.client.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/EventRegistry.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/EventRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/ClientLifecycleEventListener.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/ClientLifecycleEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/ClientLifecycleEventListenerProvider.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/ClientLifecycleEventListenerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/AuthenticationFailedInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/AuthenticationFailedInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client.parameters;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/AuthenticationSuccessfulInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/AuthenticationSuccessfulInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client.parameters;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ClientInitiatedDisconnectInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ClientInitiatedDisconnectInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client.parameters;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ClientLifecycleEventListenerProviderInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ClientLifecycleEventListenerProviderInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client.parameters;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ConnectionLostInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ConnectionLostInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client.parameters;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ConnectionStartInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ConnectionStartInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client.parameters;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/DisconnectEventInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/DisconnectEventInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client.parameters;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ServerInitiatedDisconnectInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/events/client/parameters/ServerInitiatedDisconnectInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.events.client.parameters;
 
 import com.hivemq.extension.sdk.api.events.client.ClientLifecycleEventListener;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/Interceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/Interceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.interceptor;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/connect/parameter/ConnectInboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/connect/parameter/ConnectInboundInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.interceptor.connect.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectInboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectInboundInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.interceptor.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/DisconnectOutboundInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.interceptor.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundInput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectInboundOutput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundInput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/disconnect/parameter/DisconnectOutboundOutput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.interceptor.disconnect.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/publish/PublishInboundInterceptor.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/publish/PublishInboundInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.interceptor.publish;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/publish/parameter/PublishInboundInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/publish/parameter/PublishInboundInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.interceptor.publish.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/publish/parameter/PublishInboundOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/interceptor/publish/parameter/PublishInboundOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.interceptor.publish.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/auth/DefaultAuthorizationBehaviour.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/auth/DefaultAuthorizationBehaviour.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.auth;
 
 import com.hivemq.extension.sdk.api.auth.Authorizer;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/auth/ModifiableDefaultPermissions.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/auth/ModifiableDefaultPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.auth;
 
 import com.hivemq.extension.sdk.api.annotations.Immutable;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnackReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnackReasonCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.connect;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/ConnectPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.connect;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/connect/WillPublishPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.connect;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectPacket.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.packets.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/DisconnectReasonCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.disconnect;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableInboundDisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableInboundDisconnectPacket.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.packets.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableOutboundDisconnectPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/disconnect/ModifiableOutboundDisconnectPacket.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extension.sdk.api.packets.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/DisconnectedReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/DisconnectedReasonCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.general;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/ModifiableUserProperties.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/ModifiableUserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.general;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/MqttVersion.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/MqttVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.general;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/Qos.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/Qos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.general;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/UserProperties.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/UserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.general;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/UserProperty.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/general/UserProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.general;
 
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/AckReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/AckReasonCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.publish;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiablePublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/ModifiablePublishPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.publish;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PayloadFormatIndicator.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PayloadFormatIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.publish;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/publish/PublishPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.publish;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/subscribe/RetainHandling.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/subscribe/RetainHandling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.subscribe;
 
 import com.hivemq.extension.sdk.api.annotations.Nullable;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/subscribe/SubackReasonCode.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/subscribe/SubackReasonCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.subscribe;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/subscribe/Subscription.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/packets/subscribe/Subscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.packets.subscribe;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ClientBasedInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ClientBasedInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionInformation.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionStartInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionStartInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.parameter;
 
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionStartOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionStartOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionStopInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionStopInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionStopOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/parameter/ExtensionStopOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.parameter;
 
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/CompletableScheduledFuture.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/CompletableScheduledFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services;
 
 import java.util.concurrent.CompletableFuture;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/ManagedExtensionExecutorService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/ManagedExtensionExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/Services.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/Services.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services;
 
 import com.codahale.metrics.MetricRegistry;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/auth/SecurityRegistry.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/auth/SecurityRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.auth;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/auth/provider/AuthenticatorProvider.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/auth/provider/AuthenticatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.auth.provider;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/auth/provider/AuthorizerProvider.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/auth/provider/AuthorizerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.auth.provider;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/Builders.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/Builders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Copyright 2018 dc-square GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hivemq.extension.sdk.api.services.builder;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/PublishBuilder.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/PublishBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.builder;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/RetainedPublishBuilder.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/RetainedPublishBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.builder;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/TopicPermissionBuilder.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/TopicPermissionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.builder;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/TopicSubscriptionBuilder.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/TopicSubscriptionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.builder;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/WillPublishBuilder.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/builder/WillPublishBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.builder;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/ClusterDiscoveryCallback.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/ClusterDiscoveryCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.cluster;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/ClusterService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/ClusterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.cluster;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/parameter/ClusterDiscoveryInput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/parameter/ClusterDiscoveryInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.cluster.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/parameter/ClusterDiscoveryOutput.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/parameter/ClusterDiscoveryOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.cluster.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/parameter/ClusterNodeAddress.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/cluster/parameter/ClusterNodeAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.cluster.parameter;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/DoNotImplementException.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/DoNotImplementException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.exception;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/InvalidTopicException.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/InvalidTopicException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.exception;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/LimitExceededException.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/LimitExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.exception;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/NoSuchClientIdException.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/NoSuchClientIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.exception;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/RateLimitExceededException.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/exception/RateLimitExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.exception;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/intializer/ClientInitializer.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/intializer/ClientInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.intializer;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/intializer/InitializerRegistry.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/intializer/InitializerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.intializer;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/Publish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.publish;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/PublishService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/PublishService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.publish;
 
 import com.hivemq.extension.sdk.api.services.exception.RateLimitExceededException;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/PublishToClientResult.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/PublishToClientResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.publish;
 
 /**

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.publish;
 
 

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedPublish.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/publish/RetainedPublish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.publish;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/ClientService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.session;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/SessionInformation.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/session/SessionInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.session;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/subscription/SubscriptionStore.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/subscription/SubscriptionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.subscription;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/subscription/TopicSubscription.java
+++ b/hivemq-extension-sdk/src/main/java/com/hivemq/extension/sdk/api/services/subscription/TopicSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2019 dc-square GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.extension.sdk.api.services.subscription;
 
 import com.hivemq.extension.sdk.api.annotations.DoNotImplement;

--- a/src/main/java/com/hivemq/extensions/executor/task/AbstractSimpleAsyncOutput.java
+++ b/src/main/java/com/hivemq/extensions/executor/task/AbstractSimpleAsyncOutput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.executor.task;
 
 import com.google.common.util.concurrent.SettableFuture;

--- a/src/main/java/com/hivemq/extensions/handler/ConnectInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/ConnectInboundInterceptorHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.handler;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectInterceptorHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.handler;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hivemq/extensions/interceptor/connect/ConnectInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/connect/ConnectInboundInputImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.connect;
 
 import com.hivemq.annotations.NotNull;

--- a/src/main/java/com/hivemq/extensions/interceptor/connect/ConnectInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/connect/ConnectInboundOutputImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.connect;
 
 import com.hivemq.annotations.NotNull;

--- a/src/main/java/com/hivemq/extensions/interceptor/connect/ConnectInboundProviderInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/connect/ConnectInboundProviderInputImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.connect;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.Immutable;

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.disconnect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundInputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundInputImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.Immutable;

--- a/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.disconnect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/main/java/com/hivemq/extensions/interceptor/publish/parameter/PublishOutboundOutputImpl.java
+++ b/src/main/java/com/hivemq/extensions/interceptor/publish/parameter/PublishOutboundOutputImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.publish.parameter;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.connect;
 
 import com.hivemq.annotations.NotNull;

--- a/src/main/java/com/hivemq/extensions/packets/connect/ModifiableWillPublishImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/connect/ModifiableWillPublishImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.connect;
 
 import com.hivemq.annotations.NotNull;

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/DisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/DisconnectPacketImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.disconnect;
 
 import com.hivemq.extension.sdk.api.annotations.Immutable;

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.disconnect;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImpl.java
+++ b/src/main/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.disconnect;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/hivemq/extensions/services/admin/AdminServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/admin/AdminServiceImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.admin;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/src/main/java/com/hivemq/extensions/services/general/IterationContextImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/general/IterationContextImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.general;
 
 import com.hivemq.extension.sdk.api.services.general.IterationContext;

--- a/src/main/java/com/hivemq/extensions/services/interceptor/GlobalInterceptorRegistryImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/interceptor/GlobalInterceptorRegistryImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.interceptor;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/hivemq/extensions/services/interceptor/Interceptors.java
+++ b/src/main/java/com/hivemq/extensions/services/interceptor/Interceptors.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.interceptor;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/com/hivemq/extensions/services/interceptor/InterceptorsImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/interceptor/InterceptorsImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.interceptor;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/com/hivemq/extensions/services/subscription/SubscriberForTopicResultImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/subscription/SubscriberForTopicResultImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.subscription;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/src/main/java/com/hivemq/extensions/services/subscription/SubscriberWithFilterResultImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/subscription/SubscriberWithFilterResultImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.subscription;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/src/main/java/com/hivemq/mqtt/handler/connect/RemoveConnectIdleHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/RemoveConnectIdleHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.mqtt.handler.connect;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/src/main/java/com/hivemq/mqtt/topic/tree/SubscriptionTypeItemFilter.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/SubscriptionTypeItemFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.mqtt.topic.tree;
 
 import com.hivemq.annotations.NotNull;

--- a/src/main/java/com/hivemq/persistence/local/rocksdb/RocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/rocksdb/RocksDBLocalPersistence.java
@@ -82,7 +82,7 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
             return;
         }
         RocksDB.loadLibrary();
-        if(enabled) {
+        if (enabled) {
             persistenceStartup.submitPersistenceStart(this);
         } else {
             startExternal();
@@ -107,7 +107,8 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
             }
 
         } catch (final RocksDBException e) {
-            logger.error("An error occurred while opening the {} persistence. Is another HiveMQ instance running?", name);
+            logger.error(
+                    "An error occurred while opening the {} persistence. Is another HiveMQ instance running?", name);
             logger.debug("Original Exception:", e);
             throw new UnrecoverableException();
         }
@@ -137,7 +138,11 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
                         buckets[finalI] = rocksDB;
                         counter.countDown();
                     } catch (final Exception e) {
-                        e.printStackTrace();
+                        logger.error(
+                                "An error occurred while opening the {} persistence. Is another HiveMQ instance running?",
+                                name);
+                        logger.debug("Original Exception:", e);
+                        throw new UnrecoverableException();
                     }
                 });
             }
@@ -145,7 +150,8 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
             counter.await();
 
         } catch (final InterruptedException e) {
-            logger.error("An error occurred while opening the {} persistence. Is another HiveMQ instance running?", name);
+            logger.error(
+                    "An error occurred while opening the {} persistence. Is another HiveMQ instance running?", name);
             logger.debug("Original Exception:", e);
             throw new UnrecoverableException();
         }

--- a/src/main/java/com/hivemq/persistence/local/xodus/PublishTopicTree.java
+++ b/src/main/java/com/hivemq/persistence/local/xodus/PublishTopicTree.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.persistence.local.xodus;
 
 import com.google.common.collect.ImmutableSet;

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBSerializer.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBSerializer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.persistence.payload;
 
 import com.google.common.primitives.Longs;

--- a/src/main/resources/config.xml
+++ b/src/main/resources/config.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2019 dc-square GmbH
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <hivemq>
 
     <listeners>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright 2019 dc-square GmbH
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <configuration scan="false">
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/test/java/com/hivemq/extensions/handler/ConnectInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/ConnectInboundInterceptorHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.handler;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/DisconnectInboundInterceptorHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.handler;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/DisconnectOutboundInterceptorHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.handler;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/com/hivemq/extensions/handler/PublishOutboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/PublishOutboundInterceptorHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.handler;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundInputImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.disconnect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectInboundOutputImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.disconnect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundInputImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.disconnect;
 
 import com.hivemq.extensions.packets.disconnect.DisconnectPacketImpl;

--- a/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/disconnect/DisconnectOutboundOutputImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.disconnect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/test/java/com/hivemq/extensions/interceptor/publish/parameter/PublishOutboundOutputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/interceptor/publish/parameter/PublishOutboundOutputImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.interceptor.publish.parameter;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/test/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/connect/ModifiableConnectPacketImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.connect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/test/java/com/hivemq/extensions/packets/connect/ModifiableWillPublishImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/connect/ModifiableWillPublishImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.connect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/test/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/disconnect/ModifiableInboundDisconnectPacketImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.disconnect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/test/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/disconnect/ModifiableOutboundDisconnectPacketImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.disconnect;
 
 import com.hivemq.configuration.service.FullConfigurationService;

--- a/src/test/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.packets.publish;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/com/hivemq/extensions/services/general/IterationContextImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/general/IterationContextImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.general;
 
 import org.junit.Test;

--- a/src/test/java/com/hivemq/extensions/services/interceptor/InterceptorsImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/interceptor/InterceptorsImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.extensions.services.interceptor;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;

--- a/src/test/java/com/hivemq/migration/MigrationUnitTest.java
+++ b/src/test/java/com/hivemq/migration/MigrationUnitTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.migration;
 
 import org.junit.Test;

--- a/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessageListenerAndScheduleNextTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessageListenerAndScheduleNextTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.mqtt.handler.subscribe.retained;
 
 import com.google.common.util.concurrent.Futures;

--- a/src/test/java/com/hivemq/mqtt/topic/tree/SubscriptionTypeItemFilterTest.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/SubscriptionTypeItemFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.mqtt.topic.tree;
 
 import com.hivemq.extension.sdk.api.services.subscription.SubscriptionType;

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersFromTopicWithFilterTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersFromTopicWithFilterTopicTreeImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.mqtt.topic.tree;
 
 import com.codahale.metrics.Counter;

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersWithFilterFromTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersWithFilterFromTopicTreeImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.mqtt.topic.tree;
 
 import com.codahale.metrics.Counter;

--- a/src/test/java/com/hivemq/persistence/local/xodus/PublishTopicTreeTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/PublishTopicTreeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 dc-square GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.persistence.local.xodus;
 
 import org.junit.Test;

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,19 +1,20 @@
 <!--
-  ~ Copyright 2019 dc-square GmbH
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 
+    Copyright 2019 dc-square GmbH
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
**Motivation**
Perform static code analysis on Travis build, not only test

**Changes**
- Travis now performs check instead of test
- Travis now builds javadoc
- Travis now only has one stage for faster builds
- Updated license headers