### PR TITLE
Fixed takeover retry

### DIFF
--- a/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
@@ -427,6 +427,7 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
 
             @Override
             public void onFailure(@NotNull final Throwable t) {
+                ctx.close();
                 Exceptions.rethrowError("Exception on disconnecting client with same client identifier", t);
             }
         }, ctx.executor());

--- a/src/main/java/com/hivemq/persistence/ChannelPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/ChannelPersistenceImpl.java
@@ -39,7 +39,6 @@ public class ChannelPersistenceImpl implements ChannelPersistence {
     @Nullable
     @Override
     public Channel get(final @NotNull String clientId) {
-
         return channelMap.get(clientId);
     }
 

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -616,7 +616,9 @@ public class ConnectHandlerTest {
         disconnectFuture.set(null);
         oldChannel.attr(ChannelAttributes.DISCONNECT_FUTURE).set(disconnectFuture);
 
-        when(channelPersistence.get(eq("sameClientId"))).thenReturn(oldChannel);
+        final AtomicReference<Channel> oldChannelRef = new AtomicReference<>(oldChannel);
+        when(channelPersistence.get(eq("sameClientId"))).thenAnswer(invocation -> oldChannelRef.get());
+        when(channelPersistence.remove(eq("sameClientId"))).thenAnswer(invocation -> oldChannelRef.getAndSet(null));
 
         assertTrue(oldChannel.isOpen());
         assertTrue(embeddedChannel.isOpen());
@@ -652,7 +654,9 @@ public class ConnectHandlerTest {
         disconnectFuture.set(null);
         oldChannel.attr(ChannelAttributes.DISCONNECT_FUTURE).set(disconnectFuture);
 
-        when(channelPersistence.get(eq("sameClientId"))).thenReturn(oldChannel);
+        final AtomicReference<Channel> oldChannelRef = new AtomicReference<>(oldChannel);
+        when(channelPersistence.get(eq("sameClientId"))).thenAnswer(invocation -> oldChannelRef.get());
+        when(channelPersistence.remove(eq("sameClientId"))).thenAnswer(invocation -> oldChannelRef.getAndSet(null));
 
         assertTrue(oldChannel.isOpen());
         assertTrue(embeddedChannel.isOpen());
@@ -685,19 +689,20 @@ public class ConnectHandlerTest {
         final Waiter disconnectMessageWaiter = new Waiter();
         final TestDisconnectHandler testDisconnectHandler = new TestDisconnectHandler(disconnectMessageWaiter, true);
 
-        final EmbeddedChannel oldChannel = new EmbeddedChannel(testDisconnectHandler, new TestDisconnectEventHandler(disconnectEventLatch));
+        final EmbeddedChannel oldChannel =
+                new EmbeddedChannel(testDisconnectHandler, new TestDisconnectEventHandler(disconnectEventLatch));
         oldChannel.attr(ChannelAttributes.TAKEN_OVER).set(true);
         oldChannel.attr(ChannelAttributes.DISCONNECT_FUTURE).set(disconnectFuture);
         oldChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
 
-        when(channelPersistence.get(eq("sameClientId"))).thenReturn(oldChannel);
+        final AtomicReference<Channel> oldChannelRef = new AtomicReference<>(oldChannel);
+        when(channelPersistence.get(eq("sameClientId"))).thenAnswer(invocation -> oldChannelRef.get());
+        when(channelPersistence.remove(eq("sameClientId"))).thenAnswer(invocation -> oldChannelRef.getAndSet(null));
 
         assertTrue(oldChannel.isOpen());
         assertTrue(embeddedChannel.isOpen());
 
-        final CONNECT connect1 = new CONNECT.Mqtt5Builder()
-                .withClientIdentifier("sameClientId")
-                .build();
+        final CONNECT connect1 = new CONNECT.Mqtt5Builder().withClientIdentifier("sameClientId").build();
 
         embeddedChannel.writeInbound(connect1);
 
@@ -731,19 +736,20 @@ public class ConnectHandlerTest {
         final Waiter disconnectMessageWaiter = new Waiter();
         final TestDisconnectHandler testDisconnectHandler = new TestDisconnectHandler(disconnectMessageWaiter, false);
 
-        final EmbeddedChannel oldChannel = new EmbeddedChannel(testDisconnectHandler, new TestDisconnectEventHandler(disconnectEventLatch));
+        final EmbeddedChannel oldChannel =
+                new EmbeddedChannel(testDisconnectHandler, new TestDisconnectEventHandler(disconnectEventLatch));
         oldChannel.attr(ChannelAttributes.TAKEN_OVER).set(true);
         oldChannel.attr(ChannelAttributes.DISCONNECT_FUTURE).set(disconnectFuture);
         oldChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1);
 
-        when(channelPersistence.get(eq("sameClientId"))).thenReturn(oldChannel);
+        final AtomicReference<Channel> oldChannelRef = new AtomicReference<>(oldChannel);
+        when(channelPersistence.get(eq("sameClientId"))).thenAnswer(invocation -> oldChannelRef.get());
+        when(channelPersistence.remove(eq("sameClientId"))).thenAnswer(invocation -> oldChannelRef.getAndSet(null));
 
         assertTrue(oldChannel.isOpen());
         assertTrue(embeddedChannel.isOpen());
 
-        final CONNECT connect1 = new CONNECT.Mqtt5Builder()
-                .withClientIdentifier("sameClientId")
-                .build();
+        final CONNECT connect1 = new CONNECT.Mqtt5Builder().withClientIdentifier("sameClientId").build();
 
         embeddedChannel.writeInbound(connect1);
 

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -19,17 +19,18 @@ package com.hivemq.mqtt.handler.connect;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.bootstrap.netty.ChannelDependencies;
 import com.hivemq.bootstrap.netty.ChannelHandlerNames;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.InternalConfigurations;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.auth.parameter.TopicPermission;
 import com.hivemq.extension.sdk.api.packets.auth.DefaultAuthorizationBehaviour;
 import com.hivemq.extension.sdk.api.packets.auth.ModifiableDefaultPermissions;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
 import com.hivemq.extension.sdk.api.packets.publish.AckReasonCode;
+import com.hivemq.extensions.auth.parameter.ModifiableClientSettingsImpl;
 import com.hivemq.extensions.events.OnServerDisconnectEvent;
 import com.hivemq.extensions.handler.PluginAuthenticatorServiceImpl;
 import com.hivemq.extensions.handler.PluginAuthorizerService;
@@ -37,7 +38,6 @@ import com.hivemq.extensions.handler.PluginAuthorizerServiceImpl.AuthorizeWillRe
 import com.hivemq.extensions.handler.tasks.PublishAuthorizerResult;
 import com.hivemq.extensions.packets.general.ModifiableDefaultPermissionsImpl;
 import com.hivemq.extensions.services.auth.Authorizers;
-import com.hivemq.extensions.auth.parameter.ModifiableClientSettingsImpl;
 import com.hivemq.extensions.services.builder.TopicPermissionBuilderImpl;
 import com.hivemq.limitation.TopicAliasLimiterImpl;
 import com.hivemq.logging.EventLog;
@@ -609,8 +609,12 @@ public class ConnectHandlerTest {
         final Waiter disconnectMessageWaiter = new Waiter();
         final TestDisconnectHandler testDisconnectHandler = new TestDisconnectHandler(disconnectMessageWaiter, false);
 
-        final EmbeddedChannel oldChannel = new EmbeddedChannel(testDisconnectHandler, new TestDisconnectEventHandler(disconnectEventLatch));
+        final EmbeddedChannel oldChannel =
+                new EmbeddedChannel(testDisconnectHandler, new TestDisconnectEventHandler(disconnectEventLatch));
         oldChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1_1);
+        final SettableFuture<Void> disconnectFuture = SettableFuture.create();
+        disconnectFuture.set(null);
+        oldChannel.attr(ChannelAttributes.DISCONNECT_FUTURE).set(disconnectFuture);
 
         when(channelPersistence.get(eq("sameClientId"))).thenReturn(oldChannel);
 
@@ -641,8 +645,12 @@ public class ConnectHandlerTest {
         final Waiter disconnectMessageWaiter = new Waiter();
         final TestDisconnectHandler testDisconnectHandler = new TestDisconnectHandler(disconnectMessageWaiter, true);
 
-        final EmbeddedChannel oldChannel = new EmbeddedChannel(testDisconnectHandler, new TestDisconnectEventHandler(disconnectEventLatch));
+        final EmbeddedChannel oldChannel =
+                new EmbeddedChannel(testDisconnectHandler, new TestDisconnectEventHandler(disconnectEventLatch));
         oldChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);
+        final SettableFuture<Void> disconnectFuture = SettableFuture.create();
+        disconnectFuture.set(null);
+        oldChannel.attr(ChannelAttributes.DISCONNECT_FUTURE).set(disconnectFuture);
 
         when(channelPersistence.get(eq("sameClientId"))).thenReturn(oldChannel);
 


### PR DESCRIPTION
**Motivation**

Concurrent connect tries with the same client id could lead to wrong retries

**Changes**
* exceeding MAX_TAKEOVER_RETRIES is treated as an error
* ChannelPersistence.persist is executed inside stripedLock