### PR TITLE
bugfix/empty client id and not sent connack

### DIFF
--- a/src/main/java/com/hivemq/codec/decoder/AbstractMqttConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/AbstractMqttConnectDecoder.java
@@ -17,6 +17,8 @@ package com.hivemq.codec.decoder;
 
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.MqttServerDisconnector;
@@ -40,13 +42,17 @@ public abstract class AbstractMqttConnectDecoder extends AbstractMqttDecoder<CON
     protected static final int DISCONNECTED = -1;
 
     protected final long maxSessionExpiryInterval;
+    protected final boolean allowAssignedClientId;
+    protected final @NotNull ClientIds clientIds;
 
-    protected final MqttConnacker mqttConnacker;
+    protected final @NotNull MqttConnacker mqttConnacker;
 
-    public AbstractMqttConnectDecoder(final MqttConnacker mqttConnacker, final MqttServerDisconnector disconnector, final FullConfigurationService fullMqttConfigurationService) {
+    public AbstractMqttConnectDecoder(final @NotNull MqttConnacker mqttConnacker, final @NotNull MqttServerDisconnector disconnector, final @NotNull FullConfigurationService fullMqttConfigurationService, final @NotNull ClientIds clientIds) {
         super(disconnector, fullMqttConfigurationService);
         this.mqttConnacker = mqttConnacker;
         this.maxSessionExpiryInterval = fullMqttConfigurationService.mqttConfiguration().maxSessionExpiryInterval();
+        this.allowAssignedClientId = fullMqttConfigurationService.securityConfiguration().allowServerAssignedClientId();
+        this.clientIds = clientIds;
     }
 
     /**
@@ -72,6 +78,7 @@ public abstract class AbstractMqttConnectDecoder extends AbstractMqttDecoder<CON
      *
      * @return a {@link MqttWillPublish} if valid, else {@code null}.
      */
+    @Nullable
     protected MqttWillPublish readMqtt3WillPublish(final Channel channel, final ByteBuf buf, final int willQoS, final boolean isWillRetain,
                                                    final EventLog eventLog, final HivemqId hiveMQId) {
 

--- a/src/main/java/com/hivemq/codec/decoder/AbstractMqttConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/AbstractMqttConnectDecoder.java
@@ -25,6 +25,7 @@ import com.hivemq.mqtt.message.connect.CONNECT;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
 import com.hivemq.mqtt.message.reason.Mqtt5ConnAckReasonCode;
 import com.hivemq.util.Bytes;
+import com.hivemq.util.ClientIds;
 import com.hivemq.util.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -65,8 +66,10 @@ public abstract class AbstractMqttConnectDecoder extends AbstractMqttDecoder<CON
      * @param buf          the ByteBuf of the encoded will message
      * @param willQoS      the quality of service of the will message
      * @param isWillRetain the retain flag of the will message
-     * @param log          the static logger
      * @param eventLog     the event log
+     * @param hiveMQId     the HiveMQ identifier
+     *
+     *
      * @return a {@link MqttWillPublish} if valid, else {@code null}.
      */
     protected MqttWillPublish readMqtt3WillPublish(final Channel channel, final ByteBuf buf, final int willQoS, final boolean isWillRetain,

--- a/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
@@ -24,6 +24,8 @@ import com.hivemq.codec.decoder.mqtt3.Mqtt31ConnectDecoder;
 import com.hivemq.codec.decoder.mqtt5.Mqtt5ConnectDecoder;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
@@ -65,8 +67,8 @@ public class MqttConnectDecoder {
                               final @NotNull ClientIds clientIds) {
         this.eventLog = eventLog;
         mqtt5ConnectDecoder = new Mqtt5ConnectDecoder(mqttConnacker, mqtt5disconnector, hiveMQId, clientIds, fullConfigurationService);
-        mqtt311ConnectDecoder = new Mqtt311ConnectDecoder(mqttConnacker, mqtt3disconnector, eventLog, fullConfigurationService, hiveMQId);
-        mqtt31ConnectDecoder = new Mqtt31ConnectDecoder(mqttConnacker, mqtt3disconnector, eventLog, fullConfigurationService, hiveMQId);
+        mqtt311ConnectDecoder = new Mqtt311ConnectDecoder(mqttConnacker, mqtt3disconnector, eventLog, clientIds, fullConfigurationService, hiveMQId);
+        mqtt31ConnectDecoder = new Mqtt31ConnectDecoder(mqttConnacker, mqtt3disconnector, eventLog, clientIds, fullConfigurationService, hiveMQId);
     }
 
     public @Nullable CONNECT decode(final @NotNull Channel channel, final @NotNull ByteBuf buf, final byte fixedHeader) {

--- a/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
@@ -16,8 +16,6 @@
 package com.hivemq.codec.decoder;
 
 import com.google.inject.Inject;
-import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.codec.decoder.mqtt3.Mqtt311ConnectDecoder;
 import com.hivemq.codec.decoder.mqtt3.Mqtt31ConnectDecoder;

--- a/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt311ConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt311ConnectDecoder.java
@@ -19,6 +19,8 @@ import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.codec.decoder.AbstractMqttConnectDecoder;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
@@ -34,7 +36,6 @@ import com.hivemq.util.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,18 +55,23 @@ public class Mqtt311ConnectDecoder extends AbstractMqttConnectDecoder {
     private static final Logger log = LoggerFactory.getLogger(Mqtt311ConnectDecoder.class);
 
     public static final String PROTOCOL_NAME = "MQTT";
-    private final EventLog eventLog;
-    private final HivemqId hiveMQId;
+    private final @NotNull EventLog eventLog;
+    private final @NotNull HivemqId hiveMQId;
 
-    public Mqtt311ConnectDecoder(final MqttConnacker connacker, final Mqtt3ServerDisconnector disconnector, final EventLog eventLog,
-                                 final FullConfigurationService fullConfigurationService, final HivemqId hiveMQId) {
-        super(connacker, disconnector, fullConfigurationService);
+    public Mqtt311ConnectDecoder(final @NotNull MqttConnacker connacker,
+                                 final @NotNull Mqtt3ServerDisconnector disconnector,
+                                 final @NotNull EventLog eventLog,
+                                 final @NotNull ClientIds clientIds,
+                                 final @NotNull FullConfigurationService fullConfigurationService,
+                                 final @NotNull HivemqId hiveMQId) {
+        super(connacker, disconnector, fullConfigurationService, clientIds);
         this.eventLog = eventLog;
         this.hiveMQId = hiveMQId;
     }
 
+    @Nullable
     @Override
-    public CONNECT decode(final Channel channel, final ByteBuf buf, final byte header) {
+    public CONNECT decode(final @NotNull Channel channel, final @NotNull ByteBuf buf, final byte header) {
 
 
         if (!validateHeader(header)) {
@@ -169,19 +175,32 @@ public class Mqtt311ConnectDecoder extends AbstractMqttConnectDecoder {
             if (utf8StringLength == 0) {
                 if (!isCleanSessionFlag) {
                     if (log.isDebugEnabled()) {
-                        log.debug("A client (IP: {}) connected with an a persistent session and NO clientID. Using an empty client ID is only allowed when using a cleanSession. Disconnecting client.", getChannelIP(channel).or("UNKNOWN"));
+                        log.debug("A client (IP: {}) connected with a persistent session and NO clientID. Using an empty client ID is only allowed when using a cleanSession. Disconnecting client.", getChannelIP(channel).or("UNKNOWN"));
                     }
 
+                    eventLog.clientWasDisconnected(channel, "Sent CONNECT with empty client id");
+                    channel.writeAndFlush(new CONNACK(Mqtt3ConnAckReturnCode.REFUSED_IDENTIFIER_REJECTED)).
+                            addListener(ChannelFutureListener.CLOSE);
+                    return null;
+                }
+                if (!allowAssignedClientId) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("The client id of the client (IP: {}) is empty. This is not allowed.", getChannelIP(channel).or("UNKNOWN"));
+                    }
+                    eventLog.clientWasDisconnected(channel, "Sent CONNECT with empty client id");
                     channel.writeAndFlush(new CONNACK(Mqtt3ConnAckReturnCode.REFUSED_IDENTIFIER_REJECTED)).
                             addListener(ChannelFutureListener.CLOSE);
                     return null;
                 }
 
-                clientId = "gen-" + Integer.toHexString(channel.hashCode()) + "-" + RandomStringUtils.randomAlphanumeric(10);
+                clientId = clientIds.generateNext();
+                channel.attr(ChannelAttributes.CLIENT_ID_ASSIGNED).set(true);
             } else {
                 clientId = Strings.getPrefixedString(buf, utf8StringLength);
             }
         }
+
+        channel.attr(ChannelAttributes.CLIENT_ID).set(clientId);
 
         final MqttWillPublish willPublish;
 
@@ -221,7 +240,6 @@ public class Mqtt311ConnectDecoder extends AbstractMqttConnectDecoder {
             password = null;
         }
 
-        channel.attr(ChannelAttributes.CLIENT_ID).set(clientId);
         channel.attr(ChannelAttributes.CONNECT_KEEP_ALIVE).set(keepAlive);
         channel.attr(ChannelAttributes.CLEAN_START).set(isCleanSessionFlag);
 

--- a/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt311ConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt311ConnectDecoder.java
@@ -29,6 +29,7 @@ import com.hivemq.mqtt.message.connect.CONNECT;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
 import com.hivemq.util.Bytes;
 import com.hivemq.util.ChannelAttributes;
+import com.hivemq.util.ClientIds;
 import com.hivemq.util.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;

--- a/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt31ConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt31ConnectDecoder.java
@@ -29,6 +29,7 @@ import com.hivemq.mqtt.message.connect.CONNECT;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
 import com.hivemq.util.Bytes;
 import com.hivemq.util.ChannelAttributes;
+import com.hivemq.util.ClientIds;
 import com.hivemq.util.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;

--- a/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt31ConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/mqtt3/Mqtt31ConnectDecoder.java
@@ -19,6 +19,8 @@ import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.codec.decoder.AbstractMqttConnectDecoder;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.service.FullConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
@@ -54,19 +56,20 @@ public class Mqtt31ConnectDecoder extends AbstractMqttConnectDecoder {
 
     public static final String PROTOCOL_NAME = "MQIsdp";
 
-    public final EventLog eventLog;
-    private final HivemqId hiveMQId;
+    public final @NotNull EventLog eventLog;
+    private final @NotNull HivemqId hiveMQId;
 
-    public Mqtt31ConnectDecoder(final MqttConnacker connacker, final Mqtt3ServerDisconnector disconnector,
-                                final EventLog eventLog, final FullConfigurationService fullConfigurationService,
-                                final HivemqId hiveMQId) {
-        super(connacker, disconnector, fullConfigurationService);
+    public Mqtt31ConnectDecoder(final @NotNull MqttConnacker connacker, final @NotNull Mqtt3ServerDisconnector disconnector,
+                                final @NotNull EventLog eventLog, final @NotNull ClientIds clientIds, final @NotNull FullConfigurationService fullConfigurationService,
+                                final @NotNull HivemqId hiveMQId) {
+        super(connacker, disconnector, fullConfigurationService, clientIds);
         this.eventLog = eventLog;
         this.hiveMQId = hiveMQId;
     }
 
+    @Nullable
     @Override
-    public CONNECT decode(final Channel channel, final ByteBuf buf, final byte header) {
+    public CONNECT decode(final @NotNull Channel channel, final @NotNull ByteBuf buf, final byte header) {
 
         if (buf.readableBytes() < 12) {
             if (log.isDebugEnabled()) {
@@ -160,6 +163,7 @@ public class Mqtt31ConnectDecoder extends AbstractMqttConnectDecoder {
         } else {
             clientId = Strings.getPrefixedString(buf, utf8StringLength);
         }
+        channel.attr(ChannelAttributes.CLIENT_ID).set(clientId);
 
         final MqttWillPublish willPublish;
 
@@ -197,7 +201,6 @@ public class Mqtt31ConnectDecoder extends AbstractMqttConnectDecoder {
             password = null;
         }
 
-        channel.attr(ChannelAttributes.CLIENT_ID).set(clientId);
         channel.attr(ChannelAttributes.CONNECT_KEEP_ALIVE).set(keepAlive);
         channel.attr(ChannelAttributes.CLEAN_START).set(isCleanSessionFlag);
 

--- a/src/main/java/com/hivemq/codec/decoder/mqtt5/Mqtt5ConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/mqtt5/Mqtt5ConnectDecoder.java
@@ -55,18 +55,14 @@ public class Mqtt5ConnectDecoder extends AbstractMqttConnectDecoder {
     private static final String PROTOCOL_NAME = "MQTT";
     private static final byte VARIABLE_HEADER_LENGTH = 10;
     private final HivemqId hiveMQId;
-    private final ClientIds clientIds;
-    private final boolean allowAssignedClientId;
 
     public Mqtt5ConnectDecoder(final MqttConnacker mqttConnacker,
                                final Mqtt5ServerDisconnector disconnector,
                                final HivemqId hiveMQId,
                                final ClientIds clientIds,
                                final FullConfigurationService fullMqttConfigurationService) {
-        super(mqttConnacker, disconnector, fullMqttConfigurationService);
+        super(mqttConnacker, disconnector, fullMqttConfigurationService, clientIds);
         this.hiveMQId = hiveMQId;
-        this.clientIds = clientIds;
-        this.allowAssignedClientId = fullMqttConfigurationService.securityConfiguration().allowServerAssignedClientId();
     }
 
     @Override
@@ -158,6 +154,8 @@ public class Mqtt5ConnectDecoder extends AbstractMqttConnectDecoder {
             channel.attr(ChannelAttributes.CLIENT_ID_ASSIGNED).set(false);
         }
 
+        channel.attr(ChannelAttributes.CLIENT_ID).set(clientId);
+
         final MqttWillPublish mqttWillPublish;
         if (will) {
             mqttWillPublish = decodeAndValidateWill(channel, buf, willQos, willRetain);
@@ -176,7 +174,6 @@ public class Mqtt5ConnectDecoder extends AbstractMqttConnectDecoder {
             return null;
         }
 
-        channel.attr(ChannelAttributes.CLIENT_ID).set(clientId);
         channel.attr(ChannelAttributes.CLEAN_START).set(cleanStart);
 
         return connectBuilder

--- a/src/main/java/com/hivemq/extensions/handler/ConnackOutboundInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/ConnackOutboundInterceptorHandler.java
@@ -110,6 +110,7 @@ public class ConnackOutboundInterceptorHandler extends ChannelOutboundHandlerAda
         final Channel channel = ctx.channel();
         final String clientId = channel.attr(ChannelAttributes.CLIENT_ID).get();
         if (clientId == null) {
+            ctx.write(connack, promise);
             return;
         }
 

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderTest.java
@@ -66,7 +66,7 @@ public class Mqtt31ConnectDecoderTest {
         decoder = new Mqtt31ConnectDecoder(connacker,
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new TestConfigurationBootstrap().getFullConfigurationService(),
+                new ClientIds(new ClusterId()), new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
     }
 

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderTest.java
@@ -25,6 +25,7 @@ import com.hivemq.mqtt.handler.disconnect.MqttDisconnectUtil;
 import com.hivemq.mqtt.message.ProtocolVersion;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.connect.CONNECT;
+import com.hivemq.util.ClientIds;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -66,7 +67,7 @@ public class Mqtt31ConnectDecoderTest {
         decoder = new Mqtt31ConnectDecoder(connacker,
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new ClientIds(new ClusterId()), new TestConfigurationBootstrap().getFullConfigurationService(),
+                new ClientIds(new HivemqId()), new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
     }
 

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderValidationsTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderValidationsTest.java
@@ -19,7 +19,6 @@ import com.hivemq.codec.decoder.mqtt3.Mqtt31ConnectDecoder;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.MqttConfigurationService;
-import com.hivemq.information.client.ClientIds;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
@@ -28,6 +27,7 @@ import com.hivemq.mqtt.message.connack.CONNACK;
 import com.hivemq.mqtt.message.connack.Mqtt3ConnAckReturnCode;
 import com.hivemq.mqtt.message.reason.Mqtt5ConnAckReasonCode;
 import com.hivemq.util.ChannelAttributes;
+import com.hivemq.util.ClientIds;
 import com.hivemq.util.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -81,7 +81,7 @@ public class Mqtt31ConnectDecoderValidationsTest {
         decoder = new Mqtt31ConnectDecoder(connacker,
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new ClientIds(new ClusterId()), new TestConfigurationBootstrap().getFullConfigurationService(),
+                new ClientIds(new HivemqId()), new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
 
         when(channel.attr(ChannelAttributes.CLIENT_ID)).thenReturn(attribute);

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderValidationsTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderValidationsTest.java
@@ -19,6 +19,7 @@ import com.hivemq.codec.decoder.mqtt3.Mqtt31ConnectDecoder;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.MqttConfigurationService;
+import com.hivemq.information.client.ClientIds;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
@@ -80,7 +81,7 @@ public class Mqtt31ConnectDecoderValidationsTest {
         decoder = new Mqtt31ConnectDecoder(connacker,
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new TestConfigurationBootstrap().getFullConfigurationService(),
+                new ClientIds(new ClusterId()), new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
 
         when(channel.attr(ChannelAttributes.CLIENT_ID)).thenReturn(attribute);

--- a/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderInvalidFixedHeadersTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderInvalidFixedHeadersTest.java
@@ -22,6 +22,7 @@ import com.hivemq.mqtt.handler.connack.MqttConnackSendUtil;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
 import com.hivemq.mqtt.handler.disconnect.MqttDisconnectUtil;
+import com.hivemq.util.ClientIds;
 import io.netty.channel.Channel;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
@@ -73,7 +74,7 @@ public class Mqtt311ConnectDecoderInvalidFixedHeadersTest {
         decoder = new Mqtt311ConnectDecoder(new MqttConnacker(new MqttConnackSendUtil(eventLog)),
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new ClientIds(new ClusterId()), new TestConfigurationBootstrap().getFullConfigurationService(),
+                new ClientIds(new HivemqId()), new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
     }
 

--- a/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderInvalidFixedHeadersTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderInvalidFixedHeadersTest.java
@@ -73,7 +73,7 @@ public class Mqtt311ConnectDecoderInvalidFixedHeadersTest {
         decoder = new Mqtt311ConnectDecoder(new MqttConnacker(new MqttConnackSendUtil(eventLog)),
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new TestConfigurationBootstrap().getFullConfigurationService(),
+                new ClientIds(new ClusterId()), new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
     }
 

--- a/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderTest.java
@@ -27,6 +27,7 @@ import com.hivemq.mqtt.handler.disconnect.MqttDisconnectUtil;
 import com.hivemq.mqtt.message.ProtocolVersion;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.connect.CONNECT;
+import com.hivemq.util.ClientIds;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -68,7 +69,7 @@ public class Mqtt311ConnectDecoderTest {
     private Mqtt311ConnectDecoder decoder;
 
     private static final byte fixedHeader = 0b0001_0000;
-    private ClusterId clusterId;
+    private HivemqId hiveMQId;
 
     @Before
     public void setUp() throws Exception {
@@ -78,11 +79,12 @@ public class Mqtt311ConnectDecoderTest {
         when(fullConfiguration.securityConfiguration()).thenReturn(securityConfigurationService);
         when(securityConfigurationService.validateUTF8()).thenReturn(true);
 
+        hiveMQId = new HivemqId();
         decoder = new Mqtt311ConnectDecoder(connacker,
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new TestConfigurationBootstrap().getFullConfigurationService(),
-                new HivemqId());
+                new ClientIds(hiveMQId), new TestConfigurationBootstrap().getFullConfigurationService(),
+                hiveMQId);
     }
 
     @Test
@@ -414,7 +416,7 @@ public class Mqtt311ConnectDecoderTest {
         final CONNECT connectPacket = decoder.decode(channel, buf, fixedHeader);
 
         assertTrue(connectPacket.getClientIdentifier().length() > 9);
-        assertEquals("hmq_" + clusterId.get(), connectPacket.getClientIdentifier().substring(0, 9));
+        assertEquals("hmq_" + hiveMQId.get(), connectPacket.getClientIdentifier().substring(0, 9));
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderTest.java
@@ -68,6 +68,7 @@ public class Mqtt311ConnectDecoderTest {
     private Mqtt311ConnectDecoder decoder;
 
     private static final byte fixedHeader = 0b0001_0000;
+    private ClusterId clusterId;
 
     @Before
     public void setUp() throws Exception {
@@ -412,8 +413,8 @@ public class Mqtt311ConnectDecoderTest {
 
         final CONNECT connectPacket = decoder.decode(channel, buf, fixedHeader);
 
-        assertTrue(connectPacket.getClientIdentifier().length() > 0);
-        assertEquals("gen-", connectPacket.getClientIdentifier().substring(0, 4));
+        assertTrue(connectPacket.getClientIdentifier().length() > 9);
+        assertEquals("hmq_" + clusterId.get(), connectPacket.getClientIdentifier().substring(0, 9));
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderValidationsTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderValidationsTest.java
@@ -17,6 +17,7 @@ package com.hivemq.codec.decoder.mqtt311;
 
 import com.hivemq.codec.decoder.mqtt3.Mqtt311ConnectDecoder;
 import com.hivemq.configuration.HivemqId;
+import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.handler.disconnect.Mqtt3ServerDisconnector;
@@ -24,6 +25,7 @@ import com.hivemq.mqtt.handler.disconnect.MqttDisconnectUtil;
 import com.hivemq.mqtt.message.connack.CONNACK;
 import com.hivemq.mqtt.message.connack.Mqtt3ConnAckReturnCode;
 import com.hivemq.mqtt.message.reason.Mqtt5ConnAckReasonCode;
+import com.hivemq.util.ClientIds;
 import com.hivemq.util.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -70,7 +72,7 @@ public class Mqtt311ConnectDecoderValidationsTest {
         decoder = new Mqtt311ConnectDecoder(connacker,
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new ClientIds(new ClusterId()), new TestConfigurationBootstrap().getFullConfigurationService(),
+                new ClientIds(new HivemqId()), new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
     }
 
@@ -307,8 +309,8 @@ public class Mqtt311ConnectDecoderValidationsTest {
         decoder = new Mqtt311ConnectDecoder(connacker,
                 new Mqtt3ServerDisconnector(new MqttDisconnectUtil(eventLog)),
                 eventLog,
-                new ClientIds(new ClusterId()), fullConfigurationService,
-                new ClusterId());
+                new ClientIds(new HivemqId()), fullConfigurationService,
+                new HivemqId());
 
 
         final ChannelFuture cf = mock(ChannelFuture.class);

--- a/src/test/java/com/hivemq/extensions/handler/ConnackOutboundInterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/extensions/handler/ConnackOutboundInterceptorHandlerTest.java
@@ -60,7 +60,6 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -128,10 +127,17 @@ public class ConnackOutboundInterceptorHandlerTest {
 
         channel.attr(ChannelAttributes.CLIENT_ID).set(null);
 
-        channel.writeOutbound(testConnack());
+        final CONNACK initial = testConnack();
+        channel.writeOutbound(initial);
         channel.runPendingTasks();
+        CONNACK connack = channel.readOutbound();
+        while (connack == null) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            connack = channel.readOutbound();
+        }
 
-        assertNull(channel.readOutbound());
+        assertEquals(initial, connack);
     }
 
     @Test(timeout = 5000)


### PR DESCRIPTION
**Motivation**

configuration for allowEmptyClientIdentifier is unused for mqtt 3 clients.
connacks where no client id is set to channel attributes are not sent.

**Changes**

config now used for mqtt 3 clients.
connacks are now sent correctly.