### PR TITLE
Fixed that a ConnectInboundInterceptor changes the MQTT version to 5

### DIFF
--- a/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt311ConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt311ConnectDecoder.java
@@ -19,7 +19,6 @@ import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.codec.decoder.AbstractMqttConnectDecoder;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.service.FullConfigurationService;
-import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
@@ -231,10 +230,7 @@ public class Mqtt311ConnectDecoder extends AbstractMqttConnectDecoder {
                 .withPassword(password)
                 .withCleanStart(isCleanSessionFlag)
                 .withSessionExpiryInterval(isCleanSessionFlag ? 0 : maxSessionExpiryInterval)
-                .withKeepAliveTimer(keepAlive)
-                .withPasswordRequired(isPasswordFlag)
-                .withUsernameRequired(isUsernameFlag)
-                .withWill(isWillFlag)
+                .withKeepAlive(keepAlive)
                 .withWillPublish(willPublish).build();
     }
 

--- a/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt31ConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt31ConnectDecoder.java
@@ -19,7 +19,6 @@ import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.codec.decoder.AbstractMqttConnectDecoder;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.service.FullConfigurationService;
-import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
@@ -207,10 +206,7 @@ public class Mqtt31ConnectDecoder extends AbstractMqttConnectDecoder {
                 .withPassword(password)
                 .withCleanStart(isCleanSessionFlag)
                 .withSessionExpiryInterval(isCleanSessionFlag ? 0 : maxSessionExpiryInterval)
-                .withKeepAliveTimer(keepAlive)
-                .withPasswordRequired(isPasswordFlag)
-                .withUsernameRequired(isUsernameFlag)
-                .withWill(isWillFlag)
+                .withKeepAlive(keepAlive)
                 .withWillPublish(willPublish).build();
     }
 

--- a/src/main/java/com/hivemq/codec/encoder/mqtt3/Mqtt3ConnectEncoder.java
+++ b/src/main/java/com/hivemq/codec/encoder/mqtt3/Mqtt3ConnectEncoder.java
@@ -15,8 +15,8 @@
  */
 package com.hivemq.codec.encoder.mqtt3;
 
-import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.codec.encoder.MqttEncoder;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.mqtt.message.ProtocolVersion;
 import com.hivemq.mqtt.message.connect.CONNECT;
 import com.hivemq.util.Bytes;
@@ -59,14 +59,14 @@ public class Mqtt3ConnectEncoder extends AbstractVariableHeaderLengthEncoder<CON
 
         Strings.createPrefixedBytesFromString(msg.getClientIdentifier(), out);
 
-        if (msg.isWill()) {
+        if (msg.getWillPublish() != null) {
             Strings.createPrefixedBytesFromString(msg.getWillPublish().getTopic(), out);
             Bytes.prefixBytes(msg.getWillPublish().getPayload(), out);
         }
-        if (msg.isUsernameRequired()) {
+        if (msg.getUsername() != null) {
             Strings.createPrefixedBytesFromString(msg.getUsername(), out);
         }
-        if (msg.isPasswordRequired()) {
+        if (msg.getPassword() != null) {
             Bytes.prefixBytes(msg.getPassword(), out);
         }
     }
@@ -83,14 +83,14 @@ public class Mqtt3ConnectEncoder extends AbstractVariableHeaderLengthEncoder<CON
         length += 1; // connect flag
         length += 2; // keep alive time
         length += Utf8Utils.encodedLength(msg.getClientIdentifier()) + 2;
-        if (msg.isWill()) {
+        if (msg.getWillPublish() != null) {
             length += Utf8Utils.encodedLength(msg.getWillPublish().getTopic()) + 2;
             length += msg.getWillPublish().getPayload().length + 2;
         }
-        if (msg.isUsernameRequired()) {
+        if (msg.getUsername() != null) {
             length += Utf8Utils.encodedLength(msg.getUsername()) + 2;
         }
-        if (msg.isPasswordRequired()) {
+        if (msg.getPassword() != null) {
             length += msg.getPassword().length + 2;
         }
         return length;
@@ -105,13 +105,13 @@ public class Mqtt3ConnectEncoder extends AbstractVariableHeaderLengthEncoder<CON
     private byte createConnectionFlag(final CONNECT message) {
         byte connectFlag = 0b0000_0000;
 
-        if (message.isUsernameRequired()) {
+        if (message.getUsername() != null) {
             connectFlag |= 0b1000_0000;
         }
-        if (message.isPasswordRequired()) {
+        if (message.getPassword() != null) {
             connectFlag |= 0b0100_0000;
         }
-        if (message.isWill()) {
+        if (message.getWillPublish() != null) {
 
             connectFlag |= 0b0000_0100;
 

--- a/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/ConnectHandler.java
@@ -269,7 +269,7 @@ public class ConnectHandler extends SimpleChannelInboundHandler<CONNECT> impleme
         if (connect.getMaximumPacketSize() == MAXIMUM_PACKET_SIZE_NOT_SET) {
             connect.setMaximumPacketSize(DEFAULT_MAXIMUM_PACKET_SIZE_NO_LIMIT);
         }
-        if (connect.isWill()) {
+        if (connect.getWillPublish() != null) {
             final MqttWillPublish willPublish = connect.getWillPublish();
             if (willPublish.getMessageExpiryInterval() > maxMessageExpiryInterval) {
                 willPublish.setMessageExpiryInterval(maxMessageExpiryInterval);

--- a/src/main/java/com/hivemq/mqtt/message/connect/Mqtt3CONNECT.java
+++ b/src/main/java/com/hivemq/mqtt/message/connect/Mqtt3CONNECT.java
@@ -25,30 +25,17 @@ import com.hivemq.mqtt.message.ProtocolVersion;
  */
 public interface Mqtt3CONNECT extends Message {
 
-    boolean isWill();
+    @NotNull ProtocolVersion getProtocolVersion();
 
-    boolean isPasswordRequired();
-
-    boolean isUsernameRequired();
+    @NotNull String getClientIdentifier();
 
     int getKeepAlive();
 
-    @NotNull
-    String getClientIdentifier();
+    @Nullable String getUsername();
 
-    @Nullable
-    String getUsername();
+    byte @Nullable [] getPassword();
 
-    @Nullable
-    byte[] getPassword();
+    @Nullable String getPasswordAsUTF8String();
 
-    @Nullable
-    String getPasswordAsUTF8String();
-
-    @NotNull
-    ProtocolVersion getProtocolVersion();
-
-    @Nullable
-    MqttWillPublish getWillPublish();
-
+    @Nullable MqttWillPublish getWillPublish();
 }

--- a/src/main/java/com/hivemq/mqtt/message/connect/Mqtt5CONNECT.java
+++ b/src/main/java/com/hivemq/mqtt/message/connect/Mqtt5CONNECT.java
@@ -17,6 +17,7 @@ package com.hivemq.mqtt.message.connect;
 
 import com.hivemq.codec.encoder.mqtt5.MqttVariableByteInteger;
 import com.hivemq.codec.encoder.mqtt5.UnsignedDataTypes;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.mqtt.message.Message;
 
 /**
@@ -54,34 +55,32 @@ public interface Mqtt5CONNECT extends Message {
     boolean DEFAULT_RESPONSE_INFORMATION_REQUESTED = false;
     boolean DEFAULT_PROBLEM_INFORMATION_REQUESTED = true;
 
-    //Flags
     boolean isCleanStart();
-
-    boolean isResponseInformationRequested();
-
-    boolean isProblemInformationRequested();
 
     long getSessionExpiryInterval();
 
-    //Restrictions
+    // restrictions
     int getReceiveMaximum();
 
     int getTopicAliasMaximum();
 
     long getMaximumPacketSize();
 
-    //Enhanced Auth
-    String getAuthMethod();
+    boolean isResponseInformationRequested();
 
-    byte[] getAuthData();
+    boolean isProblemInformationRequested();
 
-    //Simple Auth
-    String getUsername();
+    // simple auth
+    @Nullable String getUsername();
 
-    byte[] getPassword();
+    byte @Nullable [] getPassword();
 
-    String getPasswordAsUTF8String();
+    @Nullable String getPasswordAsUTF8String();
 
-    MqttWillPublish getWillPublish();
+    // enhanced auth
+    @Nullable String getAuthMethod();
 
+    byte @Nullable [] getAuthData();
+
+    @Nullable MqttWillPublish getWillPublish();
 }

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderTest.java
@@ -92,9 +92,6 @@ public class Mqtt31ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(true, connectPacket.isCleanStart());
         assertEquals(0, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertNull(connectPacket.getPassword());
@@ -123,9 +120,6 @@ public class Mqtt31ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertNull(connectPacket.getPassword());
@@ -156,9 +150,6 @@ public class Mqtt31ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(true, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertEquals("username", connectPacket.getUsername());
@@ -191,9 +182,6 @@ public class Mqtt31ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(true, connectPacket.isPasswordRequired());
-        assertEquals(true, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertEquals("username", connectPacket.getUsername());
@@ -230,9 +218,6 @@ public class Mqtt31ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(true, connectPacket.isPasswordRequired());
-        assertEquals(true, connectPacket.isUsernameRequired());
-        assertEquals(true, connectPacket.isWill());
         assertEquals(false, connectPacket.getWillPublish().isRetain());
 
         assertEquals("username", connectPacket.getUsername());
@@ -267,9 +252,6 @@ public class Mqtt31ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(true, connectPacket.isWill());
         assertEquals(false, connectPacket.getWillPublish().isRetain());
 
         assertNull(connectPacket.getUsername());
@@ -327,9 +309,6 @@ public class Mqtt31ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(true, connectPacket.isWill());
         assertEquals(false, connectPacket.getWillPublish().isRetain());
 
         assertNull(connectPacket.getUsername());
@@ -364,9 +343,6 @@ public class Mqtt31ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(true, connectPacket.isWill());
         assertEquals(true, connectPacket.getWillPublish().isRetain());
 
         assertNull(connectPacket.getUsername());

--- a/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderTest.java
@@ -104,9 +104,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals("clientId", connectPacket.getClientIdentifier());
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(true, connectPacket.isCleanStart());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertNull(connectPacket.getPassword());
@@ -135,9 +132,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertNull(connectPacket.getPassword());
@@ -168,9 +162,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(true, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertEquals("username", connectPacket.getUsername());
@@ -203,9 +194,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(true, connectPacket.isPasswordRequired());
-        assertEquals(true, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertEquals("username", connectPacket.getUsername());
@@ -241,9 +229,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(true, connectPacket.isPasswordRequired());
-        assertEquals(true, connectPacket.isUsernameRequired());
-        assertEquals(true, connectPacket.isWill());
         assertEquals(false, connectPacket.getWillPublish().isRetain());
 
         assertEquals("username", connectPacket.getUsername());
@@ -278,9 +263,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(true, connectPacket.isWill());
         assertEquals(false, connectPacket.getWillPublish().isRetain());
 
         assertNull(connectPacket.getUsername());
@@ -339,9 +321,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(true, connectPacket.isWill());
         assertEquals(false, connectPacket.getWillPublish().isRetain());
 
         assertNull(connectPacket.getUsername());
@@ -376,9 +355,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals(14, connectPacket.getKeepAlive());
         assertEquals(false, connectPacket.isCleanStart());
         assertEquals(SESSION_EXPIRY_MAX, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(true, connectPacket.isWill());
         assertEquals(true, connectPacket.getWillPublish().isRetain());
 
         assertNull(connectPacket.getUsername());
@@ -413,9 +389,6 @@ public class Mqtt311ConnectDecoderTest {
         assertEquals(true, connectPacket.isCleanStart());
         //clean session
         assertEquals(0, connectPacket.getSessionExpiryInterval());
-        assertEquals(false, connectPacket.isPasswordRequired());
-        assertEquals(false, connectPacket.isUsernameRequired());
-        assertEquals(false, connectPacket.isWill());
         assertEquals(null, connectPacket.getWillPublish());
 
         assertNull(connectPacket.getPassword());

--- a/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5ConnectDecoderTest.java
@@ -17,10 +17,10 @@ package com.hivemq.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
-import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.codec.encoder.mqtt5.Mqtt5PayloadFormatIndicator;
 import com.hivemq.codec.encoder.mqtt5.MqttVariableByteInteger;
 import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.mqtt.message.ProtocolVersion;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.connect.CONNECT;
@@ -128,10 +128,7 @@ public class Mqtt5ConnectDecoderTest extends AbstractMqtt5DecoderTest {
         assertEquals(true, connect.isResponseInformationRequested());
         assertEquals(false, connect.isProblemInformationRequested());
         assertEquals("test", connect.getClientIdentifier());
-        assertEquals(true, connect.isWill());
 
-        assertEquals(true, connect.isPasswordRequired());
-        assertEquals(true, connect.isUsernameRequired());
         assertEquals("username", connect.getUsername());
         assertArrayEquals(new byte[]{'p', 'a', 's', 's'}, connect.getPassword());
         assertEquals("pass", connect.getPasswordAsUTF8String());
@@ -200,9 +197,6 @@ public class Mqtt5ConnectDecoderTest extends AbstractMqtt5DecoderTest {
         assertEquals(0, connect.getKeepAlive());
         assertEquals("test", connect.getClientIdentifier());
         assertFalse(connect.isCleanStart());
-        assertFalse(connect.isPasswordRequired());
-        assertFalse(connect.isUsernameRequired());
-        assertFalse(connect.isWill());
         assertNull(connect.getWillPublish());
         assertEquals(MAXIMUM_PACKET_SIZE_NOT_SET, connect.getMaximumPacketSize());
         assertEquals(SESSION_EXPIRY_NOT_SET, connect.getSessionExpiryInterval());

--- a/src/test/java/com/hivemq/codec/encoder/Mqtt3ConnectEncoderTest.java
+++ b/src/test/java/com/hivemq/codec/encoder/Mqtt3ConnectEncoderTest.java
@@ -100,12 +100,9 @@ public class Mqtt3ConnectEncoderTest {
 
         final CONNECT.Mqtt3Builder builder = new CONNECT.Mqtt3Builder().withCleanStart(false);
 
-        builder.withWill(true);
         builder.withClientIdentifier(clientIdentifier);
         builder.withProtocolVersion(ProtocolVersion.MQTTv3_1_1);
-        builder.withUsernameRequired(true);
         builder.withUsername(username);
-        builder.withPasswordRequired(true);
         builder.withPassword(password.getBytes());
 
         final MqttWillPublish.Mqtt3Builder willBuilder = new MqttWillPublish.Mqtt3Builder();
@@ -199,7 +196,6 @@ public class Mqtt3ConnectEncoderTest {
         final CONNECT.Mqtt3Builder connectBuilder = new CONNECT.Mqtt3Builder()
                 .withProtocolVersion(ProtocolVersion.MQTTv3_1)
                 .withClientIdentifier("clientId")
-                .withWill(true)
                 .withCleanStart(false);
 
         final MqttWillPublish.Mqtt3Builder willBuilder = new MqttWillPublish.Mqtt3Builder();
@@ -248,7 +244,6 @@ public class Mqtt3ConnectEncoderTest {
         final CONNECT.Mqtt3Builder connectBuilder = new CONNECT.Mqtt3Builder()
                 .withProtocolVersion(ProtocolVersion.MQTTv3_1)
                 .withClientIdentifier("clientIé")
-                .withWill(true)
                 .withCleanStart(false);
 
         final MqttWillPublish.Mqtt3Builder willBuilder = new MqttWillPublish.Mqtt3Builder();
@@ -298,8 +293,6 @@ public class Mqtt3ConnectEncoderTest {
         final CONNECT.Mqtt3Builder connectBuilder = new CONNECT.Mqtt3Builder()
                 .withProtocolVersion(ProtocolVersion.MQTTv3_1)
                 .withClientIdentifier("clientId")
-                .withPasswordRequired(true)
-                .withUsernameRequired(true)
                 .withUsername("username")
                 .withPassword("password".getBytes(UTF_8))
                 .withCleanStart(false);
@@ -341,8 +334,6 @@ public class Mqtt3ConnectEncoderTest {
         final CONNECT.Mqtt3Builder connectBuilder = new CONNECT.Mqtt3Builder()
                 .withProtocolVersion(ProtocolVersion.MQTTv3_1)
                 .withClientIdentifier("clientIé")
-                .withPasswordRequired(true)
-                .withUsernameRequired(true)
                 .withUsername("usernamé")
                 .withPassword("password".getBytes(UTF_8))
                 .withCleanStart(false);
@@ -384,7 +375,6 @@ public class Mqtt3ConnectEncoderTest {
         final CONNECT.Mqtt3Builder connectBuilder = new CONNECT.Mqtt3Builder()
                 .withProtocolVersion(ProtocolVersion.MQTTv3_1)
                 .withClientIdentifier("clientId")
-                .withUsernameRequired(true)
                 .withUsername("username")
                 .withCleanStart(false);
 
@@ -461,9 +451,6 @@ public class Mqtt3ConnectEncoderTest {
                 .withProtocolVersion(ProtocolVersion.MQTTv3_1_1)
                 .withClientIdentifier("clientId")
                 .withCleanStart(true)
-                .withWill(true)
-                .withPasswordRequired(true)
-                .withUsernameRequired(true)
                 .withUsername("username")
                 .withPassword("password".getBytes(UTF_8));
 

--- a/src/test/java/com/hivemq/extensions/handler/PluginInitializerHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/PluginInitializerHandlerTest.java
@@ -223,7 +223,6 @@ public class PluginInitializerHandlerTest {
                 .withQos(QoS.AT_LEAST_ONCE).withPayload(new byte[]{1, 2, 3}).build();
 
         final CONNECT connect = new CONNECT.Mqtt5Builder().withClientIdentifier("test-client")
-                .withWill(true)
                 .withWillPublish(willPublish)
                 .build();
 
@@ -253,7 +252,6 @@ public class PluginInitializerHandlerTest {
                 .withQos(QoS.AT_LEAST_ONCE).withPayload(new byte[]{1, 2, 3}).build();
 
         final CONNECT connect = new CONNECT.Mqtt5Builder().withClientIdentifier("test-client")
-                .withWill(true)
                 .withWillPublish(willPublish)
                 .build();
 

--- a/src/test/java/com/hivemq/extensions/packets/connect/ConnectPacketImplTest.java
+++ b/src/test/java/com/hivemq/extensions/packets/connect/ConnectPacketImplTest.java
@@ -60,8 +60,10 @@ public class ConnectPacketImplTest {
                 .withResponseInformationRequested(true)
                 .withProblemInformationRequested(true)
                 .withWillPublish(new MqttWillPublish.Mqtt5Builder().withTopic("topic")
-                        .withPayload("payload".getBytes()).withQos(QoS.AT_LEAST_ONCE).build())
-                .withMqtt5UserProperties(Mqtt5UserProperties.of(new MqttUserProperty("one", "one")))
+                        .withPayload("payload".getBytes())
+                        .withQos(QoS.AT_LEAST_ONCE)
+                        .build())
+                .withUserProperties(Mqtt5UserProperties.of(new MqttUserProperty("one", "one")))
                 .build();
 
         final CONNECT empty = new CONNECT.Mqtt5Builder()

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -183,10 +183,10 @@ public class ConnectHandlerTest {
     public void test_disconnect_after_second_connect_message_mqtt5() {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
         final CONNECT connect2 = new CONNECT.Mqtt5Builder().withClientIdentifier("2")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         assertEquals(true, embeddedChannel.isOpen());
@@ -207,7 +207,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withSessionExpiryInterval(0)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         assertEquals(true, embeddedChannel.isOpen());
@@ -225,7 +225,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withKeepAlive(0)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         assertEquals(true, embeddedChannel.isOpen());
@@ -248,7 +248,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withKeepAlive(0)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         assertEquals(true, embeddedChannel.isOpen());
@@ -271,7 +271,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withKeepAlive(1000)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         final AtomicLong keepAliveFromCONNACK = new AtomicLong();
@@ -311,7 +311,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withKeepAlive(360)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         final AtomicLong keepAliveFromCONNACK = new AtomicLong();
@@ -346,7 +346,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withMaximumPacketSize(300)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         assertEquals(true, embeddedChannel.isOpen());
@@ -368,7 +368,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withSessionExpiryInterval(Mqtt5CONNECT.SESSION_EXPIRY_MAX)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         assertEquals(true, embeddedChannel.isOpen());
@@ -391,7 +391,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withSessionExpiryInterval(Mqtt5CONNECT.SESSION_EXPIRY_MAX)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         assertEquals(true, embeddedChannel.isOpen());
@@ -413,7 +413,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withSessionExpiryInterval(Mqtt5CONNECT.SESSION_EXPIRY_MAX)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         assertEquals(true, embeddedChannel.isOpen());
@@ -434,7 +434,7 @@ public class ConnectHandlerTest {
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withSessionExpiryInterval(Mqtt5CONNECT.SESSION_EXPIRY_MAX)
                 .withClientIdentifier("1")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
 
@@ -474,7 +474,7 @@ public class ConnectHandlerTest {
         embeddedChannel.attr(ChannelAttributes.CLIENT_ID_ASSIGNED).set(true);
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withClientIdentifier("assigned")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         final AtomicReference<String> clientID = new AtomicReference<>();
@@ -511,7 +511,7 @@ public class ConnectHandlerTest {
         embeddedChannel.attr(ChannelAttributes.CLIENT_ID_ASSIGNED).set(false);
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withClientIdentifier("ownId")
-                .withMqtt5UserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
+                .withUserProperties(Mqtt5UserProperties.NO_USER_PROPERTIES)
                 .build();
 
         final AtomicReference<String> clientID = new AtomicReference<>();
@@ -549,7 +549,7 @@ public class ConnectHandlerTest {
                 .set(Mqtt5UserProperties.of(MqttUserProperty.of("name", "value")));
 
         final CONNECT connect1 = new CONNECT.Mqtt5Builder().withClientIdentifier("ownId")
-                .withMqtt5UserProperties(Mqtt5UserProperties.of(MqttUserProperty.of("connect", "value")))
+                .withUserProperties(Mqtt5UserProperties.of(MqttUserProperty.of("connect", "value")))
                 .build();
 
         final AtomicReference<Mqtt5UserProperties> userProps = new AtomicReference<>();

--- a/src/test/java/util/TestMessageUtil.java
+++ b/src/test/java/util/TestMessageUtil.java
@@ -252,7 +252,7 @@ public class TestMessageUtil {
 
     public static CONNECT createFullMqtt5Connect() {
 
-        return new CONNECT.Mqtt5Builder().withMqtt5UserProperties(TEST_USER_PROPERTIES)
+        return new CONNECT.Mqtt5Builder().withUserProperties(TEST_USER_PROPERTIES)
                 .withClientIdentifier("clientid")
                 .withKeepAlive(60)
                 .withCleanStart(true)
@@ -266,7 +266,6 @@ public class TestMessageUtil {
                 .withPassword("password".getBytes())
                 .withAuthMethod("auth method")
                 .withAuthData("auth data".getBytes())
-                .withWill(true)
                 .withWillPublish(new MqttWillPublish.Mqtt5Builder().withHivemqId("hivemqId1")
                         .withTopic("topic")
                         .withPayload("payload".getBytes())
@@ -280,8 +279,6 @@ public class TestMessageUtil {
                         .withUserProperties(TEST_USER_PROPERTIES)
                         .withDelayInterval(60)
                         .build())
-                .withPasswordRequired(true)
-                .withUsernameRequired(true)
                 .build();
 
     }


### PR DESCRIPTION
**Motivation**

When a ConnectInboundInterceptor was used an MQTT 3.x client was handled as an MQTT 5 client by HiveMQ internally.

**Changes**
- Fixed that a ConnectInboundInterceptor changes the MQTT version to 5
