### PR TITLE
Small performance improvements

### DIFF
--- a/src/main/java/com/hivemq/codec/decoder/MqttDecoders.java
+++ b/src/main/java/com/hivemq/codec/decoder/MqttDecoders.java
@@ -15,29 +15,15 @@
  */
 package com.hivemq.codec.decoder;
 
-import com.google.common.collect.ImmutableMap;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.codec.decoder.mqtt3.*;
 import com.hivemq.codec.decoder.mqtt5.*;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.mqtt.message.Message;
-import com.hivemq.mqtt.message.PINGREQ;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
+import com.hivemq.mqtt.message.MessageType;
 import com.hivemq.mqtt.message.ProtocolVersion;
-import com.hivemq.mqtt.message.auth.AUTH;
-import com.hivemq.mqtt.message.connack.CONNACK;
-import com.hivemq.mqtt.message.disconnect.DISCONNECT;
-import com.hivemq.mqtt.message.puback.PUBACK;
-import com.hivemq.mqtt.message.pubcomp.PUBCOMP;
-import com.hivemq.mqtt.message.publish.PUBLISH;
-import com.hivemq.mqtt.message.pubrec.PUBREC;
-import com.hivemq.mqtt.message.pubrel.PUBREL;
-import com.hivemq.mqtt.message.suback.SUBACK;
-import com.hivemq.mqtt.message.subscribe.SUBSCRIBE;
-import com.hivemq.mqtt.message.unsuback.UNSUBACK;
-import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
 
 import javax.inject.Inject;
-import java.util.Map;
 
 /**
  * @author Lukas Brandl
@@ -46,8 +32,8 @@ import java.util.Map;
 @LazySingleton
 public class MqttDecoders {
 
-    private final @NotNull Map<Class<? extends Message>, MqttDecoder<? extends Message>> mqtt3Decoder;
-    private final @NotNull Map<Class<? extends Message>, MqttDecoder<? extends Message>>  mqtt5Decoder;
+    private final @Nullable MqttDecoder @NotNull [] mqtt3Decoder;
+    private final @Nullable MqttDecoder @NotNull [] mqtt5Decoder;
 
     @Inject
     public MqttDecoders(final @NotNull Mqtt3ConnackDecoder mqtt3ConnackDecoder,
@@ -72,42 +58,35 @@ public class MqttDecoders {
                         final @NotNull Mqtt5AuthDecoder mqtt5AuthDecoder,
                         final @NotNull Mqtt5UnsubscribeDecoder mqtt5UnsubscribeDecoder) {
 
-        final ImmutableMap.Builder<Class<? extends Message>, MqttDecoder<? extends Message>> mqtt3DecoderBuilder = ImmutableMap.builder();
-        final ImmutableMap.Builder<Class<? extends Message>, MqttDecoder<? extends Message>> mqtt5DecoderBuilder = ImmutableMap.builder();
+        mqtt3Decoder = new MqttDecoder[16];
+        mqtt5Decoder = new MqttDecoder[16];
 
-        mqtt3DecoderBuilder.put(CONNACK.class, mqtt3ConnackDecoder);
-        mqtt3DecoderBuilder.put(PUBLISH.class, mqtt3PublishDecoder);
-        mqtt3DecoderBuilder.put(PUBACK.class, mqtt3PubackDecoder);
-        mqtt3DecoderBuilder.put(PUBREC.class, mqtt3PubrecDecoder);
-        mqtt3DecoderBuilder.put(PUBCOMP.class, mqtt3PubcompDecoder);
-        mqtt3DecoderBuilder.put(PUBREL.class, mqtt3PubrelDecoder);
-        mqtt3DecoderBuilder.put(SUBSCRIBE.class, mqtt3SubscribeDecoder);
-        mqtt3DecoderBuilder.put(SUBACK.class, mqtt3SubackDecoder);
-        mqtt3DecoderBuilder.put(UNSUBSCRIBE.class, mqtt3UnsubscribeDecoder);
-        mqtt3DecoderBuilder.put(UNSUBACK.class, mqtt3UnsubackDecoder);
-        mqtt3DecoderBuilder.put(PINGREQ.class, mqttPingreqDecoder);
-        mqtt3DecoderBuilder.put(DISCONNECT.class, mqtt3DisconnectDecoder);
+        mqtt3Decoder[MessageType.PUBLISH.getType()] = mqtt3PublishDecoder;
+        mqtt3Decoder[MessageType.PUBACK.getType()] = mqtt3PubackDecoder;
+        mqtt3Decoder[MessageType.PUBREC.getType()] = mqtt3PubrecDecoder;
+        mqtt3Decoder[MessageType.PUBREL.getType()] = mqtt3PubrelDecoder;
+        mqtt3Decoder[MessageType.PUBCOMP.getType()] = mqtt3PubcompDecoder;
+        mqtt3Decoder[MessageType.SUBSCRIBE.getType()] =  mqtt3SubscribeDecoder;
+        mqtt3Decoder[MessageType.UNSUBSCRIBE.getType()] = mqtt3UnsubscribeDecoder;
+        mqtt3Decoder[MessageType.PINGREQ.getType()] = mqttPingreqDecoder;
+        mqtt3Decoder[MessageType.DISCONNECT.getType()] = mqtt3DisconnectDecoder;
 
-        mqtt5DecoderBuilder.put(PUBLISH.class, mqtt5PublishDecoder);
-        mqtt5DecoderBuilder.put(PUBACK.class, mqtt5PubackDecoder);
-        mqtt5DecoderBuilder.put(PUBREC.class, mqtt5PubrecDecoder);
-        mqtt5DecoderBuilder.put(PUBREL.class, mqtt5PubrelDecoder);
-        mqtt5DecoderBuilder.put(PUBCOMP.class, mqtt5PubcompDecoder);
-        mqtt5DecoderBuilder.put(SUBSCRIBE.class, mqtt5SubscribeDecoder);
-        mqtt5DecoderBuilder.put(UNSUBSCRIBE.class, mqtt5UnsubscribeDecoder);
-        mqtt5DecoderBuilder.put(PINGREQ.class, mqttPingreqDecoder);
-        mqtt5DecoderBuilder.put(DISCONNECT.class, mqtt5DisconnectDecoder);
-        mqtt5DecoderBuilder.put(AUTH.class, mqtt5AuthDecoder);
-
-        mqtt3Decoder = mqtt3DecoderBuilder.build();
-        mqtt5Decoder = mqtt5DecoderBuilder.build();
+        mqtt5Decoder[MessageType.PUBLISH.getType()] = mqtt5PublishDecoder;
+        mqtt5Decoder[MessageType.PUBACK.getType()] = mqtt5PubackDecoder;
+        mqtt5Decoder[MessageType.PUBREC.getType()] = mqtt5PubrecDecoder;
+        mqtt5Decoder[MessageType.PUBREL.getType()] = mqtt5PubrelDecoder;
+        mqtt5Decoder[MessageType.PUBCOMP.getType()] = mqtt5PubcompDecoder;
+        mqtt5Decoder[MessageType.SUBSCRIBE.getType()] = mqtt5SubscribeDecoder;
+        mqtt5Decoder[MessageType.UNSUBSCRIBE.getType()] = mqtt5UnsubscribeDecoder;
+        mqtt5Decoder[MessageType.PINGREQ.getType()] = mqttPingreqDecoder;
+        mqtt5Decoder[MessageType.DISCONNECT.getType()] = mqtt5DisconnectDecoder;
+        mqtt5Decoder[MessageType.AUTH.getType()] = mqtt5AuthDecoder;
     }
 
-    @NotNull
-    public MqttDecoder<?> decoder(final @NotNull Class<? extends Message> clazz, final @NotNull ProtocolVersion version) {
+    public @Nullable MqttDecoder<?> decoder(final @NotNull MessageType type, final @NotNull ProtocolVersion version) {
         if (version == ProtocolVersion.MQTTv5) {
-            return mqtt5Decoder.get(clazz);
+            return mqtt5Decoder[type.getType()];
         }
-        return mqtt3Decoder.get(clazz);
+        return mqtt3Decoder[type.getType()];
     }
 }

--- a/src/main/java/com/hivemq/extensions/services/publish/PublishServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/publish/PublishServiceImpl.java
@@ -101,7 +101,7 @@ public class PublishServiceImpl implements PublishService {
 
         final PUBLISH internalPublish = publishToPUBLISH((PublishImpl) publish);
         final ListenableFuture<PublishReturnCode> publishFuture = internalPublishService.publish(internalPublish, globalManagedExtensionExecutorService, null);
-        return ListenableFutureConverter.toCompletable(FutureUtils.voidFutureFromAnyFuture(publishFuture), globalManagedExtensionExecutorService);
+        return ListenableFutureConverter.toVoidCompletable(publishFuture, globalManagedExtensionExecutorService);
     }
 
     @Override

--- a/src/main/java/com/hivemq/mqtt/handler/connack/MqttConnackerImpl.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connack/MqttConnackerImpl.java
@@ -15,7 +15,6 @@
  */
 package com.hivemq.mqtt.handler.connack;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -50,8 +49,7 @@ import static com.hivemq.util.ChannelUtils.getChannelIP;
 @Singleton
 public class MqttConnackerImpl implements MqttConnacker {
 
-    @VisibleForTesting
-    public static final Logger log = LoggerFactory.getLogger(MqttConnackerImpl.class);
+    private static final @NotNull Logger log = LoggerFactory.getLogger(MqttConnackerImpl.class);
 
     private final boolean connackWithReasonCode;
     private final boolean connackWithReasonString;
@@ -109,7 +107,7 @@ public class MqttConnackerImpl implements MqttConnacker {
         Preconditions.checkArgument(reasonCode != Mqtt5ConnAckReasonCode.SUCCESS, "Success is no error");
         final ProtocolVersion protocolVersion = channel.attr(ChannelAttributes.MQTT_VERSION).get();
         logConnack(channel, logMessage, eventLogMessage);
-        if(protocolVersion == null){
+        if (protocolVersion == null) {
             channel.close();
         } else if (ProtocolVersion.MQTTv3_1 == protocolVersion || ProtocolVersion.MQTTv3_1_1 == protocolVersion) {
             connackError3(channel, connackWithReasonCode, reasonCode, reasonString, isAuthentication);
@@ -200,7 +198,7 @@ public class MqttConnackerImpl implements MqttConnacker {
                             final @Nullable Mqtt5ConnAckReasonCode reasonCode,
                             final @Nullable String reasonString,
                             final @NotNull Mqtt5UserProperties userProperties,
-                            final boolean isAuthentication){
+                            final boolean isAuthentication) {
         if ((channel.attr(ChannelAttributes.EXTENSION_CONNECT_EVENT_SENT).get() != null) &&
                 (channel.attr(ChannelAttributes.EXTENSION_DISCONNECT_EVENT_SENT).getAndSet(true) == null)) {
             final DisconnectedReasonCode disconnectedReasonCode =
@@ -213,7 +211,7 @@ public class MqttConnackerImpl implements MqttConnacker {
 
     @Nullable
     private Mqtt3ConnAckReturnCode transformReasonCode(final @Nullable Mqtt5ConnAckReasonCode reasonCode) {
-        if(reasonCode == null){
+        if (reasonCode == null) {
             return null;
         }
         switch (reasonCode) {

--- a/src/main/java/com/hivemq/mqtt/handler/disconnect/MqttServerDisconnectorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/handler/disconnect/MqttServerDisconnectorImpl.java
@@ -46,7 +46,7 @@ import static com.hivemq.util.ChannelUtils.getChannelIP;
 @Singleton
 public class MqttServerDisconnectorImpl implements MqttServerDisconnector {
 
-    public static final Logger log = LoggerFactory.getLogger(MqttServerDisconnectorImpl.class);
+    private static final @NotNull Logger log = LoggerFactory.getLogger(MqttServerDisconnectorImpl.class);
 
     private final boolean disconnectWithReasonCode;
     private final boolean disconnectWithReasonString;

--- a/src/main/java/com/hivemq/mqtt/message/publish/PUBLISH.java
+++ b/src/main/java/com/hivemq/mqtt/message/publish/PUBLISH.java
@@ -16,6 +16,7 @@
 package com.hivemq.mqtt.message.publish;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.ImmutableIntArray;
 import com.hivemq.codec.encoder.mqtt5.Mqtt5PayloadFormatIndicator;
 import com.hivemq.codec.encoder.mqtt5.UnsignedDataTypes;
@@ -408,7 +409,9 @@ public class PUBLISH extends MqttMessageWithUserProperties implements Mqtt3PUBLI
         size += ObjectMemoryEstimation.stringSize(contentType);
 
         size += 24; //User Properties Overhead
-        for (final MqttUserProperty userProperty : getUserProperties().asList()) {
+        final ImmutableList<MqttUserProperty> userProperties = getUserProperties().asList();
+        for (int i = 0; i < userProperties.size(); i++) {
+            final MqttUserProperty userProperty = userProperties.get(i);
             size += 24; //UserProperty Object Overhead
             size += ObjectMemoryEstimation.stringSize(userProperty.getName());
             size += ObjectMemoryEstimation.stringSize(userProperty.getValue());

--- a/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hivemq.configuration.service.InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR;
-import static com.hivemq.persistence.clientqueue.ClientQueuePersistenceImpl.Key;
 import static com.hivemq.util.ThreadPreConditions.SINGLE_WRITER_THREAD_PREFIX;
 
 /**
@@ -59,8 +58,7 @@ import static com.hivemq.util.ThreadPreConditions.SINGLE_WRITER_THREAD_PREFIX;
 @LazySingleton
 public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersistence {
 
-    @NotNull
-    private static final Logger log = LoggerFactory.getLogger(ClientQueueMemoryLocalPersistence.class);
+    private static final @NotNull Logger log = LoggerFactory.getLogger(ClientQueueMemoryLocalPersistence.class);
 
     private static final int NO_PACKET_ID = 0;
 
@@ -68,10 +66,15 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
     private final @NotNull PublishPayloadPersistence payloadPersistence;
 
-    final private @NotNull Map<Key, LinkedList<MessageWithID>> @NotNull [] qos12MessageBuckets;
-    private final @NotNull Map<Key, LinkedList<PublishWithRetained>> @NotNull [] qos0MessageBuckets;
-    private final @NotNull Map<Key, AtomicInteger> @NotNull [] queueSizeBuckets;
-    private final @NotNull Map<Key, AtomicInteger> @NotNull [] retainedQueueSizeBuckets;
+    final private @NotNull Map<String, Messages> @NotNull [] buckets;
+    final private @NotNull Map<String, Messages> @NotNull [] sharedBuckets;
+
+    private static class Messages {
+        final @NotNull LinkedList<MessageWithID> qos1Or2Messages = new LinkedList<>();
+        final @NotNull LinkedList<PublishWithRetained> qos0Messages = new LinkedList<>();
+        int retainedQueueSize = 0;
+        long qos0Memory = 0;
+    }
 
     //must be concurrent
     private final @NotNull Map<String, AtomicInteger> clientQos0MemoryMap;
@@ -103,19 +106,13 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         this.qos0MessagesMemory = new AtomicLong();
 
         //noinspection unchecked
-        this.qos12MessageBuckets = new HashMap[bucketCount];
+        this.buckets = new HashMap[bucketCount];
         //noinspection unchecked
-        this.qos0MessageBuckets = new HashMap[bucketCount];
-        //noinspection unchecked
-        this.queueSizeBuckets = new HashMap[bucketCount];
-        //noinspection unchecked
-        this.retainedQueueSizeBuckets = new HashMap[bucketCount];
+        this.sharedBuckets = new HashMap[bucketCount];
 
         for (int i = 0; i < bucketCount; i++) {
-            qos12MessageBuckets[i] = new HashMap<>();
-            qos0MessageBuckets[i] = new HashMap<>();
-            queueSizeBuckets[i] = new HashMap<>();
-            retainedQueueSizeBuckets[i] = new HashMap<>();
+            buckets[i] = new HashMap<>();
+            sharedBuckets[i] = new HashMap<>();
         }
 
         metricRegistry.register(
@@ -146,15 +143,20 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     @Override
     @ExecuteInSingleWriter
     public void add(
-            @NotNull final String queueId, final boolean shared, @NotNull final PUBLISH publish, final long max,
-            @NotNull final QueuedMessagesStrategy strategy, final boolean retained, final int bucketIndex) {
+            final @NotNull String queueId,
+            final boolean shared,
+            final @NotNull PUBLISH publish,
+            final long max,
+            final @NotNull QueuedMessagesStrategy strategy,
+            final boolean retained,
+            final int bucketIndex) {
+
         checkNotNull(queueId, "Queue ID must not be null");
         checkNotNull(publish, "Publish must not be null");
         checkNotNull(strategy, "Strategy must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
         add(queueId, shared, List.of(publish), max, strategy, retained, bucketIndex);
-
     }
 
     /**
@@ -163,45 +165,46 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     @Override
     @ExecuteInSingleWriter
     public void add(
-            @NotNull final String queueId, final boolean shared, @NotNull final List<PUBLISH> publishes, final long max,
-            @NotNull final QueuedMessagesStrategy strategy, final boolean retained, final int bucketIndex) {
+            final @NotNull String queueId,
+            final boolean shared,
+            final @NotNull List<PUBLISH> publishes,
+            final long max,
+            final @NotNull QueuedMessagesStrategy strategy,
+            final boolean retained,
+            final int bucketIndex) {
+
         checkNotNull(queueId, "Queue ID must not be null");
         checkNotNull(publishes, "Publishes must not be null");
         checkNotNull(strategy, "Strategy must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(queueId, shared);
-
-        final Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-
-        final AtomicInteger queueSize = getOrPutQueueSize(key, bucketIndex);
-        final AtomicInteger retainedQueueSize = getOrPutRetainedQueueSize(key, bucketIndex);
-        final int qos0Size = qos0Size(key, bucketIndex);
+        final Map<String, Messages> bucket = shared ? sharedBuckets[bucketIndex] : buckets[bucketIndex];
+        final Messages messages = bucket.computeIfAbsent(queueId, s -> new Messages());
 
         for (final PUBLISH publish : publishes) {
             final PublishWithRetained publishWithRetained = new PublishWithRetained(publish, retained);
             if (publish.getQoS() == QoS.AT_MOST_ONCE) {
-                addQos0Publish(key, publishWithRetained, bucketIndex);
+                addQos0Publish(queueId, shared, messages, publishWithRetained);
             } else {
-                final int qos1And2QueueSize = queueSize.get() - qos0Size - retainedQueueSize.get();
-                if (qos1And2QueueSize >= max && !retained) {
+                final int qos1And2QueueSize = messages.qos1Or2Messages.size() - messages.retainedQueueSize; // TODO retained QoS 0?
+                if ((qos1And2QueueSize >= max) && !retained) {
                     if (strategy == QueuedMessagesStrategy.DISCARD) {
                         logAndDecrementPayloadReference(publish, shared, queueId);
                         continue;
                     } else {
-                        final boolean discarded = discardOldest(bucket, key, false);
+                        final boolean discarded = discardOldest(queueId, shared, messages, false);
                         if (!discarded) {
                             //discard this message if no old could be discarded
                             logAndDecrementPayloadReference(publish, shared, queueId);
                             continue;
                         }
                     }
-                } else if (retainedQueueSize.get() >= retainedMessageMax && retained) {
+                } else if ((messages.retainedQueueSize >= retainedMessageMax) && retained) {
                     if (strategy == QueuedMessagesStrategy.DISCARD) {
                         logAndDecrementPayloadReference(publish, shared, queueId);
                         continue;
                     } else {
-                        final boolean discarded = discardOldest(bucket, key, true);
+                        final boolean discarded = discardOldest(queueId, shared, messages, true);
                         if (!discarded) {
                             //discard this message if no old could be discarded
                             logAndDecrementPayloadReference(publish, shared, queueId);
@@ -209,85 +212,80 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                         }
                     }
                 } else {
-                    queueSize.incrementAndGet();
                     if (retained) {
-                        retainedQueueSize.incrementAndGet();
+                        messages.retainedQueueSize++;
                     }
                 }
 
                 publishWithRetained.setPacketIdentifier(NO_PACKET_ID);
-                getOrPutMessageQueue(key, bucket).add(publishWithRetained);
+                messages.qos1Or2Messages.add(publishWithRetained);
                 increaseMessagesMemory(publishWithRetained.getEstimatedSize());
             }
         }
-
     }
 
-    private void addQos0Publish(@NotNull final Key key, @NotNull final PublishWithRetained publishWithRetained, final int bucketIndex) {
+    private void addQos0Publish(
+            final @NotNull String queueId,
+            final boolean shared,
+            final @NotNull Messages messages,
+            final @NotNull PublishWithRetained publishWithRetained) {
+
         final long currentQos0MessagesMemory = qos0MessagesMemory.get();
         if (currentQos0MessagesMemory >= qos0MemoryLimit) {
-            if (key.isShared()) {
+            if (shared) {
                 messageDroppedService.qos0MemoryExceededShared(
-                        key.getQueueId(), publishWithRetained.getTopic(), 0, currentQos0MessagesMemory, qos0MemoryLimit);
+                        queueId, publishWithRetained.getTopic(), 0, currentQos0MessagesMemory, qos0MemoryLimit);
             } else {
                 messageDroppedService.qos0MemoryExceeded(
-                        key.getQueueId(), publishWithRetained.getTopic(), 0, currentQos0MessagesMemory, qos0MemoryLimit);
+                        queueId, publishWithRetained.getTopic(), 0, currentQos0MessagesMemory, qos0MemoryLimit);
             }
             payloadPersistence.decrementReferenceCounter(publishWithRetained.getPublishId());
             return;
         }
 
-        if (!key.isShared()) {
-            final AtomicInteger clientQos0Memory = clientQos0MemoryMap.get(key.getQueueId());
-            if (clientQos0Memory != null && clientQos0Memory.get() >= qos0ClientMemoryLimit) {
-                messageDroppedService.qos0MemoryExceeded(key.getQueueId(), publishWithRetained.getTopic(), 0, clientQos0Memory.get(), qos0ClientMemoryLimit);
+        if (!shared) {
+            if (messages.qos0Memory >= qos0ClientMemoryLimit) {
+                messageDroppedService.qos0MemoryExceeded(queueId, publishWithRetained.getTopic(), 0, messages.qos0Memory, qos0ClientMemoryLimit);
                 payloadPersistence.decrementReferenceCounter(publishWithRetained.getPublishId());
                 return;
             }
         }
 
-        final Map<Key, LinkedList<PublishWithRetained>> bucketMessages = qos0MessageBuckets[bucketIndex];
-        getOrPutQos0MessageQueue(key, bucketMessages).add(publishWithRetained);
-        getOrPutQueueSize(key, bucketIndex).incrementAndGet();
+        messages.qos0Messages.add(publishWithRetained);
         if (publishWithRetained.retained) {
-            getOrPutRetainedQueueSize(key, bucketIndex).incrementAndGet();
+            messages.retainedQueueSize++;
         }
         increaseQos0MessagesMemory(publishWithRetained.getEstimatedSize());
-        increaseClientQos0MessagesMemory(key, publishWithRetained.getEstimatedSize());
+        increaseClientQos0MessagesMemory(messages, publishWithRetained.getEstimatedSize());
         increaseMessagesMemory(publishWithRetained.getEstimatedSize());
     }
-
 
     /**
      * {@inheritDoc}
      */
-    @NotNull
     @Override
     @ExecuteInSingleWriter
-    public ImmutableList<PUBLISH> readNew(
-            @NotNull final String queueId, final boolean shared, @NotNull final ImmutableIntArray packetIds,
-            final long bytesLimit, final int bucketIndex) {
+    public @NotNull ImmutableList<PUBLISH> readNew(
+            final @NotNull String queueId,
+            final boolean shared,
+            final @NotNull ImmutableIntArray packetIds,
+            final long bytesLimit,
+            final int bucketIndex) {
+
         checkNotNull(queueId, "Queue ID must not be null");
         checkNotNull(packetIds, "Packet IDs must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(queueId, shared);
-
-        final AtomicInteger queueSize = getOrPutQueueSize(key, bucketIndex);
-        if (queueSize.get() == 0) {
+        final Map<String, Messages> bucket = shared ? sharedBuckets[bucketIndex] : buckets[bucketIndex];
+        final Messages messages = bucket.get(queueId);
+        if (messages == null) {
             return ImmutableList.of();
         }
 
-        final Map<Key, LinkedList<PublishWithRetained>> qos0MessageBucket = qos0MessageBuckets[bucketIndex];
-        final LinkedList<PublishWithRetained> qos0Messages = getOrPutQos0MessageQueue(key, qos0MessageBucket);
-
         // In case there are only qos 0 messages
-        if (queueSize.get() == qos0Messages.size()) {
-            return getQos0Publishes(packetIds, bytesLimit, bucketIndex, key, qos0Messages);
+        if (messages.qos1Or2Messages.size() == 0) {
+            return getQos0Publishes(messages, packetIds, bytesLimit);
         }
-
-        final Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-        final LinkedList<MessageWithID> messageQueue = getOrPutMessageQueue(key, bucket);
 
         final int countLimit = packetIds.length();
         int messageCount = 0;
@@ -295,7 +293,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         int bytes = 0;
         final ImmutableList.Builder<PUBLISH> publishes = ImmutableList.builder();
 
-        final Iterator<MessageWithID> iterator = messageQueue.iterator();
+        final Iterator<MessageWithID> iterator = messages.qos1Or2Messages.iterator();
         while (iterator.hasNext()) {
             final MessageWithID messageWithID = iterator.next();
             if (!(messageWithID instanceof PublishWithRetained)) {
@@ -310,9 +308,8 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             if (PublishUtil.checkExpiry(publishWithRetained.getTimestamp(), publishWithRetained.getMessageExpiryInterval())) {
                 iterator.remove();
                 payloadPersistence.decrementReferenceCounter(publishWithRetained.getPublishId());
-                getOrPutQueueSize(key, bucketIndex).decrementAndGet();
                 if (publishWithRetained.retained) {
-                    getOrPutRetainedQueueSize(key, bucketIndex).decrementAndGet();
+                    messages.retainedQueueSize--;
                 }
                 increaseMessagesMemory(-publishWithRetained.getEstimatedSize());
                 //do not return here, because we could have a QoS 0 message left
@@ -330,86 +327,85 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             }
 
             // poll a qos 0 message
-            if (!qos0Messages.isEmpty()) {
-                final PUBLISH qos0Publish = pollQos0Message(key, qos0Messages, bucketIndex);
-                if (!PublishUtil.checkExpiry(qos0Publish.getTimestamp(), qos0Publish.getMessageExpiryInterval())) {
-                    publishes.add(qos0Publish);
-                    messageCount++;
-                    bytes += qos0Publish.getEstimatedSizeInMemory();
-                }
+            final PUBLISH qos0Publish = pollQos0Message(messages);
+            if ((qos0Publish != null) && !PublishUtil.checkExpiry(qos0Publish.getTimestamp(), qos0Publish.getMessageExpiryInterval())) {
+                publishes.add(qos0Publish);
+                messageCount++;
+                bytes += qos0Publish.getEstimatedSizeInMemory();
             }
             if ((messageCount == countLimit) || (bytes > bytesLimit)) {
                 break;
             }
         }
         return publishes.build();
-
     }
 
-    @NotNull
-    private ImmutableList<PUBLISH> getQos0Publishes(
-            final @NotNull ImmutableIntArray packetIds,
-            final long bytesLimit,
-            final int bucketIndex,
-            final @NotNull Key key,
-            final @NotNull LinkedList<PublishWithRetained> qos0Messages) {
+    private @NotNull ImmutableList<PUBLISH> getQos0Publishes(
+            final @NotNull Messages messages, final @NotNull ImmutableIntArray packetIds, final long bytesLimit) {
+
         final ImmutableList.Builder<PUBLISH> publishes = ImmutableList.builder();
         int qos0MessagesFound = 0;
         int qos0Bytes = 0;
         while (qos0MessagesFound < packetIds.length() && bytesLimit > qos0Bytes) {
-            final PUBLISH qos0Publish = pollQos0Message(key, qos0Messages, bucketIndex);
+            final PUBLISH qos0Publish = pollQos0Message(messages);
+            if (qos0Publish == null) {
+                break;
+            }
             if (!PublishUtil.checkExpiry(qos0Publish.getTimestamp(), qos0Publish.getMessageExpiryInterval())) {
                 publishes.add(qos0Publish);
                 qos0MessagesFound++;
                 qos0Bytes += qos0Publish.getEstimatedSizeInMemory();
-            }
-            if (qos0Messages.isEmpty()) {
-                break;
             }
         }
 
         return publishes.build();
     }
 
-    @NotNull
-    private PUBLISH pollQos0Message(@NotNull final Key key, final @NotNull LinkedList<PublishWithRetained> qos0Messages, final int bucketIndex) {
-        final PublishWithRetained publishWithRetained = qos0Messages.remove(0);
-        getOrPutQueueSize(key, bucketIndex).decrementAndGet();
-        if (publishWithRetained.retained) {
-            getOrPutRetainedQueueSize(key, bucketIndex).decrementAndGet();
+    private @Nullable PUBLISH pollQos0Message(final @NotNull Messages messages) {
+        final PublishWithRetained publishWithRetained = messages.qos0Messages.poll();
+        if (publishWithRetained == null) {
+            return null;
         }
-        increaseQos0MessagesMemory(-publishWithRetained.getEstimatedSize());
-        increaseClientQos0MessagesMemory(key, -publishWithRetained.getEstimatedSize());
-        increaseMessagesMemory(-publishWithRetained.getEstimatedSize());
+        if (publishWithRetained.retained) {
+            messages.retainedQueueSize--;
+        }
+        final int estimatedSize = publishWithRetained.getEstimatedSize();
+        increaseQos0MessagesMemory(-estimatedSize);
+        increaseClientQos0MessagesMemory(messages, -estimatedSize);
+        increaseMessagesMemory(-estimatedSize);
         payloadPersistence.decrementReferenceCounter(publishWithRetained.getPublishId());
         return publishWithRetained;
     }
 
-    @NotNull
     @Override
     @ExecuteInSingleWriter
-    public ImmutableList<MessageWithID> readInflight(
-            @NotNull final String client, final boolean shared, final int batchSize,
-            final long bytesLimit, final int bucketIndex) {
-        checkNotNull(client, "client id must not be null");
+    public @NotNull ImmutableList<MessageWithID> readInflight(
+            final @NotNull String queueId,
+            final boolean shared,
+            final int batchSize,
+            final long bytesLimit,
+            final int bucketIndex) {
+
+        checkNotNull(queueId, "client id must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(client, shared);
-
-        final @NotNull Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-        final LinkedList<MessageWithID> messageQueue = getOrPutMessageQueue(key, bucket);
+        final Map<String, Messages> bucket = shared ? sharedBuckets[bucketIndex] : buckets[bucketIndex];
+        final Messages messages = bucket.get(queueId);
+        if (messages == null) {
+            return ImmutableList.of();
+        }
 
         int messageCount = 0;
         int bytes = 0;
-        final ImmutableList.Builder<MessageWithID> messages = ImmutableList.builder();
+        final ImmutableList.Builder<MessageWithID> publishes = ImmutableList.builder();
 
-        for (final MessageWithID messageWithID : messageQueue) {
+        for (final MessageWithID messageWithID : messages.qos1Or2Messages) {
             // Stop at first non inflight message
             // This works because in-flight messages are always first in the queue
             if (messageWithID.getPacketIdentifier() == NO_PACKET_ID) {
                 break;
             }
-            messages.add(messageWithID);
+            publishes.add(messageWithID);
             messageCount++;
 
             if (messageWithID instanceof PublishWithRetained) {
@@ -422,24 +418,26 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                 break;
             }
         }
-        return messages.build();
+        return publishes.build();
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @Nullable
     @ExecuteInSingleWriter
-    public String replace(@NotNull final String client, @NotNull final PUBREL pubrel, final int bucketIndex) {
-        checkNotNull(client, "client id must not be null");
+    public @Nullable String replace(
+            final @NotNull String queueId, final @NotNull PUBREL pubrel, final int bucketIndex) {
+
+        checkNotNull(queueId, "client id must not be null");
         checkNotNull(pubrel, "pubrel must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(client, false);
-
-        final Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-        final LinkedList<MessageWithID> messageQueue = getOrPutMessageQueue(key, bucket);
+        final Map<String, Messages> bucket = buckets[bucketIndex];
+        final Messages messages = bucket.get(queueId);
+        if (messages == null) {
+            return null;
+        }
 
         boolean packetIdFound = false;
         String replacedId = null;
@@ -447,7 +445,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
         int messageIndexInQueue = -1;
 
-        for (final MessageWithID messageWithID : messageQueue) {
+        for (final MessageWithID messageWithID : messages.qos1Or2Messages) {
             messageIndexInQueue++;
             final int packetId = messageWithID.getPacketIdentifier();
             if (packetId == NO_PACKET_ID) {
@@ -474,11 +472,10 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         }
         final PubrelWithRetained pubrelWithRetained = new PubrelWithRetained(pubrel, retained);
         if (packetIdFound) {
-            messageQueue.set(messageIndexInQueue, pubrelWithRetained);
+            messages.qos1Or2Messages.set(messageIndexInQueue, pubrelWithRetained);
         } else {
-            getOrPutQueueSize(key, bucketIndex).incrementAndGet();
             // Ensure unknown PUBRELs are always first in queue
-            messageQueue.addFirst(pubrelWithRetained);
+            messages.qos1Or2Messages.addFirst(pubrelWithRetained);
         }
         increaseMessagesMemory(pubrelWithRetained.getEstimatedSize());
         return replacedId;
@@ -489,25 +486,28 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      */
     @Override
     @ExecuteInSingleWriter
-    public String remove(@NotNull final String client, final int packetId, final int bucketIndex) {
-        return remove(client, packetId, null, bucketIndex);
+    public @Nullable String remove(final @NotNull String queueId, final int packetId, final int bucketIndex) {
+        return remove(queueId, packetId, null, bucketIndex);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    @Nullable
     @ExecuteInSingleWriter
-    public String remove(
-            @NotNull final String client, final int packetId, @Nullable final String uniqueId, final int bucketIndex) {
-        checkNotNull(client, "client id must not be null");
+    public @Nullable String remove(
+            final @NotNull String queueId, final int packetId, final @Nullable String uniqueId, final int bucketIndex) {
+
+        checkNotNull(queueId, "client id must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(client, false);
-        final Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-        final LinkedList<MessageWithID> messageQueue = getOrPutMessageQueue(key, bucket);
-        final Iterator<MessageWithID> iterator = messageQueue.iterator();
+        final Map<String, Messages> bucket = buckets[bucketIndex];
+        final Messages messages = bucket.get(queueId);
+        if (messages == null) {
+            return null;
+        }
+
+        final Iterator<MessageWithID> iterator = messages.qos1Or2Messages.iterator();
         while (iterator.hasNext()) {
             final MessageWithID messageWithID = iterator.next();
             if (messageWithID.getPacketIdentifier() == packetId) {
@@ -520,9 +520,8 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                     payloadPersistence.decrementReferenceCounter(publish.getPublishId());
                     removedId = publish.getUniqueId();
                 }
-                getOrPutQueueSize(key, bucketIndex).decrementAndGet();
                 if (isRetained(messageWithID)) {
-                    getOrPutRetainedQueueSize(key, bucketIndex).decrementAndGet();
+                    messages.retainedQueueSize--;
                 }
                 increaseMessagesMemory(-getMessageSize(messageWithID));
                 iterator.remove();
@@ -538,12 +537,13 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      */
     @Override
     @ExecuteInSingleWriter
-    public int size(@NotNull final String queueId, final boolean shared, final int bucketIndex) {
+    public int size(final @NotNull String queueId, final boolean shared, final int bucketIndex) {
         checkNotNull(queueId, "Queue ID must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX); // QueueSizes are not thread save
-        final Key key = new Key(queueId, shared);
-        final AtomicInteger queueSize = queueSizeBuckets[bucketIndex].get(key);
-        return (queueSize == null) ? 0 : queueSize.get();
+
+        final Map<String, Messages> bucket = shared ? sharedBuckets[bucketIndex] : buckets[bucketIndex];
+        final Messages messages = bucket.get(queueId);
+        return (messages == null) ? 0 : (messages.qos1Or2Messages.size() + messages.qos0Messages.size());
     }
 
     /**
@@ -551,11 +551,13 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      */
     @Override
     @ExecuteInSingleWriter
-    public int qos0Size(@NotNull final String queueId, final boolean shared, final int bucketIndex) {
+    public int qos0Size(final @NotNull String queueId, final boolean shared, final int bucketIndex) {
         checkNotNull(queueId, "Queue ID must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX); // QueueSizes are not thread save
-        final Key key = new Key(queueId, shared);
-        return qos0Size(key, bucketIndex);
+
+        final Map<String, Messages> bucket = shared ? sharedBuckets[bucketIndex] : buckets[bucketIndex];
+        final Messages messages = bucket.get(queueId);
+        return (messages == null) ? 0 : messages.qos0Messages.size();
     }
 
     /**
@@ -563,33 +565,30 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      */
     @Override
     @ExecuteInSingleWriter
-    public void clear(@NotNull final String queueId, final boolean shared, final int bucketIndex) {
+    public void clear(final @NotNull String queueId, final boolean shared, final int bucketIndex) {
         checkNotNull(queueId, "Queue ID must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(queueId, shared);
+        final Map<String, Messages> bucket = shared ? sharedBuckets[bucketIndex] : buckets[bucketIndex];
+        final Messages messages = bucket.remove(queueId);
+        if (messages == null) {
+            return;
+        }
 
-        final Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-        final LinkedList<MessageWithID> messageQueue = getOrPutMessageQueue(key, bucket);
-        for (final MessageWithID messageWithID : messageQueue) {
+        for (final MessageWithID messageWithID : messages.qos1Or2Messages) {
             if (messageWithID instanceof PublishWithRetained) {
                 payloadPersistence.decrementReferenceCounter(((PublishWithRetained) messageWithID).getPublishId());
             }
             increaseMessagesMemory(-getMessageSize(messageWithID));
         }
-        bucket.remove(key);
 
-        final Map<Key, LinkedList<PublishWithRetained>> bucketMessages = qos0MessageBuckets[bucketIndex];
-        final LinkedList<PublishWithRetained> qos0Messages = getOrPutQos0MessageQueue(key, bucketMessages);
-        for (final PublishWithRetained qos0Message : qos0Messages) {
-            increaseQos0MessagesMemory(-qos0Message.getEstimatedSize());
-            increaseClientQos0MessagesMemory(key, -qos0Message.getEstimatedSize());
-            increaseMessagesMemory(-qos0Message.getEstimatedSize());
+        for (final PublishWithRetained qos0Message : messages.qos0Messages) {
+            final int estimatedSize = qos0Message.getEstimatedSize();
+            increaseQos0MessagesMemory(-estimatedSize);
+            increaseClientQos0MessagesMemory(messages, -estimatedSize); // TODO can be removed
+            increaseMessagesMemory(-estimatedSize);
             payloadPersistence.decrementReferenceCounter(qos0Message.getPublishId());
         }
-        bucketMessages.remove(key);
-        queueSizeBuckets[bucketIndex].remove(key);
-        retainedQueueSizeBuckets[bucketIndex].remove(key);
     }
 
     /**
@@ -597,46 +596,42 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      */
     @Override
     @ExecuteInSingleWriter
-    public void removeAllQos0Messages(@NotNull final String queueId, final boolean shared, final int bucketIndex) {
+    public void removeAllQos0Messages(final @NotNull String queueId, final boolean shared, final int bucketIndex) {
         checkNotNull(queueId, "Queue id must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(queueId, shared);
-        final Map<Key, LinkedList<PublishWithRetained>> bucketMessages = qos0MessageBuckets[bucketIndex];
-        final LinkedList<PublishWithRetained> publishesWithRetained = getOrPutQos0MessageQueue(key, bucketMessages);
-        for (final PublishWithRetained publishWithRetained : publishesWithRetained) {
+        final Map<String, Messages> bucket = shared ? sharedBuckets[bucketIndex] : buckets[bucketIndex];
+        final Messages messages = bucket.get(queueId);
+        if (messages == null) {
+            return;
+        }
+
+        for (final PublishWithRetained publishWithRetained : messages.qos0Messages) {
             payloadPersistence.decrementReferenceCounter(publishWithRetained.getPublishId());
-            getOrPutQueueSize(key, bucketIndex).decrementAndGet();
             if (publishWithRetained.retained) {
-                getOrPutRetainedQueueSize(key, bucketIndex).decrementAndGet();
+                messages.retainedQueueSize--;
             }
             increaseQos0MessagesMemory(-publishWithRetained.getEstimatedSize());
-            increaseClientQos0MessagesMemory(key, -publishWithRetained.getEstimatedSize());
+            increaseClientQos0MessagesMemory(messages, -publishWithRetained.getEstimatedSize()); // TODO set to 0 instead
             increaseMessagesMemory(-publishWithRetained.getEstimatedSize());
         }
-        bucketMessages.remove(key);
     }
 
     /**
      * {@inheritDoc}
      */
-    @NotNull
     @Override
     @ExecuteInSingleWriter
-    public ImmutableSet<String> cleanUp(final int bucketIndex) {
+    public @NotNull ImmutableSet<String> cleanUp(final int bucketIndex) {
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final ImmutableSet.Builder<String> sharedQueues = ImmutableSet.builder();
-        final Map<Key, AtomicInteger> bucketClients = queueSizeBuckets[bucketIndex];
+        final Map<String, Messages> bucket = buckets[bucketIndex];
+        final Map<String, Messages> sharedBucket = sharedBuckets[bucketIndex];
 
-        for (final Key bucketKey : bucketClients.keySet()) {
-            if (bucketKey.isShared()) {
-                sharedQueues.add(bucketKey.getQueueId());
-            }
-            cleanExpiredMessages(bucketKey, bucketIndex);
-        }
+        bucket.forEach((queueId, messages) -> cleanExpiredMessages(messages));
+        sharedBucket.forEach((queueId, messages) -> cleanExpiredMessages(messages));
 
-        return sharedQueues.build();
+        return ImmutableSet.copyOf(sharedBucket.keySet());
     }
 
     /**
@@ -645,15 +640,19 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     @Override
     @ExecuteInSingleWriter
     public void removeShared(
-            @NotNull final String sharedSubscription, @NotNull final String uniqueId, final int bucketIndex) {
+            final @NotNull String sharedSubscription, final @NotNull String uniqueId, final int bucketIndex) {
+
         checkNotNull(sharedSubscription, "Shared subscription must not be null");
         checkNotNull(uniqueId, "Unique id must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(sharedSubscription, true);
-        final Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-        final LinkedList<MessageWithID> messageQueue = getOrPutMessageQueue(key, bucket);
-        final Iterator<MessageWithID> iterator = messageQueue.iterator();
+        final Map<String, Messages> bucket = sharedBuckets[bucketIndex];
+        final Messages messages = bucket.get(sharedSubscription);
+        if (messages == null) {
+            return;
+        }
+
+        final Iterator<MessageWithID> iterator = messages.qos1Or2Messages.iterator();
         while (iterator.hasNext()) {
             final MessageWithID messageWithID = iterator.next();
             if (messageWithID instanceof PublishWithRetained) {
@@ -662,9 +661,8 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                     continue;
                 }
                 payloadPersistence.decrementReferenceCounter(publish.getPublishId());
-                getOrPutQueueSize(key, bucketIndex).decrementAndGet();
                 if (publish.retained) {
-                    getOrPutRetainedQueueSize(key, bucketIndex).decrementAndGet();
+                    messages.retainedQueueSize--;
                 }
                 increaseMessagesMemory(-publish.getEstimatedSize());
                 iterator.remove();
@@ -678,15 +676,19 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     @Override
     @ExecuteInSingleWriter
     public void removeInFlightMarker(
-            @NotNull final String sharedSubscription, @NotNull final String uniqueId, final int bucketIndex) {
+            final @NotNull String sharedSubscription, final @NotNull String uniqueId, final int bucketIndex) {
+
         checkNotNull(sharedSubscription, "Shared subscription must not be null");
         checkNotNull(uniqueId, "Unique id must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        final Key key = new Key(sharedSubscription, true);
-        final Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-        final LinkedList<MessageWithID> messageQueue = getOrPutMessageQueue(key, bucket);
-        for (final MessageWithID messageWithID : messageQueue) {
+        final Map<String, Messages> bucket = sharedBuckets[bucketIndex];
+        final Messages messages = bucket.get(sharedSubscription);
+        if (messages == null) {
+            return;
+        }
+
+        for (final MessageWithID messageWithID : messages.qos1Or2Messages) {
             if (messageWithID instanceof PublishWithRetained) {
                 final PublishWithRetained publish = (PublishWithRetained) messageWithID;
                 if (!uniqueId.equals(publish.getUniqueId())) {
@@ -707,10 +709,8 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     @ExecuteInSingleWriter
     public void closeDB(final int bucketIndex) {
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
-        qos0MessageBuckets[bucketIndex].clear();
-        qos12MessageBuckets[bucketIndex].clear();
-        queueSizeBuckets[bucketIndex].clear();
-        retainedQueueSizeBuckets[bucketIndex].clear();
+        buckets[bucketIndex].clear();
+        sharedBuckets[bucketIndex].clear();
         clientQos0MemoryMap.clear();
         totalMemorySize.set(0L);
         qos0MessagesMemory.set(0L);
@@ -737,7 +737,8 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     }
 
     private void logMessageDropped(
-            @NotNull final PUBLISH publish, final boolean shared, @NotNull final String queueId) {
+            final @NotNull PUBLISH publish, final boolean shared, final @NotNull String queueId) {
+
         if (shared) {
             messageDroppedService.queueFullShared(queueId, publish.getTopic(), publish.getQoS().getQosNumber());
         } else {
@@ -771,43 +772,27 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      * @param size the amount of bytes the currently used qos 0 memory will be increased by. May be negative.
      */
     @VisibleForTesting
-    void increaseClientQos0MessagesMemory(final Key key, final int size) {
-        if (key.isShared()) {
-            return;
+    void increaseClientQos0MessagesMemory(final @NotNull Messages messages, final int size) {
+        if (size < 0) {
+            messages.qos0Memory += size - ObjectMemoryEstimation.linkedListNodeOverhead();
+        } else {
+            messages.qos0Memory += size + ObjectMemoryEstimation.linkedListNodeOverhead();
         }
-
-        clientQos0MemoryMap.compute(key.getQueueId(), (clientId, clientQos0Memory) -> {
-            if (clientQos0Memory == null) {
-                if (size < 0) {
-                    //strange case that should never happen as there must be a increase before a decrease..
-                    return null;
-                } else {
-                    return new AtomicInteger(size + ObjectMemoryEstimation.linkedListNodeOverhead());
-                }
-            }
-            if (size < 0) {
-                clientQos0Memory.addAndGet(size - ObjectMemoryEstimation.linkedListNodeOverhead());
-            } else {
-                clientQos0Memory.addAndGet(size + ObjectMemoryEstimation.linkedListNodeOverhead());
-            }
-            if (clientQos0Memory.get() <= 0) {
-                return null; //this removes the AtomicInteger
-            }
-            return clientQos0Memory;
-        });
+        if (messages.qos0Memory < 0) {
+            messages.qos0Memory = 0;
+        }
     }
 
     /**
      * @return true if a message was discarded, else false
      */
     private boolean discardOldest(
-            @NotNull final Map<Key, LinkedList<MessageWithID>> bucket,
-            @NotNull final Key key,
+            final @NotNull String queueId,
+            final boolean shared,
+            final @NotNull Messages messages,
             final boolean retainedOnly) {
 
-        final LinkedList<MessageWithID> publishes = getOrPutMessageQueue(key, bucket);
-
-        final Iterator<MessageWithID> iterator = publishes.iterator();
+        final Iterator<MessageWithID> iterator = messages.qos1Or2Messages.iterator();
         while (iterator.hasNext()) {
             final MessageWithID messageWithID = iterator.next();
             if (!(messageWithID instanceof PublishWithRetained)) {
@@ -820,11 +805,10 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             }
             // Messages that are queued as retained messages are not discarded,
             // otherwise a client could only receive a limited amount of retained messages per subscription.
-            if (retainedOnly && !publish.retained ||
-                    !retainedOnly && publish.retained) {
+            if ((retainedOnly && !publish.retained) || (!retainedOnly && publish.retained)) {
                 continue;
             }
-            logAndDecrementPayloadReference(publish, key.isShared(), key.getQueueId());
+            logAndDecrementPayloadReference(publish, shared, queueId);
             iterator.remove();
             return true;
         }
@@ -834,35 +818,30 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
     private void logAndDecrementPayloadReference(
             final @NotNull PUBLISH publish, final boolean shared, final @NotNull String queueId) {
+
         logMessageDropped(publish, shared, queueId);
         payloadPersistence.decrementReferenceCounter(publish.getPublishId());
     }
 
 
-    private void cleanExpiredMessages(@NotNull final Key key, final int bucketIndex) {
+    private void cleanExpiredMessages(final @NotNull Messages messages) {
 
-        final Map<Key, LinkedList<PublishWithRetained>> bucketMessages = qos0MessageBuckets[bucketIndex];
-        final LinkedList<PublishWithRetained> qos0Messages = getOrPutQos0MessageQueue(key, bucketMessages);
-        final Iterator<PublishWithRetained> iterator = qos0Messages.iterator();
+        final Iterator<PublishWithRetained> iterator = messages.qos0Messages.iterator();
         while (iterator.hasNext()) {
             final PublishWithRetained publishWithRetained = iterator.next();
             if (PublishUtil.checkExpiry(publishWithRetained.getTimestamp(), publishWithRetained.getMessageExpiryInterval())) {
-                getOrPutQueueSize(key, bucketIndex).decrementAndGet();
                 increaseQos0MessagesMemory(-publishWithRetained.getEstimatedSize());
-                increaseClientQos0MessagesMemory(key, -publishWithRetained.getEstimatedSize());
+                increaseClientQos0MessagesMemory(messages, -publishWithRetained.getEstimatedSize());
                 increaseMessagesMemory(-publishWithRetained.getEstimatedSize());
                 payloadPersistence.decrementReferenceCounter(publishWithRetained.getPublishId());
                 if (publishWithRetained.retained) {
-                    getOrPutRetainedQueueSize(key, bucketIndex).decrementAndGet();
+                    messages.retainedQueueSize--;
                 }
                 iterator.remove();
             }
         }
 
-        final Map<Key, LinkedList<MessageWithID>> bucket = qos12MessageBuckets[bucketIndex];
-        final LinkedList<MessageWithID> messageQueue = getOrPutMessageQueue(key, bucket);
-
-        final Iterator<MessageWithID> qos12iterator = messageQueue.iterator();
+        final Iterator<MessageWithID> qos12iterator = messages.qos1Or2Messages.iterator();
         while (qos12iterator.hasNext()) {
             final MessageWithID messageWithID = qos12iterator.next();
             if (messageWithID instanceof PubrelWithRetained) {
@@ -876,9 +855,8 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                 if (!PublishUtil.checkExpiry(pubrel.getPublishTimestamp(), pubrel.getExpiryInterval())) {
                     continue;
                 }
-                getOrPutQueueSize(key, bucketIndex).decrementAndGet();
                 if (pubrel.retained) {
-                    getOrPutRetainedQueueSize(key, bucketIndex).decrementAndGet();
+                    messages.retainedQueueSize--;
                 }
                 increaseMessagesMemory(-pubrel.getEstimatedSize());
                 qos12iterator.remove();
@@ -890,66 +868,14 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                 final boolean drop = PublishUtil.checkExpiry(publish) && (!isInflight || expireInflight);
                 if (drop) {
                     payloadPersistence.decrementReferenceCounter(publish.getPublishId());
-                    getOrPutQueueSize(key, bucketIndex).decrementAndGet();
                     if (publish.retained) {
-                        getOrPutRetainedQueueSize(key, bucketIndex).decrementAndGet();
+                        messages.retainedQueueSize--;
                     }
                     increaseMessagesMemory(-publish.getEstimatedSize());
                     qos12iterator.remove();
                 }
             }
-
         }
-    }
-
-    @NotNull
-    private AtomicInteger getOrPutQueueSize(@NotNull final Key key, final int bucketIndex) {
-        final Map<Key, AtomicInteger> queueSizeBucket = queueSizeBuckets[bucketIndex];
-        return getOrPutQueueSizeFromBucket(key, queueSizeBucket);
-    }
-
-    private @NotNull AtomicInteger getOrPutRetainedQueueSize(@NotNull final Key key, final int bucketIndex) {
-        final Map<Key, AtomicInteger> queueSizeBucket = retainedQueueSizeBuckets[bucketIndex];
-        return getOrPutQueueSizeFromBucket(key, queueSizeBucket);
-    }
-
-    private @NotNull AtomicInteger getOrPutQueueSizeFromBucket(
-            final @NotNull Key key, final @NotNull Map<Key, AtomicInteger> queueSizeBucket) {
-        return queueSizeBucket.compute(key, (ignore, queueSize) -> {
-            if (queueSize == null) {
-                return new AtomicInteger();
-            }
-            return queueSize;
-        });
-    }
-
-    @NotNull
-    private LinkedList<PublishWithRetained> getOrPutQos0MessageQueue(@NotNull final Key key, final @NotNull Map<Key, LinkedList<PublishWithRetained>> bucket) {
-        return bucket.compute(key, (ignore, publishes) -> {
-            if (publishes == null) {
-                return new LinkedList<>();
-            }
-            return publishes;
-        });
-    }
-
-    @NotNull
-    private LinkedList<MessageWithID> getOrPutMessageQueue(@NotNull final Key key, final @NotNull Map<Key, LinkedList<MessageWithID>> bucket) {
-        return bucket.compute(key, (ignore, publishes) -> {
-            if (publishes == null) {
-                return new LinkedList<>();
-            }
-            return publishes;
-        });
-    }
-
-    private int qos0Size(@NotNull final Key key, final int bucketIndex) {
-        final Map<Key, LinkedList<PublishWithRetained>> bucketMessages = qos0MessageBuckets[bucketIndex];
-        final LinkedList<PublishWithRetained> publishes = bucketMessages.get(key);
-        if (publishes != null) {
-            return publishes.size();
-        }
-        return 0;
     }
 
     @VisibleForTesting
@@ -957,7 +883,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
         private final boolean retained;
 
-        PublishWithRetained(@NotNull final PUBLISH publish, final boolean retained) {
+        PublishWithRetained(final @NotNull PUBLISH publish, final boolean retained) {
             super(publish, publish.getPersistence());
             this.retained = retained;
         }
@@ -973,7 +899,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
         private final boolean retained;
 
-        private PubrelWithRetained(@NotNull final PUBREL pubrel, final boolean retained) {
+        private PubrelWithRetained(final @NotNull PUBREL pubrel, final boolean retained) {
             super(pubrel.getPacketIdentifier(),
                     pubrel.getReasonCode(),
                     pubrel.getReasonString(),

--- a/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -62,7 +62,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     private static final int NO_PACKET_ID = 0;
 
     private final @NotNull Map<String, Messages> @NotNull [] buckets;
-    private final  @NotNull Map<String, Messages> @NotNull [] sharedBuckets;
+    private final @NotNull Map<String, Messages> @NotNull [] sharedBuckets;
 
     private static class Messages {
         final @NotNull LinkedList<MessageWithID> qos1Or2Messages = new LinkedList<>();
@@ -598,6 +598,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             // increaseClientQos0MessagesMemory not necessary as messages.qos0Memory = 0 below
             increaseMessagesMemory(-publishWithRetained.getEstimatedSize());
         }
+        messages.qos0Messages.clear();
         messages.qos0Memory = 0;
     }
 
@@ -749,8 +750,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     /**
      * @param size the amount of bytes the currently used qos 0 memory will be increased by. May be negative.
      */
-    @VisibleForTesting
-    void increaseClientQos0MessagesMemory(final @NotNull Messages messages, final int size) {
+    private void increaseClientQos0MessagesMemory(final @NotNull Messages messages, final int size) {
         if (size < 0) {
             messages.qos0Memory += size - ObjectMemoryEstimation.linkedListNodeOverhead();
         } else {
@@ -800,7 +800,6 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         logMessageDropped(publish, shared, queueId);
         payloadPersistence.decrementReferenceCounter(publish.getPublishId());
     }
-
 
     private void cleanExpiredMessages(final @NotNull Messages messages) {
 

--- a/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -577,11 +577,11 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         }
 
         for (final PublishWithRetained qos0Message : messages.qos0Messages) {
+            payloadPersistence.decrementReferenceCounter(qos0Message.getPublishId());
             final int estimatedSize = qos0Message.getEstimatedSize();
             increaseQos0MessagesMemory(-estimatedSize);
-            increaseClientQos0MessagesMemory(messages, -estimatedSize); // TODO can be removed
+            // increaseClientQos0MessagesMemory not necessary as messages are removed completely
             increaseMessagesMemory(-estimatedSize);
-            payloadPersistence.decrementReferenceCounter(qos0Message.getPublishId());
         }
     }
 
@@ -603,9 +603,10 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         for (final PublishWithRetained publishWithRetained : messages.qos0Messages) {
             payloadPersistence.decrementReferenceCounter(publishWithRetained.getPublishId());
             increaseQos0MessagesMemory(-publishWithRetained.getEstimatedSize());
-            increaseClientQos0MessagesMemory(messages, -publishWithRetained.getEstimatedSize()); // TODO set to 0 instead
+            // increaseClientQos0MessagesMemory not necessary as messages.qos0Memory = 0 below
             increaseMessagesMemory(-publishWithRetained.getEstimatedSize());
         }
+        messages.qos0Memory = 0;
     }
 
     /**

--- a/src/main/java/com/hivemq/persistence/util/AbstractFutureUtils.java
+++ b/src/main/java/com/hivemq/persistence/util/AbstractFutureUtils.java
@@ -38,13 +38,6 @@ public abstract class AbstractFutureUtils {
     private static final Logger log = LoggerFactory.getLogger(AbstractFutureUtils.class);
     private static final AnyToVoidFunction ANY_TO_VOID_FUNCTION = new AnyToVoidFunction();
 
-    public abstract @NotNull ListenableFuture<Void> voidFutureFromAnyFuture(@NotNull ListenableFuture<?> anyFuture);
-
-    public @NotNull ListenableFuture<Void> voidFutureFromAnyFuture(
-            final @NotNull ListenableFuture<?> anyFuture, final @NotNull Executor executor) {
-        return Futures.transform(anyFuture, ANY_TO_VOID_FUNCTION, executor);
-    }
-
     public @NotNull ListenableFuture<Void> mergeVoidFutures(
             final @NotNull ListenableFuture<Void> future1, final @NotNull ListenableFuture<Void> future2) {
         return voidFutureFromList(ImmutableList.of(future1, future2));

--- a/src/main/java/com/hivemq/persistence/util/FutureUtils.java
+++ b/src/main/java/com/hivemq/persistence/util/FutureUtils.java
@@ -33,10 +33,6 @@ public class FutureUtils {
     @Inject
     public static AbstractFutureUtils delegate;
 
-    public static @NotNull ListenableFuture<Void> voidFutureFromAnyFuture(final @NotNull ListenableFuture<?> anyFuture) {
-        return delegate.voidFutureFromAnyFuture(anyFuture);
-    }
-
     public static @NotNull ListenableFuture<Void> mergeVoidFutures(
             final @NotNull ListenableFuture<Void> future1, final @NotNull ListenableFuture<Void> future2) {
         return delegate.mergeVoidFutures(future1, future2);

--- a/src/main/java/com/hivemq/persistence/util/FutureUtilsImpl.java
+++ b/src/main/java/com/hivemq/persistence/util/FutureUtilsImpl.java
@@ -39,11 +39,6 @@ public class FutureUtilsImpl extends AbstractFutureUtils {
     }
 
     @Override
-    public @NotNull ListenableFuture<Void> voidFutureFromAnyFuture(final @NotNull ListenableFuture<?> anyFuture) {
-        return super.voidFutureFromAnyFuture(anyFuture, persistenceExecutorService);
-    }
-
-    @Override
     public <T> void addPersistenceCallback(
             final @NotNull ListenableFuture<T> future, final @NotNull FutureCallback<? super T> callback) {
         super.addPersistenceCallback(future, callback, persistenceExecutorService);

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3ConnackDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3ConnackDecoderTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 import util.TestMqttDecoder;
@@ -30,6 +31,7 @@ import util.TestMqttDecoder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@Ignore("A CONNACK is never decoded by HiveMQ")
 public class Mqtt3ConnackDecoderTest {
 
     private EmbeddedChannel embeddedChannel;
@@ -39,7 +41,7 @@ public class Mqtt3ConnackDecoderTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        embeddedChannel = new EmbeddedChannel(TestMqttDecoder.create(false));
+        embeddedChannel = new EmbeddedChannel(TestMqttDecoder.create());
         embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1_1);
 
     }

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3SubackDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3SubackDecoderTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 import util.TestMqttDecoder;
@@ -30,6 +31,7 @@ import util.TestMqttDecoder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+@Ignore("A SUBACK is never decoded by HiveMQ")
 public class Mqtt3SubackDecoderTest {
 
     private EmbeddedChannel embeddedChannel;
@@ -38,7 +40,7 @@ public class Mqtt3SubackDecoderTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        embeddedChannel = new EmbeddedChannel(TestMqttDecoder.create(false));
+        embeddedChannel = new EmbeddedChannel(TestMqttDecoder.create());
         embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1_1);
     }
 

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3UnsubackDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3UnsubackDecoderTest.java
@@ -22,12 +22,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 import util.TestMqttDecoder;
 
 import static org.junit.Assert.assertEquals;
 
+@Ignore("A UNSUBACK is never decoded by HiveMQ")
 public class Mqtt3UnsubackDecoderTest {
     private EmbeddedChannel embeddedChannel;
 
@@ -35,7 +37,7 @@ public class Mqtt3UnsubackDecoderTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        embeddedChannel = new EmbeddedChannel(TestMqttDecoder.create(false));
+        embeddedChannel = new EmbeddedChannel(TestMqttDecoder.create());
         embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv3_1_1);
     }
 

--- a/src/test/java/com/hivemq/codec/decoder/mqtt5/AbstractMqttDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt5/AbstractMqttDecoderTest.java
@@ -19,6 +19,7 @@ import com.hivemq.mqtt.handler.disconnect.MqttServerDisconnectorImpl;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.After;
 import org.junit.Before;
+import org.slf4j.LoggerFactory;
 import util.LogbackCapturingAppender;
 import util.TestMqttDecoder;
 
@@ -29,7 +30,7 @@ public class AbstractMqttDecoderTest {
 
     @Before
     public void setUp() {
-        logCapture = LogbackCapturingAppender.Factory.weaveInto(MqttServerDisconnectorImpl.log);
+        logCapture = LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(MqttServerDisconnectorImpl.class));
         createChannel();
     }
 

--- a/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5SubscribeDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5SubscribeDecoderTest.java
@@ -832,7 +832,7 @@ public class Mqtt5SubscribeDecoderTest extends AbstractMqtt5DecoderTest {
 
         final FullConfigurationService fullConfig = new TestConfigurationBootstrap().getFullConfigurationService();
         fullConfig.mqttConfiguration().setSubscriptionIdentifierEnabled(false);
-        channel = new EmbeddedChannel(TestMqttDecoder.create(false, fullConfig));
+        channel = new EmbeddedChannel(TestMqttDecoder.create(fullConfig));
         final byte[] encoded = {
                 // fixed header
                 //   type, reserved

--- a/src/test/java/com/hivemq/mqtt/handler/connack/MqttConnackerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connack/MqttConnackerTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
 import util.DummyHandler;
 import util.LogbackCapturingAppender;
 
@@ -63,7 +64,7 @@ public class MqttConnackerTest {
         mqttConnacker = new MqttConnackerImpl(eventLog);
         channel = new EmbeddedChannel();
         channel.pipeline().addLast(new DummyHandler());
-        logbackCapturingAppender = LogbackCapturingAppender.Factory.weaveInto(MqttConnackerImpl.log);
+        logbackCapturingAppender = LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(MqttConnackerImpl.class));
     }
 
     @After

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -1580,7 +1580,7 @@ public class ConnectHandlerTest {
     }
 
     private void buildPipeline() {
-        embeddedChannel.pipeline().addFirst(ChannelHandlerNames.MQTT_MESSAGE_DECODER, TestMqttDecoder.create(true));
+        embeddedChannel.pipeline().addFirst(ChannelHandlerNames.MQTT_MESSAGE_DECODER, TestMqttDecoder.create());
         embeddedChannel.pipeline().addLast(ChannelHandlerNames.GLOBAL_THROTTLING_HANDLER, new DummyHandler());
         embeddedChannel.attr(ChannelAttributes.CLIENT_ID).set("clientId");
         embeddedChannel.attr(ChannelAttributes.MQTT_VERSION).set(ProtocolVersion.MQTTv5);

--- a/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
@@ -246,6 +246,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
             pubrels[i] = new PUBREL(i + 1);
         }
         for (final PUBREL pubrel : pubrels) {
+            persistence.add("client1", false, createPublish(pubrel.getPacketIdentifier(), QoS.EXACTLY_ONCE, "topic"), 100L, DISCARD, false, 0);
             persistence.replace("client1", pubrel, 0);
         }
 
@@ -260,6 +261,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
             pubrels[i] = new PUBREL(i + 1);
         }
         for (final PUBREL pubrel : pubrels) {
+            persistence.add("client1", false, createPublish(pubrel.getPacketIdentifier(), QoS.EXACTLY_ONCE, "topic"), 100L, DISCARD, false, 0);
             persistence.replace("client1", pubrel, 0);
         }
         final PUBLISH[] publishes = new PUBLISH[4];

--- a/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
@@ -41,14 +41,11 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.hivemq.configuration.service.MqttConfigurationService.QueuedMessagesStrategy.DISCARD;
 import static com.hivemq.configuration.service.MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST;
-import static com.hivemq.persistence.clientqueue.ClientQueuePersistenceImpl.Key;
 import static com.hivemq.persistence.clientqueue.ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
@@ -831,7 +828,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
 
         final int size = new PublishWithRetained(publish1, false).getEstimatedSize() + ObjectMemoryEstimation.linkedListNodeOverhead() +
                 new PublishWithRetained(publish2, false).getEstimatedSize() + ObjectMemoryEstimation.linkedListNodeOverhead() +
-                new PublishWithRetained(publish3, false).getEstimatedSize() +  ObjectMemoryEstimation.linkedListNodeOverhead();
+                new PublishWithRetained(publish3, false).getEstimatedSize() + ObjectMemoryEstimation.linkedListNodeOverhead();
 
         assertEquals(size, gauge.getValue().longValue());
 
@@ -964,7 +961,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
         final ImmutableList.Builder<PUBLISH> publishes1 = ImmutableList.builder();
         final ImmutableList.Builder<PUBLISH> publishes2 = ImmutableList.builder();
         for (int i = 0; i < 10; i++) {
-            if(i < 5) {
+            if (i < 5) {
                 publishes1.add(createPublish(1, QoS.AT_LEAST_ONCE, "topic" + i));
             } else {
                 publishes2.add(createPublish(1, QoS.AT_LEAST_ONCE, "topic" + i));
@@ -1010,73 +1007,12 @@ public class ClientQueueMemoryLocalPersistenceTest {
     }
 
     @Test(timeout = 5000)
-    public void test_increase_negative_size() {
-
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), -10000);
-
-        final Map<String, AtomicInteger> clientQos0MemoryMap = persistence.getClientQos0MemoryMap();
-
-        assertNull(clientQos0MemoryMap.get("client"));
-
-    }
-
-    @Test(timeout = 5000)
-    public void test_increase_positive_size() {
-
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-
-        final Map<String, AtomicInteger> clientQos0MemoryMap = persistence.getClientQos0MemoryMap();
-
-        assertNotNull(clientQos0MemoryMap.get("client"));
-
-    }
-
-    @Test(timeout = 5000)
-    public void test_multiple_increases() {
-
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), -10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), -10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), -10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), -10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), -10000);
-
-        final Map<String, AtomicInteger> clientQos0MemoryMap = persistence.getClientQos0MemoryMap();
-
-        assertNull(clientQos0MemoryMap.get("client"));
-
-    }
-
-    @Test(timeout = 5000)
-    public void test_increase_decrease_increase_decrease_increase() {
-
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), -10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), -10000);
-        persistence.increaseClientQos0MessagesMemory(new Key("client", false), 10000);
-
-        final Map<String, AtomicInteger> clientQos0MemoryMap = persistence.getClientQos0MemoryMap();
-
-        assertNotNull(clientQos0MemoryMap.get("client"));
-
-    }
-
-    @Test(timeout = 5000)
     public void test_add_qos_0_per_client_exceeded() {
 
         persistence.add("client", false, createBigPublish(1, QoS.AT_MOST_ONCE, "topic", 1, 500), 1000, DISCARD, false, BucketUtils.getBucket("client", 4));
         persistence.add("client", false, createBigPublish(1, QoS.AT_MOST_ONCE, "topic", 1, 500), 1000, DISCARD, false, BucketUtils.getBucket("client", 4));
 
         verify(messageDroppedService).qos0MemoryExceeded(eq("client"), eq("topic"), eq(0), anyLong(), eq(1024L));
-
-        final Map<String, AtomicInteger> clientQos0MemoryMap = persistence.getClientQos0MemoryMap();
-
-        assertNotNull(clientQos0MemoryMap.get("client"));
 
         final Gauge<Long> gauge = metricRegistry.getGauges().get(HiveMQMetrics.QUEUED_MESSAGES_MEMORY_PERSISTENCE_TOTAL_SIZE.name());
         assertTrue(gauge.getValue() > 0);
@@ -1095,10 +1031,6 @@ public class ClientQueueMemoryLocalPersistenceTest {
         persistence.add("client", false, createPublish(2, QoS.AT_MOST_ONCE, "topic", 2), 1000, DISCARD, false, BucketUtils.getBucket("client", 4));
 
         verify(messageDroppedService).qos0MemoryExceeded(eq("client"), eq("topic"), eq(0), anyLong(), eq(1024L));
-
-        final Map<String, AtomicInteger> clientQos0MemoryMap = persistence.getClientQos0MemoryMap();
-
-        assertNotNull(clientQos0MemoryMap.get("client"));
 
         final Gauge<Long> gauge = metricRegistry.getGauges().get(HiveMQMetrics.QUEUED_MESSAGES_MEMORY_PERSISTENCE_TOTAL_SIZE.name());
         assertTrue(gauge.getValue() > 0);
@@ -1148,7 +1080,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
         assertTrue(gauge.getValue() > 0);
 
         int byteLimit = totalPublishBytes / 2;
-        final ImmutableList<PUBLISH> allReadPublishes = persistence.readNew("client", false, createPacketIds(1,100), byteLimit, 0);
+        final ImmutableList<PUBLISH> allReadPublishes = persistence.readNew("client", false, createPacketIds(1, 100), byteLimit, 0);
         assertEquals(51, allReadPublishes.size());
 
         final ImmutableList<PUBLISH> allReadPublishes2 = persistence.readNew("client", false, createPacketIds(52, 100), byteLimit, 0);
@@ -1182,10 +1114,10 @@ public class ClientQueueMemoryLocalPersistenceTest {
 
         int byteLimit = totalPublishBytes / 2;
         System.out.println(byteLimit);
-        final ImmutableList<PUBLISH> allReadPublishes = persistence.readNew("client", false, createPacketIds(1,100), byteLimit, 0);
+        final ImmutableList<PUBLISH> allReadPublishes = persistence.readNew("client", false, createPacketIds(1, 100), byteLimit, 0);
         assertEquals(51, allReadPublishes.size());
 
-        final ImmutableList<PUBLISH> allReadPublishes2 = persistence.readNew("client", false, createPacketIds(52,100), byteLimit, 0);
+        final ImmutableList<PUBLISH> allReadPublishes2 = persistence.readNew("client", false, createPacketIds(52, 100), byteLimit, 0);
         assertEquals(49, allReadPublishes2.size());
 
         assertTrue(gauge.getValue() > 0);
@@ -1224,14 +1156,14 @@ public class ClientQueueMemoryLocalPersistenceTest {
         assertTrue(gauge.getValue() > 0);
 
         int byteLimit = totalPublishBytes / 2;
-        final ImmutableList<PUBLISH> allReadPublishes = persistence.readNew("client", false, createPacketIds(1,100), byteLimit, 0);
+        final ImmutableList<PUBLISH> allReadPublishes = persistence.readNew("client", false, createPacketIds(1, 100), byteLimit, 0);
         assertEquals(51, allReadPublishes.size());
 
         for (final PUBLISH pub : allReadPublishes) {
             persistence.remove("client", pub.getPacketIdentifier(), pub.getUniqueId(), 0);
         }
 
-        final ImmutableList<PUBLISH> allReadPublishes2 = persistence.readNew("client", false, createPacketIds(52,100), byteLimit, 0);
+        final ImmutableList<PUBLISH> allReadPublishes2 = persistence.readNew("client", false, createPacketIds(52, 100), byteLimit, 0);
         assertEquals(48, allReadPublishes2.size());
         assertTrue(gauge.getValue() > 0);
 
@@ -1240,7 +1172,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
         }
 
         //last qos0 message
-        final ImmutableList<PUBLISH> allReadPublishes3 = persistence.readNew("client", false, createPacketIds(100,100), byteLimit, 0);
+        final ImmutableList<PUBLISH> allReadPublishes3 = persistence.readNew("client", false, createPacketIds(100, 100), byteLimit, 0);
         assertEquals(1, allReadPublishes3.size());
         assertEquals(0, gauge.getValue().longValue());
 

--- a/src/test/java/com/hivemq/persistence/util/FutureUtilsTest.java
+++ b/src/test/java/com/hivemq/persistence/util/FutureUtilsTest.java
@@ -22,14 +22,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import util.InitFutureUtilsExecutorRule;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Lukas Brandl
@@ -38,28 +35,6 @@ public class FutureUtilsTest {
 
     @Rule
     public InitFutureUtilsExecutorRule initFutureUtilsExecutorRule = new InitFutureUtilsExecutorRule();
-
-    @Test
-    public void test_void_future_from_any_future_success() throws Exception {
-        final SettableFuture<Object> future = SettableFuture.create();
-
-        final ListenableFuture<Void> voidFuture = FutureUtils.voidFutureFromAnyFuture(future);
-        assertEquals(false, voidFuture.isDone());
-        future.set(new Object());
-        assertEquals(true, voidFuture.isDone());
-        voidFuture.get();
-    }
-
-    @Test(expected = ExecutionException.class)
-    public void test_void_future_from_any_future_failure() throws Exception {
-        final SettableFuture<Object> future = SettableFuture.create();
-
-        final ListenableFuture<Void> voidFuture = FutureUtils.voidFutureFromAnyFuture(future);
-        assertEquals(false, voidFuture.isDone());
-        future.setException(new RuntimeException());
-        assertEquals(true, voidFuture.isDone());
-        voidFuture.get();
-    }
 
     @Test
     public void test_future_merge() throws Exception {

--- a/src/test/java/util/TestMqttDecoder.java
+++ b/src/test/java/util/TestMqttDecoder.java
@@ -43,22 +43,14 @@ import static com.hivemq.mqtt.message.publish.PUBLISH.MESSAGE_EXPIRY_INTERVAL_MA
 public class TestMqttDecoder {
 
     public static MQTTMessageDecoder create() {
-        return create(true);
-    }
-
-    public static MQTTMessageDecoder create(final boolean strict) {
         final FullConfigurationService fullConfig = new TestConfigurationBootstrap().getFullConfigurationService();
         fullConfig.securityConfiguration().setValidateUTF8(true);
         fullConfig.mqttConfiguration().setMaxSessionExpiryInterval(SESSION_EXPIRY_MAX);
         fullConfig.mqttConfiguration().setMaxMessageExpiryInterval(MESSAGE_EXPIRY_INTERVAL_MAX);
-        return create(strict, fullConfig);
+        return create(fullConfig);
     }
 
-    public static MQTTMessageDecoder create(final FullConfigurationService fullMqttConfigurationService) {
-        return create(true, fullMqttConfigurationService);
-    }
-
-    public static MQTTMessageDecoder create(final boolean strict, final FullConfigurationService fullConfigurationService) {
+    public static MQTTMessageDecoder create(final FullConfigurationService fullConfigurationService) {
 
         final EventLog eventLog = new EventLog();
         final HivemqId hiveMQId = new HivemqId();
@@ -73,7 +65,6 @@ public class TestMqttDecoder {
 
         return new MQTTMessageDecoder(
                 mqttConnectDecoder,
-                strict,
                 fullConfigurationService.mqttConfiguration(),
                 new MqttDecoders(new Mqtt3ConnackDecoder(eventLog),
                         new Mqtt3PublishDecoder(hiveMQId, disconnector, fullConfigurationService),


### PR DESCRIPTION
**Motivation**

Small performance improvements from the performance-improvement branch that are ready to be merged

**Changes**
- Refactored ClientQueueMemoryLocalPersistence (biggest change)
- Improved efficiency of iteration over ImmutableList in PUBLISH
- Removed copy (multiple times) of default permissions for each publish
- Use array instead of map in MqttDecoders
- Removed FutureUtils.voidFutureFromAnyFuture (cleanup)