### PR TITLE
build > fixed javadoc options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -300,9 +300,7 @@ tasks.register('packaging', Zip) {
 defaultTasks 'clean', 'packaging'
 
 tasks.javadoc {
-    options.addStringOption('Xdoclint:none', '-quiet')
     options.addStringOption('-html5')
-    options.addBooleanOption '-no-module-directories', true
 
     include('com/hivemq/embedded/*')
 

--- a/build.gradle
+++ b/build.gradle
@@ -310,6 +310,19 @@ tasks.javadoc {
             args = ["${projectDir}/gradle/tools/javadoc-cleaner-1.0.jar"]
         }
     }
+
+    doLast { // javadoc search fix for jdk 11 https://bugs.openjdk.java.net/browse/JDK-8215291
+        copy {
+            from "${buildDir}/docs/javadoc/search.js"
+            into "${buildDir}/tmp/javadoc/"
+            filter { line -> line.replaceAll('if \\(ui.item.p == item.l\\) \\{', 'if \\(item.m && ui.item.p == item.l\\) \\{') }
+        }
+        delete "${buildDir}/docs/javadoc/search.js"
+        copy {
+            from "${buildDir}/tmp/javadoc/search.js"
+            into "${buildDir}/docs/javadoc/"
+        }
+    }
 }
 
 javadocLinks {


### PR DESCRIPTION
**Motivation**
Javadoc links to JDK 11 are not working

**Changes**
- Removed unnecessary javadoc options