### PR TITLE
increase systemd unit's stop timeout

### DIFF
--- a/src/packaging/bin/init-script/hivemq.service
+++ b/src/packaging/bin/init-script/hivemq.service
@@ -14,6 +14,7 @@ KillMode=process
 Restart=always
 KillSignal=15
 SuccessExitStatus=143
+TimeoutStopSec=3600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
to compensate for possibly slow shutdown after SIGTERM under heavy load
(systemd default is 90s)

**Motivation**

Resolves HMQE-928

**Changes**

override timeout in systemd unit