### PR TITLE
fix HIVEMQ_HOME leading to startup error

### DIFF
--- a/src/packaging/bin/diagnostics.sh
+++ b/src/packaging/bin/diagnostics.sh
@@ -23,7 +23,7 @@ echo '                 |_|  |_||_|  \_/  \___||_|  |_| \___\_\'
 echo
 echo "-------------------------------------------------------------------------"
 echo ""
-echo "  HiveMQ Start Script for Linux/Unix v1.10"
+echo "  HiveMQ Start Script for Linux/Unix v1.11"
 echo ""
 echo "                 DIAGNOSTIC MODE "
 echo ""
@@ -61,8 +61,8 @@ if hash java 2>/dev/null; then
         HIVEMQ_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
         HOME_OPT="-Dhivemq.home=$HIVEMQ_FOLDER"
     else
-        HIVEMQ_FOLDER=$HIVEMQ_HOME
-        HOME_OPT=""
+        HIVEMQ_FOLDER="$HIVEMQ_HOME"
+        HOME_OPT="-Dhivemq.home=$HIVEMQ_FOLDER"
     fi
 
     if [ ! -d "$HIVEMQ_FOLDER" ]; then

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -23,7 +23,7 @@ echo '                 |_|  |_||_|  \_/  \___||_|  |_| \___\_\'
 echo
 echo "-------------------------------------------------------------------------"
 echo ""
-echo "  HiveMQ Start Script for Linux/Unix v1.10"
+echo "  HiveMQ Start Script for Linux/Unix v1.11"
 echo ""
 
 if hash java 2>/dev/null; then
@@ -60,8 +60,8 @@ if hash java 2>/dev/null; then
         HIVEMQ_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
         HOME_OPT="-Dhivemq.home=$HIVEMQ_FOLDER"
     else
-        HIVEMQ_FOLDER=$HIVEMQ_HOME
-        HOME_OPT=""
+        HIVEMQ_FOLDER="$HIVEMQ_HOME"
+        HOME_OPT="-Dhivemq.home=$HIVEMQ_FOLDER"
     fi
 
     if [ ! -d "$HIVEMQ_FOLDER" ]; then


### PR DESCRIPTION
**Motivation**

Fixes incorrect behavior of run.sh script when setting a custom HIVEMQ_HOME value

**Changes**

HOME_OPT is now set correctly even when HIVEMQ_HOME is set instead of being set as empty.