### PR TITLE
Move Javassist to test dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,6 @@ dependencies {
             [group: 'io.netty', name: 'netty-handler', version: nettyVersion],
             [group: 'io.netty', name: 'netty-codec-http', version: nettyVersion],
 
-            /* Javassist is needed for better netty performance */
-            [group: 'org.javassist', name: 'javassist', version: '3.24.0-GA'],
             /* Logging */
             [group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.25'],
 
@@ -219,6 +217,8 @@ dependencies {
 
             // wiremock
             [group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.8.0'],
+
+            [group: 'org.javassist', name: 'javassist', version: '3.26.0-GA'],
     )
 
     testCompile([group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0']) {


### PR DESCRIPTION
**Motivation**

Netty has removed the usage of this optional dependency back in 2017: https://github.com/netty/netty/commit/7d08b4fc357e12ee2487e87d8fdcbeee1152e5a0

**Changes**

Move Javassist to test dependencies as we are using it in our test utils.
