### PR TITLE
Fixed ConcurrentModificationException on iteration over HashMap

### DIFF
--- a/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistence.java
@@ -174,7 +174,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
         Preconditions.checkNotNull(buckets, "Buckets must be initialized at this point");
 
         for (int i = 0; i < buckets.length; i++) {
-            qos0MessageBuckets.put(i, new HashMap<>());
+            qos0MessageBuckets.put(i, new ConcurrentHashMap<>());
             queueSizeBuckets.put(i, new ConcurrentSkipListMap<>());
             retainedQueueSizeBuckets.put(i, new ConcurrentHashMap<>());
         }


### PR DESCRIPTION
**Motivation**

While collection of gauges, a ConcurrentModificiationException might be thrown, because of concurrent edit of a HashMaß while iteration over it in for-each loop. 

**Changes**

Changed Type from HashMap to ConcurrentHashMap