### PR TITLE
fixed wildcard topic matching for retained messages

### DIFF
--- a/src/main/java/com/hivemq/persistence/local/xodus/PublishTopicTree.java
+++ b/src/main/java/com/hivemq/persistence/local/xodus/PublishTopicTree.java
@@ -154,11 +154,18 @@ public class PublishTopicTree {
         public Set<String> get(
                 @NotNull final ArrayList<String> subTopics, @Nullable final String currentTopic, final boolean getAll) {
             if (childNodes == null && child == null) {
-                if (currentTopic == null || (!subTopics.isEmpty() && !getAll)) {
+                if (currentTopic == null) {
                     return ImmutableSet.of();
                 }
-
-                return ImmutableSet.of(currentTopic);
+                if (subTopics.isEmpty() || getAll) {
+                    return ImmutableSet.of(currentTopic);
+                }
+                final String currentSubTopic = subTopics.get(0);
+                if (currentSubTopic.equals("#")) {
+                    // x/y/z matches x/y/z/#
+                    return ImmutableSet.of(currentTopic);
+                }
+                return ImmutableSet.of();
             }
             final Set<String> result = new HashSet<>();
 
@@ -169,7 +176,8 @@ public class PublishTopicTree {
                 return result;
             }
             final String currentSubTopic = subTopics.get(0);
-            if (getAll && directMatch) {
+            if ((getAll || currentSubTopic.equals("#")) && directMatch) {
+                // x/y/z matches x/y/z/#
                 result.add(currentTopic);
             }
 

--- a/src/test/java/com/hivemq/persistence/local/xodus/PublishTopicTreeTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/PublishTopicTreeTest.java
@@ -143,7 +143,7 @@ public class PublishTopicTreeTest {
         assertEquals(7, result.size());
 
         result = tree.get("topic/#");
-        assertEquals(5, result.size());
+        assertEquals(6, result.size());
 
     }
 
@@ -237,5 +237,25 @@ public class PublishTopicTreeTest {
         assertTrue(result.contains("topic/a/b"));
         assertTrue(result.contains("topic/a/b/c"));
 
+    }
+
+    @Test
+    public void test_wildcard_edge_cases() {
+        tree.add("a/b/c");
+        tree.add("a/b/c/d");
+        Set<String> results = tree.get("a/b/c/#");
+        assertTrue(results.contains("a/b/c"));
+        assertTrue(results.contains("a/b/c/d"));
+        assertEquals(2, results.size());
+
+        tree.remove("a/b/c");
+        tree.remove("a/b/c/d");
+        results = tree.get("#");
+        assertEquals(0, results.size());
+
+        tree.add("a/b/");
+        results = tree.get("a/b/+");
+        assertEquals(1, results.size());
+        assertTrue(results.contains("a/b/"));
     }
 }

--- a/src/test/java/com/hivemq/persistence/local/xodus/PublishTopicTreeTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/PublishTopicTreeTest.java
@@ -254,6 +254,7 @@ public class PublishTopicTreeTest {
         assertEquals(0, results.size());
 
         tree.add("a/b/");
+        tree.add("a/b");
         results = tree.get("a/b/+");
         assertEquals(1, results.size());
         assertTrue(results.contains("a/b/"));


### PR DESCRIPTION
**Changes**
Fixed an issue with wildcard matching for retained messages.
Multi-level wildcard would not match direct subscriptions.
"x/y/x" would not match for "x/y/z/#" for example.