### PR TITLE
Change heap dump folder environment variable

### DIFF
--- a/src/packaging/bin/diagnostics.sh
+++ b/src/packaging/bin/diagnostics.sh
@@ -69,7 +69,7 @@ if hash java 2>/dev/null; then
     if [ -z "$HEAPDUMP_FOLDER" ]; then
         HEAPDUMP_PATH="$HIVEMQ_FOLDER"
     else
-        HEAPDUMP_PATH="$HEAPDUMP_HOME"
+        HEAPDUMP_PATH="$HEAPDUMP_FOLDER"
     fi
 
     if [ ! -d "$HIVEMQ_FOLDER" ]; then

--- a/src/packaging/bin/diagnostics.sh
+++ b/src/packaging/bin/diagnostics.sh
@@ -66,6 +66,12 @@ if hash java 2>/dev/null; then
         HOME_OPT="-Dhivemq.home=$HIVEMQ_FOLDER"
     fi
 
+    if [ -z "$HEAPDUMP_FOLDER" ]; then
+        HEAPDUMP_PATH="$HIVEMQ_FOLDER"
+    else
+        HEAPDUMP_PATH="$HEAPDUMP_HOME"
+    fi
+
     if [ ! -d "$HIVEMQ_FOLDER" ]; then
         echoerr "ERROR! HiveMQ Home Folder not found."
     else
@@ -80,7 +86,8 @@ if hash java 2>/dev/null; then
             else
                 JAVA_OPTS="$JAVA_OPTS -XX:+CrashOnOutOfMemoryError"
                 JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-                HEAPDUMP_PATH_OPT="-XX:HeapDumpPath=$HIVEMQ_FOLDER/heap-dump.hprof"
+                HEAPDUMP_PATH_OPT="-XX:HeapDumpPath=$HEAPDUMP_PATH/heap-dump.hprof"
+                ERROR_FILE_PATH_OPT="-XX:ErrorFile=$HEAPDUMP_PATH/hs_err_pid%p.log"
 
                 echo "-------------------------------------------------------------------------"
                 echo ""
@@ -94,7 +101,7 @@ if hash java 2>/dev/null; then
                 echo ""
                 # Run HiveMQ
                 JAR_PATH="$HIVEMQ_FOLDER/bin/hivemq.jar"
-                exec "java" "${HOME_OPT}" "${HEAPDUMP_PATH_OPT}" ${JAVA_OPTS} -jar "${JAR_PATH}"
+                exec "java" "${HOME_OPT}" "${HEAPDUMP_PATH_OPT}" "${ERROR_FILE_PATH_OPT}" ${JAVA_OPTS} -jar "${JAR_PATH}"
             fi
         fi
     fi

--- a/src/packaging/bin/diagnostics.sh
+++ b/src/packaging/bin/diagnostics.sh
@@ -23,7 +23,7 @@ echo '                 |_|  |_||_|  \_/  \___||_|  |_| \___\_\'
 echo
 echo "-------------------------------------------------------------------------"
 echo ""
-echo "  HiveMQ Start Script for Linux/Unix v1.12"
+echo "  HiveMQ Start Script for Linux/Unix v1.13"
 echo ""
 echo "                 DIAGNOSTIC MODE "
 echo ""

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -65,6 +65,12 @@ if hash java 2>/dev/null; then
         HOME_OPT="-Dhivemq.home=$HIVEMQ_FOLDER"
     fi
 
+    if [ -z "$HEAPDUMP_FOLDER" ]; then
+        HEAPDUMP_PATH="$HIVEMQ_FOLDER"
+    else
+        HEAPDUMP_PATH="$HEAPDUMP_HOME"
+    fi
+
     if [ ! -d "$HIVEMQ_FOLDER" ]; then
         echoerr "ERROR! HiveMQ Home Folder not found."
     else
@@ -79,7 +85,8 @@ if hash java 2>/dev/null; then
             else
                 JAVA_OPTS="$JAVA_OPTS -XX:+CrashOnOutOfMemoryError"
                 JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-                HEAPDUMP_PATH_OPT="-XX:HeapDumpPath=$HIVEMQ_FOLDER/heap-dump.hprof"
+                HEAPDUMP_PATH_OPT="-XX:HeapDumpPath=$HEAPDUMP_PATH/heap-dump.hprof"
+                ERROR_FILE_PATH_OPT="-XX:ErrorFile=$HEAPDUMP_PATH/hs_err_pid%p.log"
 
                 echo "-------------------------------------------------------------------------"
                 echo ""
@@ -93,7 +100,7 @@ if hash java 2>/dev/null; then
                 echo ""
                 # Run HiveMQ
                 JAR_PATH="$HIVEMQ_FOLDER/bin/hivemq.jar"
-                exec "java" "${HOME_OPT}" "${HEAPDUMP_PATH_OPT}" ${JAVA_OPTS} -jar "${JAR_PATH}"
+                exec "java" "${HOME_OPT}" "${HEAPDUMP_PATH_OPT}" "${ERROR_FILE_PATH_OPT}" ${JAVA_OPTS} -jar "${JAR_PATH}"
             fi
         fi
     fi

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -68,7 +68,7 @@ if hash java 2>/dev/null; then
     if [ -z "$HEAPDUMP_FOLDER" ]; then
         HEAPDUMP_PATH="$HIVEMQ_FOLDER"
     else
-        HEAPDUMP_PATH="$HEAPDUMP_HOME"
+        HEAPDUMP_PATH="$HEAPDUMP_FOLDER"
     fi
 
     if [ ! -d "$HIVEMQ_FOLDER" ]; then

--- a/src/packaging/bin/run.sh
+++ b/src/packaging/bin/run.sh
@@ -23,7 +23,7 @@ echo '                 |_|  |_||_|  \_/  \___||_|  |_| \___\_\'
 echo
 echo "-------------------------------------------------------------------------"
 echo ""
-echo "  HiveMQ Start Script for Linux/Unix v1.12"
+echo "  HiveMQ Start Script for Linux/Unix v1.13"
 echo ""
 
 echoerr() { printf "%s\n" "$*" >&2; }


### PR DESCRIPTION

**Motivation**

On k8s automatically generated heap dumps should be written to a shared volume, so that they can be fetched/shipped after a container is stopped


**Changes**

A environment variable `HEAPDUMP_FOLDER` can be set to override the default destination for automatically generated heap dumps or error.pid.log files