### PR TITLE
Added Flushing of MemTables for RocksDB to limit memory consumption

### DIFF
--- a/src/main/java/com/hivemq/persistence/local/rocksdb/RocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/rocksdb/RocksDBLocalPersistence.java
@@ -222,6 +222,12 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
         return buckets[BucketUtils.getBucket(key, bucketCount)];
     }
 
+
+    @NotNull
+    protected int getBucketIndex(final @NotNull String key) {
+        return BucketUtils.getBucket(key, bucketCount);
+    }
+
     protected void checkBucketIndex(final int bucketIndex) {
         checkArgument(bucketIndex >= 0 && bucketIndex < buckets.length, "Invalid bucket index: " + bucketIndex);
     }

--- a/src/main/java/com/hivemq/util/PhysicalMemoryUtil.java
+++ b/src/main/java/com/hivemq/util/PhysicalMemoryUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.util;
 
 import java.lang.management.ManagementFactory;

--- a/src/main/java/com/hivemq/util/PhysicalMemoryUtil.java
+++ b/src/main/java/com/hivemq/util/PhysicalMemoryUtil.java
@@ -1,0 +1,23 @@
+package com.hivemq.util;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+
+public class PhysicalMemoryUtil {
+    public static long physicalMemory() {
+        final long heap = Runtime.getRuntime().maxMemory();
+        try {
+            final OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
+            if (!(operatingSystemMXBean instanceof com.sun.management.OperatingSystemMXBean)) {
+                return (long) (heap * 1.5);
+            }
+            final long physicalMemory = ((com.sun.management.OperatingSystemMXBean) operatingSystemMXBean).getTotalPhysicalMemorySize();
+            if (physicalMemory > 0) {
+                return physicalMemory;
+            }
+            return (long) (heap * 1.5);
+        } catch (final Exception e) {
+            return (long) (heap * 1.5);
+        }
+    }
+}

--- a/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
@@ -154,20 +154,24 @@ public class PublishPayloadRocksDBLocalPersistenceTest {
 
     @Test
     public void put_bigPayloads_memtableFlushed() {
-
         final long memtableSize = persistence.getMemtableSize();
-
-        int bytesPuttedIn = 0;
-
+        long bytesPuttedIn = 0L;
         final byte[] payload1 = "payload".getBytes();
-
         while (bytesPuttedIn < memtableSize) {
-            assertEquals(bytesPuttedIn, persistence.getBytesInCurrentMemtable());
+            for (final long memTableSize : persistence.getRocksdbToMemTableSize()) {
+                //skip the empty entries
+                if (memTableSize == 0) {
+                    continue;
+                }
+                assertEquals(bytesPuttedIn, memTableSize);
+            }
             persistence.put(0L, payload1);
             bytesPuttedIn += payload1.length;
         }
-        //after flush memtable must be empty
-        assertEquals(0, persistence.getBytesInCurrentMemtable());
+        //after flush memTable must be empty (all -  because the others were empty already)
+        for (final long memTableSize : persistence.getRocksdbToMemTableSize()) {
+            assertEquals(0L, memTableSize);
+        }
     }
 
 }

--- a/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
@@ -151,4 +151,23 @@ public class PublishPayloadRocksDBLocalPersistenceTest {
         assertEquals(false, allIds.contains(1L));
     }
 
+
+    @Test
+    public void put_bigPayloads_memtableFlushed() {
+
+        final long memtableSize = persistence.getMemtableSize();
+
+        int bytesPuttedIn = 0;
+
+        final byte[] payload1 = "payload".getBytes();
+
+        while (bytesPuttedIn < memtableSize) {
+            assertEquals(bytesPuttedIn, persistence.getBytesInCurrentMemtable());
+            persistence.put(0L, payload1);
+            bytesPuttedIn += payload1.length;
+        }
+        //after flush memtable must be empty
+        assertEquals(0, persistence.getBytesInCurrentMemtable());
+    }
+
 }


### PR DESCRIPTION
**Motivation**
MemTables can exceed their limits, which may lead to Out-of-Memory errors. 

**Changes**
Added hard-flushing of MemTables in PublishPayloadRocksDBLocalPersistence to avoid Out-of-Memory errors.