### PR TITLE
bugfix/implementing-multiple-interceptors

### DIFF
--- a/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextImpl.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.extensions.client;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.Interceptor;
@@ -43,8 +45,7 @@ import com.hivemq.extensions.classloader.IsolatedPluginClassloader;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Florian Limpöck
@@ -52,404 +53,509 @@ import java.util.stream.Collectors;
  */
 public class ClientContextImpl {
 
-    private final @NotNull List<Interceptor> interceptorList;
-    private final @NotNull ModifiableDefaultPermissions defaultPermissions;
     private final @NotNull HiveMQExtensions hiveMQExtensions;
+    private final @NotNull ModifiableDefaultPermissions defaultPermissions;
+    private volatile @NotNull ImmutableList<PublishInboundInterceptor> publishInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PublishOutboundInterceptor> publishOutbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PubackInboundInterceptor> pubackInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PubackOutboundInterceptor> pubackOutbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PubrecInboundInterceptor> pubrecInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PubrecOutboundInterceptor> pubrecOutbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PubrelInboundInterceptor> pubrelInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PubrelOutboundInterceptor> pubrelOutbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PubcompInboundInterceptor> pubcompInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PubcompOutboundInterceptor> pubcompOutbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<SubscribeInboundInterceptor> subscribeInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<SubackOutboundInterceptor> subackOutbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<UnsubscribeInboundInterceptor> unsubscribeInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<UnsubackOutboundInterceptor> unsubackOutbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<DisconnectInboundInterceptor> disconnectInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<DisconnectOutboundInterceptor> disconnectOutbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PingReqInboundInterceptor> pingReqInbounds = ImmutableList.of();
+    private volatile @NotNull ImmutableList<PingRespOutboundInterceptor> pingRespOutbounds = ImmutableList.of();
 
     public ClientContextImpl(
             final @NotNull HiveMQExtensions hiveMQExtensions,
             final @NotNull ModifiableDefaultPermissions defaultPermissions) {
 
-        this.interceptorList = new CopyOnWriteArrayList<>();
         this.hiveMQExtensions = hiveMQExtensions;
         this.defaultPermissions = defaultPermissions;
     }
 
-    public void addInterceptor(final @NotNull Interceptor interceptor) {
-        if (!interceptorList.contains(interceptor)) {
-            interceptorList.add(interceptor);
-        }
+    public synchronized void addPublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
+        publishInbounds = addInterceptor(publishInbounds, interceptor);
     }
 
-    public void update(final @NotNull ClientContextPluginImpl clientContextPlugin) {
-        interceptorList.addAll(clientContextPlugin.getAllInterceptors());
+    public synchronized void addPublishOutboundInterceptor(final @NotNull PublishOutboundInterceptor interceptor) {
+        publishOutbounds = addInterceptor(publishOutbounds, interceptor);
     }
 
-    public void addPublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
-        addInterceptor(interceptor);
+    public synchronized void addPubackInboundInterceptor(final @NotNull PubackInboundInterceptor interceptor) {
+        pubackInbounds = addInterceptor(pubackInbounds, interceptor);
     }
 
-    public void addPublishOutboundInterceptor(final @NotNull PublishOutboundInterceptor interceptor) {
-        addInterceptor(interceptor);
+    public synchronized void addPubackOutboundInterceptor(final @NotNull PubackOutboundInterceptor interceptor) {
+        pubackOutbounds = addInterceptor(pubackOutbounds, interceptor);
     }
 
-    public void addSubscribeInboundInterceptor(final @NotNull SubscribeInboundInterceptor interceptor) {
-        addInterceptor(interceptor);
+    public synchronized void addPubrecInboundInterceptor(final @NotNull PubrecInboundInterceptor interceptor) {
+        pubrecInbounds = addInterceptor(pubrecInbounds, interceptor);
     }
 
-    public void removeInterceptor(final @NotNull Interceptor interceptor) {
-        interceptorList.remove(interceptor);
+    public synchronized void addPubrecOutboundInterceptor(final @NotNull PubrecOutboundInterceptor interceptor) {
+        pubrecOutbounds = addInterceptor(pubrecOutbounds, interceptor);
     }
 
-    public @Immutable @NotNull List<@NotNull Interceptor> getAllInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .collect(Collectors.toUnmodifiableList());
+    public synchronized void addPubrelInboundInterceptor(final @NotNull PubrelInboundInterceptor interceptor) {
+        pubrelInbounds = addInterceptor(pubrelInbounds, interceptor);
+    }
+
+    public synchronized void addPubrelOutboundInterceptor(final @NotNull PubrelOutboundInterceptor interceptor) {
+        pubrelOutbounds = addInterceptor(pubrelOutbounds, interceptor);
+    }
+
+    public synchronized void addPubcompInboundInterceptor(final @NotNull PubcompInboundInterceptor interceptor) {
+        pubcompInbounds = addInterceptor(pubcompInbounds, interceptor);
+    }
+
+    public synchronized void addPubcompOutboundInterceptor(final @NotNull PubcompOutboundInterceptor interceptor) {
+        pubcompOutbounds = addInterceptor(pubcompOutbounds, interceptor);
+    }
+
+    public synchronized void addSubscribeInboundInterceptor(final @NotNull SubscribeInboundInterceptor interceptor) {
+        subscribeInbounds = addInterceptor(subscribeInbounds, interceptor);
+    }
+
+    public synchronized void addSubackOutboundInterceptor(final @NotNull SubackOutboundInterceptor interceptor) {
+        subackOutbounds = addInterceptor(subackOutbounds, interceptor);
+    }
+
+    public synchronized void addUnsubscribeInboundInterceptor(
+            final @NotNull UnsubscribeInboundInterceptor interceptor) {
+
+        unsubscribeInbounds = addInterceptor(unsubscribeInbounds, interceptor);
+    }
+
+    public synchronized void addUnsubackOutboundInterceptor(final @NotNull UnsubackOutboundInterceptor interceptor) {
+        unsubackOutbounds = addInterceptor(unsubackOutbounds, interceptor);
+    }
+
+    public synchronized void addDisconnectInboundInterceptor(final @NotNull DisconnectInboundInterceptor interceptor) {
+        disconnectInbounds = addInterceptor(disconnectInbounds, interceptor);
+    }
+
+    public synchronized void addDisconnectOutboundInterceptor(
+            final @NotNull DisconnectOutboundInterceptor interceptor) {
+
+        disconnectOutbounds = addInterceptor(disconnectOutbounds, interceptor);
+    }
+
+    public synchronized void addPingReqInboundInterceptor(final @NotNull PingReqInboundInterceptor interceptor) {
+        pingReqInbounds = addInterceptor(pingReqInbounds, interceptor);
+    }
+
+    public synchronized void addPingRespOutboundInterceptor(final @NotNull PingRespOutboundInterceptor interceptor) {
+        pingRespOutbounds = addInterceptor(pingRespOutbounds, interceptor);
+    }
+
+    public synchronized void removePublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
+        publishInbounds = removeInterceptor(publishInbounds, interceptor);
+    }
+
+    public synchronized void removePublishOutboundInterceptor(final @NotNull PublishOutboundInterceptor interceptor) {
+        publishOutbounds = removeInterceptor(publishOutbounds, interceptor);
+    }
+
+    public synchronized void removePubackInboundInterceptor(final @NotNull PubackInboundInterceptor interceptor) {
+        pubackInbounds = removeInterceptor(pubackInbounds, interceptor);
+    }
+
+    public synchronized void removePubackOutboundInterceptor(final @NotNull PubackOutboundInterceptor interceptor) {
+        pubackOutbounds = removeInterceptor(pubackOutbounds, interceptor);
+    }
+
+    public synchronized void removePubrecInboundInterceptor(final @NotNull PubrecInboundInterceptor interceptor) {
+        pubrecInbounds = removeInterceptor(pubrecInbounds, interceptor);
+    }
+
+    public synchronized void removePubrecOutboundInterceptor(final @NotNull PubrecOutboundInterceptor interceptor) {
+        pubrecOutbounds = removeInterceptor(pubrecOutbounds, interceptor);
+    }
+
+    public synchronized void removePubrelInboundInterceptor(final @NotNull PubrelInboundInterceptor interceptor) {
+        pubrelInbounds = removeInterceptor(pubrelInbounds, interceptor);
+    }
+
+    public synchronized void removePubrelOutboundInterceptor(final @NotNull PubrelOutboundInterceptor interceptor) {
+        pubrelOutbounds = removeInterceptor(pubrelOutbounds, interceptor);
+    }
+
+    public synchronized void removePubcompInboundInterceptor(final @NotNull PubcompInboundInterceptor interceptor) {
+        pubcompInbounds = removeInterceptor(pubcompInbounds, interceptor);
+    }
+
+    public synchronized void removePubcompOutboundInterceptor(final @NotNull PubcompOutboundInterceptor interceptor) {
+        pubcompOutbounds = removeInterceptor(pubcompOutbounds, interceptor);
+    }
+
+    public synchronized void removeSubscribeInboundInterceptor(final @NotNull SubscribeInboundInterceptor interceptor) {
+        subscribeInbounds = removeInterceptor(subscribeInbounds, interceptor);
+    }
+
+    public synchronized void removeSubackOutboundInterceptor(final @NotNull SubackOutboundInterceptor interceptor) {
+        subackOutbounds = removeInterceptor(subackOutbounds, interceptor);
+    }
+
+    public synchronized void removeUnsubscribeInboundInterceptor(
+            final @NotNull UnsubscribeInboundInterceptor interceptor) {
+
+        unsubscribeInbounds = removeInterceptor(unsubscribeInbounds, interceptor);
+    }
+
+    public synchronized void removeUnsubackOutboundInterceptor(final @NotNull UnsubackOutboundInterceptor interceptor) {
+        unsubackOutbounds = removeInterceptor(unsubackOutbounds, interceptor);
+    }
+
+    public synchronized void removeDisconnectInboundInterceptor(
+            final @NotNull DisconnectInboundInterceptor interceptor) {
+
+        disconnectInbounds = removeInterceptor(disconnectInbounds, interceptor);
+    }
+
+    public synchronized void removeDisconnectOutboundInterceptor(
+            final @NotNull DisconnectOutboundInterceptor interceptor) {
+
+        disconnectOutbounds = removeInterceptor(disconnectOutbounds, interceptor);
+    }
+
+    public synchronized void removePingReqInboundInterceptor(final @NotNull PingReqInboundInterceptor interceptor) {
+        pingReqInbounds = removeInterceptor(pingReqInbounds, interceptor);
+    }
+
+    public synchronized void removePingRespOutboundInterceptor(final @NotNull PingRespOutboundInterceptor interceptor) {
+        pingRespOutbounds = removeInterceptor(pingRespOutbounds, interceptor);
+    }
+
+    public @Immutable @NotNull List<@NotNull Interceptor> getAllInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return streamAllInterceptors()
+                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(extensionClassLoader))
+                .collect(ImmutableList.toImmutableList());
     }
 
     public @Immutable @NotNull List<@NotNull Interceptor> getAllInterceptors() {
-        return interceptorList.stream()
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .collect(Collectors.toUnmodifiableList());
+        return streamAllInterceptors()
+                .sorted(Comparator.comparingInt(this::getExtensionPriority).reversed())
+                .collect(ImmutableList.toImmutableList());
     }
 
-    public @Immutable @NotNull List<@NotNull PublishInboundInterceptor> getPublishInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PublishInboundInterceptor)
-                .map(interceptor -> (PublishInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    private @NotNull Stream<Interceptor> streamAllInterceptors() {
+        return Streams.concat(
+                publishInbounds.stream(), publishOutbounds.stream(),
+                pubackInbounds.stream(), pubackOutbounds.stream(),
+                pubrecInbounds.stream(), pubrecOutbounds.stream(),
+                pubrelInbounds.stream(), pubrelOutbounds.stream(),
+                pubcompInbounds.stream(), pubcompOutbounds.stream(),
+                subscribeInbounds.stream(), subackOutbounds.stream(),
+                unsubscribeInbounds.stream(), unsubackOutbounds.stream(),
+                disconnectInbounds.stream(), disconnectOutbounds.stream(),
+                pingReqInbounds.stream(), pingRespOutbounds.stream());
+    }
+
+    public @Immutable @NotNull List<@NotNull PublishInboundInterceptor> getPublishInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(publishInbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PublishInboundInterceptor> getPublishInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PublishInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PublishInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return publishInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PublishOutboundInterceptor> getPublishOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PublishOutboundInterceptor)
-                .map(interceptor -> (PublishOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PublishOutboundInterceptor> getPublishOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(publishOutbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PublishOutboundInterceptor> getPublishOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PublishOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PublishOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return publishOutbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PubackInboundInterceptor> getPubackInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PubackInboundInterceptor)
-                .map(interceptor -> (PubackInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PubackInboundInterceptor> getPubackInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pubackInbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PubackInboundInterceptor> getPubackInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PubackInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PubackInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return pubackInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PubackOutboundInterceptor> getPubackOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PubackOutboundInterceptor)
-                .map(interceptor -> (PubackOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PubackOutboundInterceptor> getPubackOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pubackOutbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PubackOutboundInterceptor> getPubackOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PubackOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PubackOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return pubackOutbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PubrecInboundInterceptor> getPubrecInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PubrecInboundInterceptor)
-                .map(interceptor -> (PubrecInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PubrecInboundInterceptor> getPubrecInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pubrecInbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PubrecInboundInterceptor> getPubrecInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PubrecInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PubrecInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return pubrecInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PubrecOutboundInterceptor> getPubrecOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PubrecOutboundInterceptor)
-                .map(interceptor -> (PubrecOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PubrecOutboundInterceptor> getPubrecOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pubrecOutbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PubrecOutboundInterceptor> getPubrecOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PubrecOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PubrecOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return pubrecOutbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PubrelInboundInterceptor> getPubrelInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PubrelInboundInterceptor)
-                .map(interceptor -> (PubrelInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PubrelInboundInterceptor> getPubrelInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pubrelInbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PubrelInboundInterceptor> getPubrelInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PubrelInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PubrelInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return pubrelInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PubrelOutboundInterceptor> getPubrelOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PubrelOutboundInterceptor)
-                .map(interceptor -> (PubrelOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PubrelOutboundInterceptor> getPubrelOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pubrelOutbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PubrelOutboundInterceptor> getPubrelOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PubrelOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PubrelOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return pubrelOutbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PubcompInboundInterceptor> getPubcompInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PubcompInboundInterceptor)
-                .map(interceptor -> (PubcompInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PubcompInboundInterceptor> getPubcompInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pubcompInbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PubcompInboundInterceptor> getPubcompInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PubcompInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PubcompInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return pubcompInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PubcompOutboundInterceptor> getPubcompOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PubcompOutboundInterceptor)
-                .map(interceptor -> (PubcompOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PubcompOutboundInterceptor> getPubcompOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pubcompOutbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull PubcompOutboundInterceptor> getPubcompOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PubcompOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PubcompOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return pubcompOutbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull SubscribeInboundInterceptor> getSubscribeInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof SubscribeInboundInterceptor)
-                .map(interceptor -> (SubscribeInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull SubscribeInboundInterceptor> getSubscribeInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(subscribeInbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull SubscribeInboundInterceptor> getSubscribeInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof SubscribeInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (SubscribeInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return subscribeInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull SubackOutboundInterceptor> getSubackOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof SubackOutboundInterceptor)
-                .map(interceptor -> (SubackOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull SubackOutboundInterceptor> getSubackOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(subackOutbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull SubackOutboundInterceptor> getSubackOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof SubackOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (SubackOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return subackOutbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull UnsubscribeInboundInterceptor> getUnsubscribeInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof UnsubscribeInboundInterceptor)
-                .map(interceptor -> (UnsubscribeInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull UnsubscribeInboundInterceptor> getUnsubscribeInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(unsubscribeInbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull UnsubscribeInboundInterceptor> getUnsubscribeInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof UnsubscribeInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (UnsubscribeInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return unsubscribeInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull UnsubackOutboundInterceptor> getUnsubackOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof UnsubackOutboundInterceptor)
-                .map(interceptor -> (UnsubackOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull UnsubackOutboundInterceptor> getUnsubackOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(unsubackOutbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull UnsubackOutboundInterceptor> getUnsubackOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof UnsubackOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (UnsubackOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return unsubackOutbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull DisconnectInboundInterceptor> getDisconnectInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof DisconnectInboundInterceptor)
-                .map(interceptor -> (DisconnectInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull DisconnectInboundInterceptor> getDisconnectInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(disconnectInbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull DisconnectInboundInterceptor> getDisconnectInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof DisconnectInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (DisconnectInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return disconnectInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull DisconnectOutboundInterceptor> getDisconnectOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof DisconnectOutboundInterceptor)
-                .map(interceptor -> (DisconnectOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull DisconnectOutboundInterceptor> getDisconnectOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(disconnectOutbounds, extensionClassLoader);
     }
 
     public @Immutable @NotNull List<@NotNull DisconnectOutboundInterceptor> getDisconnectOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof DisconnectOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (DisconnectOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+        return disconnectOutbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PingReqInboundInterceptor> getPingRequestInboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PingReqInboundInterceptor)
-                .map(interceptor -> (PingReqInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PingReqInboundInterceptor> getPingReqInboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pingReqInbounds, extensionClassLoader);
     }
 
-    public @Immutable @NotNull List<@NotNull PingReqInboundInterceptor> getPingRequestInboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PingReqInboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparingInt(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PingReqInboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PingReqInboundInterceptor> getPingReqInboundInterceptors() {
+        return pingReqInbounds;
     }
 
-    public @Immutable @NotNull List<@NotNull PingRespOutboundInterceptor> getPingResponseOutboundInterceptorsForPlugin(
-            final @NotNull IsolatedPluginClassloader pluginClassloader) {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor.getClass().getClassLoader().equals(pluginClassloader))
-                .filter(interceptor -> interceptor instanceof PingRespOutboundInterceptor)
-                .map(interceptor -> (PingRespOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PingRespOutboundInterceptor> getPingRespOutboundInterceptorsOfExtension(
+            final @NotNull IsolatedPluginClassloader extensionClassLoader) {
+
+        return filterInterceptorsOfExtension(pingRespOutbounds, extensionClassLoader);
     }
 
-    public @Immutable @NotNull List<@NotNull PingRespOutboundInterceptor> getPingResponseOutboundInterceptors() {
-        return interceptorList.stream()
-                .filter(interceptor -> interceptor instanceof PingRespOutboundInterceptor)
-                .filter(this::hasPluginForClassloader)
-                .sorted(Comparator.comparing(this::comparePluginPriority).reversed())
-                .map(interceptor -> (PingRespOutboundInterceptor) interceptor)
-                .collect(Collectors.toUnmodifiableList());
+    public @Immutable @NotNull List<@NotNull PingRespOutboundInterceptor> getPingRespOutboundInterceptors() {
+        return pingRespOutbounds;
     }
 
     public @NotNull ModifiableDefaultPermissions getDefaultPermissions() {
         return defaultPermissions;
     }
 
-    private int comparePluginPriority(final Object object) {
+    private <T extends Interceptor> @NotNull ImmutableList<T> addInterceptor(
+            final @NotNull ImmutableList<T> interceptors, final @NotNull T interceptor) {
+
+        if (interceptors.isEmpty()) {
+            return ImmutableList.of(interceptor);
+        }
+        final int priority = getExtensionPriority(interceptor);
+        int low = 0;
+        int high = interceptors.size() - 1;
+        while (low <= high) {
+            final int mid = low + high >>> 1;
+            final T midInterceptor = interceptors.get(mid);
+            final int midPriority = getExtensionPriority(midInterceptor);
+
+            if (midPriority >= priority) {
+                if (midPriority == priority && midInterceptor == interceptor) {
+                    return interceptors;
+                }
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+        final ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(interceptors.size() + 1);
+        for (int i = 0; i < low; i++) {
+            builder.add(interceptors.get(i));
+        }
+        builder.add(interceptor);
+        for (int i = low; i < interceptors.size(); i++) {
+            builder.add(interceptors.get(i));
+        }
+        return builder.build();
+    }
+
+    private <T extends Interceptor> @NotNull ImmutableList<T> removeInterceptor(
+            final @NotNull ImmutableList<T> interceptors, final @NotNull T interceptor) {
+
+        if (interceptors.isEmpty()) {
+            return interceptors;
+        }
+        if (interceptors.size() == 1 && interceptors.get(0) == interceptor) {
+            return ImmutableList.of();
+        }
+        final int priority = getExtensionPriority(interceptor);
+        int low = 0;
+        int high = interceptors.size() - 1;
+        while (low <= high) {
+            final int mid = low + high >>> 1;
+            final T midInterceptor = interceptors.get(mid);
+            final int midPriority = getExtensionPriority(midInterceptor);
+
+            if (midPriority >= priority) {
+                if (midPriority == priority && midInterceptor == interceptor) {
+                    final ImmutableList.Builder<T> builder =
+                            ImmutableList.builderWithExpectedSize(interceptors.size() - 1);
+                    for (int i = 0; i < mid; i++) {
+                        builder.add(interceptors.get(i));
+                    }
+                    for (int i = mid + 1; i < interceptors.size(); i++) {
+                        builder.add(interceptors.get(i));
+                    }
+                    return builder.build();
+                }
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return interceptors;
+    }
+
+    private <T extends Interceptor> @NotNull ImmutableList<T> filterInterceptorsOfExtension(
+            final @NotNull ImmutableList<T> interceptors,
+            final @NotNull IsolatedPluginClassloader extensionClassloader) {
+
+        final ImmutableList.Builder<T> builder = ImmutableList.builder();
+        for (int i = 0; i < interceptors.size(); i++) {
+            final T interceptor = interceptors.get(i);
+            if (interceptor.getClass().getClassLoader().equals(extensionClassloader)) {
+                builder.add(interceptor);
+            }
+        }
+        return builder.build();
+    }
+
+    private <T extends Interceptor> @NotNull ImmutableList<T> removeInterceptorsOfExtension(
+            final @NotNull ImmutableList<T> interceptors,
+            final @NotNull IsolatedPluginClassloader extensionClassloader) {
+
+        final ImmutableList.Builder<T> builder = ImmutableList.builder();
+        for (int i = 0; i < interceptors.size(); i++) {
+            final T interceptor = interceptors.get(i);
+            if (!interceptor.getClass().getClassLoader().equals(extensionClassloader)) {
+                builder.add(interceptor);
+            }
+        }
+        return builder.build();
+    }
+
+    private int getExtensionPriority(final @NotNull Object object) {
         if (!(object.getClass().getClassLoader() instanceof IsolatedPluginClassloader)) {
             return -1;
         }
-        final HiveMQExtension plugin = hiveMQExtensions.getExtensionForClassloader(
+        final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
                 (IsolatedPluginClassloader) object.getClass().getClassLoader());
-        if (plugin != null) {
-            return plugin.getPriority();
+        if (extension != null) {
+            return extension.getPriority();
         } else {
             return -1;
         }
-    }
-
-    private boolean hasPluginForClassloader(final Object object) {
-        if (!(object.getClass().getClassLoader() instanceof IsolatedPluginClassloader)) {
-            return true;
-        }
-        return hiveMQExtensions.getExtensionForClassloader(
-                (IsolatedPluginClassloader) object.getClass().getClassLoader()) != null;
     }
 }

--- a/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
+++ b/src/main/java/com/hivemq/extensions/client/ClientContextPluginImpl.java
@@ -64,277 +64,277 @@ public class ClientContextPluginImpl extends AbstractOutput implements ClientCon
 
     @Override
     public void addPublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPublishInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPublishOutboundInterceptor(final @NotNull PublishOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPublishOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPubackInboundInterceptor(final @NotNull PubackInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPubackInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPubackOutboundInterceptor(final @NotNull PubackOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPubackOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPubrecInboundInterceptor(final @NotNull PubrecInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPubrecInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPubrecOutboundInterceptor(final @NotNull PubrecOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPubrecOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPubrelInboundInterceptor(final @NotNull PubrelInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPubrelInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPubrelOutboundInterceptor(final @NotNull PubrelOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPubrelOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPubcompInboundInterceptor(final @NotNull PubcompInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPubcompInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPubcompOutboundInterceptor(final @NotNull PubcompOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPubcompOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addSubscribeInboundInterceptor(final @NotNull SubscribeInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addSubscribeInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addSubackOutboundInterceptor(final @NotNull SubackOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addSubackOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addUnsubscribeInboundInterceptor(final @NotNull UnsubscribeInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addUnsubscribeInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addUnsubackOutboundInterceptor(final @NotNull UnsubackOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addUnsubackOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addDisconnectInboundInterceptor(final @NotNull DisconnectInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addDisconnectInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addDisconnectOutboundInterceptor(final @NotNull DisconnectOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addDisconnectOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPingReqInboundInterceptor(final @NotNull PingReqInboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPingReqInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void addPingRespOutboundInterceptor(final @NotNull PingRespOutboundInterceptor interceptor) {
-        clientContext.addInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.addPingRespOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePublishInboundInterceptor(final @NotNull PublishInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePublishInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePublishOutboundInterceptor(final @NotNull PublishOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePublishOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePubackInboundInterceptor(final @NotNull PubackInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePubackInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePubackOutboundInterceptor(final @NotNull PubackOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePubackOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePubrecInboundInterceptor(final @NotNull PubrecInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePubrecInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePubrecOutboundInterceptor(final @NotNull PubrecOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePubrecOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePubrelInboundInterceptor(final @NotNull PubrelInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePubrelInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePubrelOutboundInterceptor(final @NotNull PubrelOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePubrelOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePubcompInboundInterceptor(final @NotNull PubcompInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePubcompInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePubcompOutboundInterceptor(final @NotNull PubcompOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePubcompOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removeSubscribeInboundInterceptor(final @NotNull SubscribeInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removeSubscribeInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removeSubackOutboundInterceptor(final @NotNull SubackOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removeSubackOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removeUnsubscribeInboundInterceptor(final @NotNull UnsubscribeInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removeUnsubscribeInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removeUnsubackOutboundInterceptor(final @NotNull UnsubackOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removeUnsubackOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removeDisconnectInboundInterceptor(final @NotNull DisconnectInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removeDisconnectInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removeDisconnectOutboundInterceptor(final @NotNull DisconnectOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removeDisconnectOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePingReqInboundInterceptor(final @NotNull PingReqInboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePingReqInboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public void removePingRespOutboundInterceptor(final @NotNull PingRespOutboundInterceptor interceptor) {
-        clientContext.removeInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
+        clientContext.removePingRespOutboundInterceptor(checkNotNull(interceptor, "The interceptor must never be null"));
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull Interceptor> getAllInterceptors() {
-        return clientContext.getAllInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getAllInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PublishInboundInterceptor> getPublishInboundInterceptors() {
-        return clientContext.getPublishInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPublishInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PublishOutboundInterceptor> getPublishOutboundInterceptors() {
-        return clientContext.getPublishOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPublishOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PubackInboundInterceptor> getPubackInboundInterceptors() {
-        return clientContext.getPubackInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPubackInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PubackOutboundInterceptor> getPubackOutboundInterceptors() {
-        return clientContext.getPubackOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPubackOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PubrecInboundInterceptor> getPubrecInboundInterceptors() {
-        return clientContext.getPubrecInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPubrecInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PubrecOutboundInterceptor> getPubrecOutboundInterceptors() {
-        return clientContext.getPubrecOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPubrecOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PubrelInboundInterceptor> getPubrelInboundInterceptors() {
-        return clientContext.getPubrelInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPubrelInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PubrelOutboundInterceptor> getPubrelOutboundInterceptors() {
-        return clientContext.getPubrelOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPubrelOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PubcompInboundInterceptor> getPubcompInboundInterceptors() {
-        return clientContext.getPubcompInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPubcompInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PubcompOutboundInterceptor> getPubcompOutboundInterceptors() {
-        return clientContext.getPubcompOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPubcompOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull SubscribeInboundInterceptor> getSubscribeInboundInterceptors() {
-        return clientContext.getSubscribeInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getSubscribeInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull SubackOutboundInterceptor> getSubackOutboundInterceptors() {
-        return clientContext.getSubackOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getSubackOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull UnsubscribeInboundInterceptor> getUnsubscribeInboundInterceptors() {
-        return clientContext.getUnsubscribeInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getUnsubscribeInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull UnsubackOutboundInterceptor> getUnsubackOutboundInterceptors() {
-        return clientContext.getUnsubackOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getUnsubackOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull DisconnectInboundInterceptor> getDisconnectInboundInterceptors() {
-        return clientContext.getDisconnectInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getDisconnectInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull DisconnectOutboundInterceptor> getDisconnectOutboundInterceptors() {
-        return clientContext.getDisconnectOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getDisconnectOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PingReqInboundInterceptor> getPingReqInboundInterceptors() {
-        return clientContext.getPingRequestInboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPingReqInboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override
     public @Immutable @NotNull List<@NotNull PingRespOutboundInterceptor> getPingRespOutboundInterceptors() {
-        return clientContext.getPingResponseOutboundInterceptorsForPlugin(pluginClassloader);
+        return clientContext.getPingRespOutboundInterceptorsOfExtension(pluginClassloader);
     }
 
     @Override

--- a/src/main/java/com/hivemq/extensions/handler/PubcompInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/PubcompInterceptorHandler.java
@@ -55,19 +55,19 @@ public class PubcompInterceptorHandler extends ChannelDuplexHandler {
     private final @NotNull FullConfigurationService configurationService;
     private final @NotNull PluginOutPutAsyncer asyncer;
     private final @NotNull HiveMQExtensions hiveMQExtensions;
-    private final @NotNull PluginTaskExecutorService pluginTaskExecutorService;
+    private final @NotNull PluginTaskExecutorService executorService;
 
     @Inject
     public PubcompInterceptorHandler(
             final @NotNull FullConfigurationService configurationService,
             final @NotNull PluginOutPutAsyncer asyncer,
             final @NotNull HiveMQExtensions hiveMQExtensions,
-            final @NotNull PluginTaskExecutorService pluginTaskExecutorService) {
+            final @NotNull PluginTaskExecutorService executorService) {
 
         this.configurationService = configurationService;
         this.asyncer = asyncer;
         this.hiveMQExtensions = hiveMQExtensions;
-        this.pluginTaskExecutorService = pluginTaskExecutorService;
+        this.executorService = executorService;
     }
 
     @Override
@@ -124,19 +124,19 @@ public class PubcompInterceptorHandler extends ChannelDuplexHandler {
 
         for (final PubcompOutboundInterceptor interceptor : interceptors) {
 
-            final HiveMQExtension plugin = hiveMQExtensions.getExtensionForClassloader(
+            final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
                     (IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
 
             // disabled extension would be null
-            if (plugin == null) {
+            if (extension == null) {
                 interceptorContext.increment(output);
                 continue;
             }
 
             final PubcompOutboundInterceptorTask interceptorTask =
-                    new PubcompOutboundInterceptorTask(interceptor, plugin.getId());
+                    new PubcompOutboundInterceptorTask(interceptor, extension.getId());
 
-            pluginTaskExecutorService.handlePluginInOutTaskExecution(
+            executorService.handlePluginInOutTaskExecution(
                     interceptorContext, input, output, interceptorTask);
         }
     }
@@ -168,19 +168,19 @@ public class PubcompInterceptorHandler extends ChannelDuplexHandler {
 
         for (final PubcompInboundInterceptor interceptor : interceptors) {
 
-            final HiveMQExtension plugin = hiveMQExtensions.getExtensionForClassloader(
+            final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
                     (IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
 
             // disabled extension would be null
-            if (plugin == null) {
+            if (extension == null) {
                 interceptorContext.increment(output);
                 continue;
             }
 
             final PubcompInboundInterceptorTask interceptorTask =
-                    new PubcompInboundInterceptorTask(interceptor, plugin.getId());
+                    new PubcompInboundInterceptorTask(interceptor, extension.getId());
 
-            pluginTaskExecutorService.handlePluginInOutTaskExecution(
+            executorService.handlePluginInOutTaskExecution(
                     interceptorContext, input, output, interceptorTask);
         }
     }

--- a/src/main/java/com/hivemq/extensions/handler/PubrecInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/PubrecInterceptorHandler.java
@@ -123,17 +123,17 @@ public class PubrecInterceptorHandler extends ChannelDuplexHandler {
 
         for (final PubrecOutboundInterceptor interceptor : interceptors) {
 
-            final HiveMQExtension plugin = hiveMQExtensions.getExtensionForClassloader(
+            final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
                     (IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
 
             // disabled extension would be null
-            if (plugin == null) {
+            if (extension == null) {
                 interceptorContext.increment(output);
                 continue;
             }
 
             final PubrecOutboundInterceptorTask
-                    interceptorTask = new PubrecOutboundInterceptorTask(interceptor, plugin.getId());
+                    interceptorTask = new PubrecOutboundInterceptorTask(interceptor, extension.getId());
 
             pluginTaskExecutorService.handlePluginInOutTaskExecution(
                     interceptorContext, input, output, interceptorTask);
@@ -168,17 +168,17 @@ public class PubrecInterceptorHandler extends ChannelDuplexHandler {
 
         for (final PubrecInboundInterceptor interceptor : interceptors) {
 
-            final HiveMQExtension plugin = hiveMQExtensions.getExtensionForClassloader(
+            final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
                     (IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
 
             // disabled extension would be null
-            if (plugin == null) {
+            if (extension == null) {
                 interceptorContext.increment(output);
                 continue;
             }
 
             final PubrecInboundInterceptorTask interceptorTask =
-                    new PubrecInboundInterceptorTask(interceptor, plugin.getId());
+                    new PubrecInboundInterceptorTask(interceptor, extension.getId());
 
             pluginTaskExecutorService.handlePluginInOutTaskExecution(
                     interceptorContext, input, output, interceptorTask);

--- a/src/main/java/com/hivemq/extensions/handler/PubrelInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/PubrelInterceptorHandler.java
@@ -55,19 +55,19 @@ public class PubrelInterceptorHandler extends ChannelDuplexHandler {
     private final @NotNull FullConfigurationService configurationService;
     private final @NotNull PluginOutPutAsyncer asyncer;
     private final @NotNull HiveMQExtensions hiveMQExtensions;
-    private final @NotNull PluginTaskExecutorService pluginTaskExecutorService;
+    private final @NotNull PluginTaskExecutorService executorService;
 
     @Inject
     public PubrelInterceptorHandler(
             final @NotNull FullConfigurationService configurationService,
             final @NotNull PluginOutPutAsyncer asyncer,
             final @NotNull HiveMQExtensions hiveMQExtensions,
-            final @NotNull PluginTaskExecutorService pluginTaskExecutorService) {
+            final @NotNull PluginTaskExecutorService executorService) {
 
         this.configurationService = configurationService;
         this.asyncer = asyncer;
         this.hiveMQExtensions = hiveMQExtensions;
-        this.pluginTaskExecutorService = pluginTaskExecutorService;
+        this.executorService = executorService;
     }
 
     @Override
@@ -124,18 +124,18 @@ public class PubrelInterceptorHandler extends ChannelDuplexHandler {
 
         for (final PubrelOutboundInterceptor interceptor : interceptors) {
 
-            final HiveMQExtension plugin = hiveMQExtensions.getExtensionForClassloader(
+            final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
                     (IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
 
             // disabled extension would be null
-            if (plugin == null) {
+            if (extension == null) {
                 interceptorContext.increment(output);
                 continue;
             }
             final PubrelOutboundInterceptorTask interceptorTask =
-                    new PubrelOutboundInterceptorTask(interceptor, plugin.getId());
+                    new PubrelOutboundInterceptorTask(interceptor, extension.getId());
 
-            pluginTaskExecutorService.handlePluginInOutTaskExecution(
+            executorService.handlePluginInOutTaskExecution(
                     interceptorContext, input, output, interceptorTask);
         }
     }
@@ -168,18 +168,18 @@ public class PubrelInterceptorHandler extends ChannelDuplexHandler {
 
         for (final PubrelInboundInterceptor interceptor : interceptors) {
 
-            final HiveMQExtension plugin = hiveMQExtensions.getExtensionForClassloader(
+            final HiveMQExtension extension = hiveMQExtensions.getExtensionForClassloader(
                     (IsolatedPluginClassloader) interceptor.getClass().getClassLoader());
 
             // disabled extension would be null
-            if (plugin == null) {
+            if (extension == null) {
                 interceptorContext.increment(output);
                 continue;
             }
             final PubrelInboundInterceptorTask interceptorTask =
-                    new PubrelInboundInterceptorTask(interceptor, plugin.getId());
+                    new PubrelInboundInterceptorTask(interceptor, extension.getId());
 
-            pluginTaskExecutorService.handlePluginInOutTaskExecution(
+            executorService.handlePluginInOutTaskExecution(
                     interceptorContext, input, output, interceptorTask);
         }
     }

--- a/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandler.java
@@ -61,19 +61,19 @@ public class UnsubscribeInboundInterceptorHandler extends ChannelInboundHandlerA
     private final @NotNull FullConfigurationService configurationService;
     private final @NotNull PluginOutPutAsyncer asyncer;
     private final @NotNull HiveMQExtensions hiveMQExtensions;
-    private final @NotNull PluginTaskExecutorService pluginTaskExecutorService;
+    private final @NotNull PluginTaskExecutorService executorService;
 
     @Inject
     public UnsubscribeInboundInterceptorHandler(
             final @NotNull FullConfigurationService configurationService,
             final @NotNull PluginOutPutAsyncer asyncer,
             final @NotNull HiveMQExtensions hiveMQExtensions,
-            final @NotNull PluginTaskExecutorService pluginTaskExecutorService) {
+            final @NotNull PluginTaskExecutorService executorService) {
 
         this.configurationService = configurationService;
         this.asyncer = asyncer;
         this.hiveMQExtensions = hiveMQExtensions;
-        this.pluginTaskExecutorService = pluginTaskExecutorService;
+        this.executorService = executorService;
     }
 
     @Override
@@ -127,7 +127,7 @@ public class UnsubscribeInboundInterceptorHandler extends ChannelInboundHandlerA
 
             final UnsubscribeInboundInterceptorTask interceptorTask =
                     new UnsubscribeInboundInterceptorTask(interceptor, extension.getId());
-            pluginTaskExecutorService.handlePluginInOutTaskExecution(
+            executorService.handlePluginInOutTaskExecution(
                     interceptorContext, input, output, interceptorTask);
         }
     }

--- a/src/test/java/com/hivemq/extensions/handler/IncomingSubscribeHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/IncomingSubscribeHandlerTest.java
@@ -16,7 +16,6 @@
 
 package com.hivemq.extensions.handler;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 import com.hivemq.annotations.NotNull;
 import com.hivemq.common.shutdown.ShutdownHooks;
@@ -47,7 +46,6 @@ import com.hivemq.mqtt.message.suback.SUBACK;
 import com.hivemq.mqtt.message.subscribe.SUBSCRIBE;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.util.ChannelAttributes;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
@@ -381,7 +379,7 @@ public class IncomingSubscribeHandlerTest {
             }
         });
 
-        when(hiveMQExtensions.getExtensionForClassloader(any(IsolatedPluginClassloader.class))).thenReturn(plugin, plugin, null);
+        when(hiveMQExtensions.getExtensionForClassloader(any(IsolatedPluginClassloader.class))).thenReturn(null);
 
         channel.writeInbound(new SUBSCRIBE(1, new Topic("topic", QoS.AT_LEAST_ONCE, true, true, Mqtt5RetainHandling.SEND, 1)));
 

--- a/src/test/java/com/hivemq/extensions/handler/PingInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/PingInterceptorHandlerTest.java
@@ -125,7 +125,7 @@ public class PingInterceptorHandlerTest {
                 = new ClientContextImpl(hiveMQExtensions, new ModifiableDefaultPermissionsImpl());
 
         final PingReqInboundInterceptor interceptor = getIsolatedInboundInterceptor("SimplePingReqTestInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addPingReqInboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -152,7 +152,7 @@ public class PingInterceptorHandlerTest {
 
         final PingReqInboundInterceptor interceptor =
                 getIsolatedInboundInterceptor("AdvancedPingReqTestInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addPingReqInboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -178,7 +178,7 @@ public class PingInterceptorHandlerTest {
 
         final PingRespOutboundInterceptor interceptor =
                 getIsolatedOutboundInterceptor("SimplePingRespTestInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addPingRespOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -204,7 +204,7 @@ public class PingInterceptorHandlerTest {
 
         final PingRespOutboundInterceptor interceptor =
                 getIsolatedOutboundInterceptor("AdvancedPingRespTestInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addPingRespOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -224,7 +224,7 @@ public class PingInterceptorHandlerTest {
     }
 
 
-    private PingReqInboundInterceptor getIsolatedInboundInterceptor(final @NotNull String name) throws Exception {
+    private @NotNull PingReqInboundInterceptor getIsolatedInboundInterceptor(final @NotNull String name) throws Exception {
         final JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
                 .addClass("com.hivemq.extensions.handler.PingInterceptorHandlerTest$" + name);
 
@@ -244,7 +244,8 @@ public class PingInterceptorHandlerTest {
         return interceptor;
     }
 
-    private PingRespOutboundInterceptor getIsolatedOutboundInterceptor(final @NotNull String name)
+
+    private @NotNull PingRespOutboundInterceptor getIsolatedOutboundInterceptor(final @NotNull String name)
             throws Exception {
         final JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
                 .addClass("com.hivemq.extensions.handler.PingInterceptorHandlerTest$" + name);

--- a/src/test/java/com/hivemq/extensions/handler/SubackOutboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/SubackOutboundInterceptorHandlerTest.java
@@ -117,7 +117,7 @@ public class SubackOutboundInterceptorHandlerTest {
                 new ClientContextImpl(hiveMQExtensions, new ModifiableDefaultPermissionsImpl());
 
         final SubackOutboundInterceptor interceptor = getIsolatedOutboundInterceptor("SimpleSubackTestInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addSubackOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -141,7 +141,7 @@ public class SubackOutboundInterceptorHandlerTest {
                 new ClientContextImpl(hiveMQExtensions, new ModifiableDefaultPermissionsImpl());
 
         final SubackOutboundInterceptor interceptor = getIsolatedOutboundInterceptor("TestModifySubackInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addSubackOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -167,7 +167,7 @@ public class SubackOutboundInterceptorHandlerTest {
                 new ClientContextImpl(hiveMQExtensions, new ModifiableDefaultPermissionsImpl());
 
         final SubackOutboundInterceptor interceptor = getIsolatedOutboundInterceptor("TestExceptionSubackInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addSubackOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -191,7 +191,7 @@ public class SubackOutboundInterceptorHandlerTest {
                 new ClientContextImpl(hiveMQExtensions, new ModifiableDefaultPermissionsImpl());
         final SubackOutboundInterceptor interceptor =
                 getIsolatedOutboundInterceptor("TestIndexOutofBoundsSubackInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addSubackOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);

--- a/src/test/java/com/hivemq/extensions/handler/UnsubackOutboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/UnsubackOutboundInterceptorHandlerTest.java
@@ -117,7 +117,7 @@ public class UnsubackOutboundInterceptorHandlerTest {
         final ClientContextImpl clientContext =
                 new ClientContextImpl(extensions, new ModifiableDefaultPermissionsImpl());
         final UnsubackOutboundInterceptor interceptor = getIsolatedOutboundInterceptor("TestSimpleUnsubackInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addUnsubackOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -140,7 +140,7 @@ public class UnsubackOutboundInterceptorHandlerTest {
         final ClientContextImpl clientContext =
                 new ClientContextImpl(extensions, new ModifiableDefaultPermissionsImpl());
         final UnsubackOutboundInterceptor interceptor = getIsolatedOutboundInterceptor("TestModifyUnsubackInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addUnsubackOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
@@ -165,7 +165,7 @@ public class UnsubackOutboundInterceptorHandlerTest {
 
         final UnsubackOutboundInterceptor interceptor =
                 getIsolatedOutboundInterceptor("TestExceptionUnsubackInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addUnsubackOutboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);

--- a/src/test/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/UnsubscribeInboundInterceptorHandlerTest.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.interceptor.unsubscribe.UnsubscribeInboundInterceptor;
 import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundInput;
 import com.hivemq.extension.sdk.api.interceptor.unsubscribe.parameter.UnsubscribeInboundOutput;
@@ -44,6 +43,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -57,7 +57,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 public class UnsubscribeInboundInterceptorHandlerTest {
@@ -129,12 +128,12 @@ public class UnsubscribeInboundInterceptorHandlerTest {
 
         final UnsubscribeInboundInterceptor interceptor =
                 getIsolatedInboundInterceptor("SimpleUnsubscribeTestInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addUnsubscribeInboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
 
-        when(extensions.getExtensionForClassloader(any(IsolatedPluginClassloader.class))).thenReturn(extension);
+        when(extensions.getExtensionForClassloader(ArgumentMatchers.any(IsolatedPluginClassloader.class))).thenReturn(extension);
 
         channel.writeInbound(testUnsubscribe());
         UNSUBSCRIBE unsubscribe = channel.readInbound();
@@ -154,12 +153,12 @@ public class UnsubscribeInboundInterceptorHandlerTest {
 
         final UnsubscribeInboundInterceptor interceptor =
                 getIsolatedInboundInterceptor("ModifyUnsubscribeTestInterceptor");
-        clientContext.addInterceptor(interceptor);
+        clientContext.addUnsubscribeInboundInterceptor(interceptor);
 
         channel.attr(ChannelAttributes.PLUGIN_CLIENT_CONTEXT).set(clientContext);
         channel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
 
-        when(extensions.getExtensionForClassloader(any(IsolatedPluginClassloader.class))).thenReturn(extension);
+        when(extensions.getExtensionForClassloader(ArgumentMatchers.any(IsolatedPluginClassloader.class))).thenReturn(extension);
 
         channel.writeInbound(testUnsubscribe());
         UNSUBSCRIBE unsubscribe = channel.readInbound();


### PR DESCRIPTION
**Motivation**
When implementing for example publish inbound and outbound interceptors but only calling `addPublishInboundInterceptor`, the outbound interceptor is also called.

**Changes**
* Split interceptor list by type for correct handling of multiple interceptor implementations
* Cleaned up plugin -> extension in interceptors