### PR TITLE
Automatic publishing of hivemq-community-edition-embedded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       script: PUSH_IMAGE=true docker/build.sh
     - stage: release
       install: skip
-      script: ./gradlew packaging
+      script: ./gradlew packaging bintrayUpload
       deploy:
         provider: releases
         token:

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,13 @@ plugins {
     id 'java'
     id 'java-library'
     id 'maven-publish'
+    id 'com.jfrog.bintray'
     id 'com.github.johnrengelman.shadow'
     id 'com.github.hierynomus.license'
     id 'org.owasp.dependencycheck'
     id 'com.github.sgtsilvio.gradle.utf8'
     id 'com.github.sgtsilvio.gradle.metadata'
+    id 'com.github.sgtsilvio.gradle.javadoc-links'
 
     /* Code Quality Plugins */
     id 'jacoco'
@@ -302,12 +304,18 @@ tasks.javadoc {
     options.addStringOption('-html5')
     options.addBooleanOption '-no-module-directories', true
 
+    include('com/hivemq/embedded/*')
+
     doLast {
         javaexec {
             main = '-jar'
             args = ["${projectDir}/gradle/tools/javadoc-cleaner-1.0.jar"]
         }
     }
+}
+
+javadocLinks {
+    configuration = 'api'
 }
 
 
@@ -488,6 +496,30 @@ publishing {
                 usage('java-runtime') {
                     fromResolutionResult()
                 }
+            }
+        }
+    }
+}
+
+bintray {
+    user = "${project.findProperty('bintrayUser') ?: System.getenv('BINTRAY_USER')}"
+    key = "${project.findProperty('bintrayKey') ?: System.getenv('BINTRAY_KEY')}"
+    publications = ['embedded']
+    publish = true
+    pkg {
+        userOrg = 'hivemq'
+        repo = 'HiveMQ'
+        name = 'hivemq-community-edition-embedded'
+        desc = project.description
+        websiteUrl = metadata.url
+        issueTrackerUrl = metadata.issueManagement.url
+        vcsUrl = metadata.scm.url
+        licenses = [metadata.license.shortName]
+        labels = ['hivemq', 'mqtt-broker', 'mqtt-server', 'mqtt', 'mqtt5', 'broker', 'messaging', 'pubsub']
+        version {
+            released = new Date().toString()
+            gpg {
+                sign = true
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,11 +41,12 @@ system-rules.version=1.19.0
 #
 # plugins
 #
+plugin.bintray.version=1.8.4
 plugin.shadow.version=4.0.4
 plugin.license.version=0.15.0
-plugin.bintray.version=1.8.4
 plugin.dependencycheck.version=5.3.2
 plugin.spotbugs.version=3.0.0
 plugin.forbiddenapis.version=2.6
 plugin.utf8.version=0.1.0
 plugin.metadata.version=0.1.2
+plugin.javadoc-links.version=0.1.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,13 +1,14 @@
 pluginManagement {
     plugins {
+        id 'com.jfrog.bintray' version "${getProperty("plugin.bintray.version")}"
         id 'com.github.johnrengelman.shadow' version "${getProperty("plugin.shadow.version")}"
         id 'com.github.hierynomus.license' version "${getProperty("plugin.license.version")}"
-        id 'com.jfrog.bintray' version "${getProperty("plugin.bintray.version")}"
         id 'org.owasp.dependencycheck' version "${getProperty("plugin.dependencycheck.version")}"
         id 'com.github.spotbugs' version "${getProperty("plugin.spotbugs.version")}"
         id 'de.thetaphi.forbiddenapis' version "${getProperty("plugin.forbiddenapis.version")}"
         id 'com.github.sgtsilvio.gradle.utf8' version "${getProperty("plugin.utf8.version")}"
         id 'com.github.sgtsilvio.gradle.metadata' version "${getProperty("plugin.metadata.version")}"
+        id 'com.github.sgtsilvio.gradle.javadoc-links' version "${getProperty("plugin.javadoc-links.version")}"
     }
 }
 


### PR DESCRIPTION
**Motivation**
Publish hivemq-community-edition-embedded via gradle.
Publish automatically on release via Travis.

**Changes**
- Configured bintray plugin to publish embeeded publication
- Added javadoc-links plugin
- Included only com.hivemq.embedded classes in javadoc