### PR TITLE
Id 1893 noop memory payload persistence

### DIFF
--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -21,7 +21,10 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.hivemq.configuration.service.ConfigurationService;
+import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.MqttConfigurationService;
+import com.hivemq.configuration.service.PersistenceConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.mqtt.handler.publish.PublishStatus;
@@ -62,18 +65,22 @@ public class PublishDistributorImpl implements PublishDistributor {
     private final SingleWriterService singleWriterService;
     @NotNull
     private final MqttConfigurationService mqttConfigurationService;
+    @NotNull
+    final boolean persistenceInMemory;
 
     @Inject
     public PublishDistributorImpl(@NotNull final PublishPayloadPersistence payloadPersistence,
                                   @NotNull final ClientQueuePersistence clientQueuePersistence,
                                   @NotNull final ClientSessionPersistence clientSessionPersistence,
                                   @NotNull final SingleWriterService singleWriterService,
-                                  @NotNull final MqttConfigurationService mqttConfigurationService) {
+                                  @NotNull final MqttConfigurationService mqttConfigurationService,
+                                  @NotNull final FullConfigurationService configurationService) {
         this.payloadPersistence = payloadPersistence;
         this.clientQueuePersistence = clientQueuePersistence;
         this.clientSessionPersistence = clientSessionPersistence;
         this.singleWriterService = singleWriterService;
         this.mqttConfigurationService = mqttConfigurationService;
+        this.persistenceInMemory = configurationService.persistenceConfigurationService().getMode() == PersistenceConfigurationService.PersistenceMode.IN_MEMORY;
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -192,7 +192,7 @@ public class PublishDistributorImpl implements PublishDistributor {
                 .fromPublish(publish)
                 //in file: not needed the payload anymore as we just put it in the payload persistence.
                 //in-memory: we must set the payload, as the payload persistence is NOOP
-                .withPayload(removePayload?null:publish.getPayload())
+                .withPayload(removePayload ? null : publish.getPayload())
                 .withPersistence(payloadPersistence)
                 .withRetain(publish.isRetain() && retainAsPublished)
                 .withSubscriptionIdentifiers(identifiers);

--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -190,7 +190,7 @@ public class PublishDistributorImpl implements PublishDistributor {
 
         final PUBLISHFactory.Mqtt5Builder builder = new PUBLISHFactory.Mqtt5Builder()
                 .fromPublish(publish)
-                //in file: not needed the payload anymore as we just put it in the payload persistence.
+                //in file: the payload is not needed anymore as we just put it in the payload persistence.
                 //in-memory: we must set the payload, as the payload persistence is NOOP
                 .withPayload(removePayload ? null : publish.getPayload())
                 .withPersistence(payloadPersistence)

--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -65,22 +65,18 @@ public class PublishDistributorImpl implements PublishDistributor {
     private final SingleWriterService singleWriterService;
     @NotNull
     private final MqttConfigurationService mqttConfigurationService;
-    @NotNull
-    final boolean persistenceInMemory;
 
     @Inject
     public PublishDistributorImpl(@NotNull final PublishPayloadPersistence payloadPersistence,
                                   @NotNull final ClientQueuePersistence clientQueuePersistence,
                                   @NotNull final ClientSessionPersistence clientSessionPersistence,
                                   @NotNull final SingleWriterService singleWriterService,
-                                  @NotNull final MqttConfigurationService mqttConfigurationService,
-                                  @NotNull final FullConfigurationService configurationService) {
+                                  @NotNull final MqttConfigurationService mqttConfigurationService) {
         this.payloadPersistence = payloadPersistence;
         this.clientQueuePersistence = clientQueuePersistence;
         this.clientSessionPersistence = clientSessionPersistence;
         this.singleWriterService = singleWriterService;
         this.mqttConfigurationService = mqttConfigurationService;
-        this.persistenceInMemory = configurationService.persistenceConfigurationService().getMode() == PersistenceConfigurationService.PersistenceMode.IN_MEMORY;
     }
 
     @NotNull
@@ -184,7 +180,7 @@ public class PublishDistributorImpl implements PublishDistributor {
 
     @NotNull
     private PUBLISH createPublish(@NotNull final PUBLISH publish, final int subscriptionQos, final boolean retainAsPublished, @Nullable final ImmutableIntArray subscriptionIdentifier) {
-        payloadPersistence.add(publish.getPayload(), 1, publish.getPublishId());
+        final boolean removePayload = payloadPersistence.add(publish.getPayload(), 1, publish.getPublishId());
         final ImmutableIntArray identifiers;
         if (subscriptionIdentifier == null) {
             identifiers = ImmutableIntArray.of();
@@ -196,7 +192,7 @@ public class PublishDistributorImpl implements PublishDistributor {
                 .fromPublish(publish)
                 //in file: not needed the payload anymore as we just put it in the payload persistence.
                 //in-memory: we must set the payload, as the payload persistence is NOOP
-                .withPayload(persistenceInMemory?publish.getPayload():null)
+                .withPayload(removePayload?null:publish.getPayload())
                 .withPersistence(payloadPersistence)
                 .withRetain(publish.isRetain() && retainAsPublished)
                 .withSubscriptionIdentifiers(identifiers);

--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -194,7 +194,9 @@ public class PublishDistributorImpl implements PublishDistributor {
 
         final PUBLISHFactory.Mqtt5Builder builder = new PUBLISHFactory.Mqtt5Builder()
                 .fromPublish(publish)
-                .withPayload(null) // not needed anymore as we just put it in the payload persistence.
+                //in file: not needed the payload anymore as we just put it in the payload persistence.
+                //in-memory: we must set the payload, as the payload persistence is NOOP
+                .withPayload(persistenceInMemory?publish.getPayload():null)
                 .withPersistence(payloadPersistence)
                 .withRetain(publish.isRetain() && retainAsPublished)
                 .withSubscriptionIdentifiers(identifiers);

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -166,8 +166,10 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         ClientSessionWill sessionWill = null;
         if (willPublish != null) {
             final long publishId = PublishPayloadPersistenceImpl.createId();
-            publishPayloadPersistence.add(willPublish.getPayload(), 1, publishId);
-            willPublish.setPayload(null);
+            final boolean removePayload = publishPayloadPersistence.add(willPublish.getPayload(), 1, publishId);
+            if(removePayload){
+                willPublish.setPayload(null);
+            }
             sessionWill = new ClientSessionWill(willPublish, publishId);
         }
         final ClientSession clientSession = new ClientSession(true, clientSessionExpiryInterval, sessionWill, queueLimit);

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -167,7 +167,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
         if (willPublish != null) {
             final long publishId = PublishPayloadPersistenceImpl.createId();
             final boolean removePayload = publishPayloadPersistence.add(willPublish.getPayload(), 1, publishId);
-            if(removePayload){
+            if (removePayload) {
                 willPublish.setPayload(null);
             }
             sessionWill = new ClientSessionWill(willPublish, publishId);

--- a/src/main/java/com/hivemq/persistence/ioc/LocalPersistenceModule.java
+++ b/src/main/java/com/hivemq/persistence/ioc/LocalPersistenceModule.java
@@ -95,8 +95,6 @@ class LocalPersistenceModule extends SingletonModule<Class<LocalPersistenceModul
         /* Payload Persistence */
         if (persistenceConfigurationService.getMode() == PersistenceConfigurationService.PersistenceMode.IN_MEMORY) {
             bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadNoopPersistenceImpl.class));
-            bind(PublishPayloadNoopPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
-                    PublishPayloadNoopPersistenceImpl.class));
         } else {
             bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadPersistence.class));
             bind(PublishPayloadPersistenceImpl.class).toInstance(persistenceInjector.getInstance(

--- a/src/main/java/com/hivemq/persistence/ioc/LocalPersistenceModule.java
+++ b/src/main/java/com/hivemq/persistence/ioc/LocalPersistenceModule.java
@@ -93,11 +93,11 @@ class LocalPersistenceModule extends SingletonModule<Class<LocalPersistenceModul
         bind(ClientQueuePersistence.class).to(ClientQueuePersistenceImpl.class).in(LazySingleton.class);
 
         /* Payload Persistence */
-        if(persistenceConfigurationService.getMode()==PersistenceConfigurationService.PersistenceMode.IN_MEMORY){
+        if (persistenceConfigurationService.getMode() == PersistenceConfigurationService.PersistenceMode.IN_MEMORY) {
             bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadNoopPersistenceImpl.class));
             bind(PublishPayloadNoopPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
                     PublishPayloadNoopPersistenceImpl.class));
-        }else{
+        } else {
             bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadPersistence.class));
             bind(PublishPayloadPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
                     PublishPayloadPersistenceImpl.class));

--- a/src/main/java/com/hivemq/persistence/ioc/LocalPersistenceModule.java
+++ b/src/main/java/com/hivemq/persistence/ioc/LocalPersistenceModule.java
@@ -20,7 +20,6 @@ import com.hivemq.bootstrap.ioc.SingletonModule;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.configuration.service.PersistenceConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.mqtt.topic.tree.TopicTreeImpl;
 import com.hivemq.persistence.ChannelPersistence;
@@ -31,7 +30,6 @@ import com.hivemq.persistence.clientqueue.ClientQueuePersistenceImpl;
 import com.hivemq.persistence.clientsession.*;
 import com.hivemq.persistence.ioc.provider.local.IncomingMessageFlowPersistenceLocalProvider;
 import com.hivemq.persistence.local.IncomingMessageFlowLocalPersistence;
-import com.hivemq.persistence.payload.PublishPayloadNoopPersistenceImpl;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.persistence.payload.PublishPayloadPersistenceImpl;
 import com.hivemq.persistence.qos.IncomingMessageFlowPersistence;
@@ -94,36 +92,11 @@ class LocalPersistenceModule extends SingletonModule<Class<LocalPersistenceModul
         bind(ClientQueuePersistence.class).to(ClientQueuePersistenceImpl.class).in(LazySingleton.class);
 
         /* Payload Persistence */
-        if(persistenceConfigurationService.getMode()==PersistenceConfigurationService.PersistenceMode.IN_MEMORY){
-            bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadNoopPersistenceImpl.class));
-            bind(PublishPayloadNoopPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
-                    PublishPayloadNoopPersistenceImpl.class));
-        }else{
-            bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadPersistence.class));
-            bind(PublishPayloadPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
-                    PublishPayloadPersistenceImpl.class));
-        }
+        bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadPersistence.class));
+        bind(PublishPayloadPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
+                PublishPayloadPersistenceImpl.class));
 
         /* Startup */
         bind(PersistenceStartup.class).toInstance(persistenceInjector.getInstance(PersistenceStartup.class));
-
-    }
-
-    private void bindLocalPersistence(
-            final @NotNull Class localPersistenceClass,
-            final @NotNull Class localPersistenceImplClass,
-            final @Nullable Class localPersistenceProviderClass) {
-
-        final Object instance = persistenceInjector.getInstance(localPersistenceImplClass);
-        if (instance != null) {
-            bind(localPersistenceImplClass).toInstance(instance);
-            bind(localPersistenceClass).toInstance(instance);
-        } else {
-            if (localPersistenceProviderClass != null) {
-                bind(localPersistenceClass).toProvider(localPersistenceProviderClass).in(Singleton.class);
-            } else {
-                bind(localPersistenceClass).to(localPersistenceImplClass).in(Singleton.class);
-            }
-        }
     }
 }

--- a/src/main/java/com/hivemq/persistence/ioc/LocalPersistenceModule.java
+++ b/src/main/java/com/hivemq/persistence/ioc/LocalPersistenceModule.java
@@ -30,6 +30,7 @@ import com.hivemq.persistence.clientqueue.ClientQueuePersistenceImpl;
 import com.hivemq.persistence.clientsession.*;
 import com.hivemq.persistence.ioc.provider.local.IncomingMessageFlowPersistenceLocalProvider;
 import com.hivemq.persistence.local.IncomingMessageFlowLocalPersistence;
+import com.hivemq.persistence.payload.PublishPayloadNoopPersistenceImpl;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.persistence.payload.PublishPayloadPersistenceImpl;
 import com.hivemq.persistence.qos.IncomingMessageFlowPersistence;
@@ -92,9 +93,15 @@ class LocalPersistenceModule extends SingletonModule<Class<LocalPersistenceModul
         bind(ClientQueuePersistence.class).to(ClientQueuePersistenceImpl.class).in(LazySingleton.class);
 
         /* Payload Persistence */
-        bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadPersistence.class));
-        bind(PublishPayloadPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
-                PublishPayloadPersistenceImpl.class));
+        if(persistenceConfigurationService.getMode()==PersistenceConfigurationService.PersistenceMode.IN_MEMORY){
+            bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadNoopPersistenceImpl.class));
+            bind(PublishPayloadNoopPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
+                    PublishPayloadNoopPersistenceImpl.class));
+        }else{
+            bind(PublishPayloadPersistence.class).toInstance(persistenceInjector.getInstance(PublishPayloadPersistence.class));
+            bind(PublishPayloadPersistenceImpl.class).toInstance(persistenceInjector.getInstance(
+                    PublishPayloadPersistenceImpl.class));
+        }
 
         /* Startup */
         bind(PersistenceStartup.class).toInstance(persistenceInjector.getInstance(PersistenceStartup.class));

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
@@ -98,14 +98,6 @@ public class PublishPayloadNoopPersistenceImpl implements PublishPayloadPersiste
         //NOOP
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @NotNull
-    public List<Long> getAllIds() {
-        throw new UnsupportedOperationException("getAllIds iys not supported for in-memory persistence");
-    }
 
     @Override
     public void closeDB() {

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.persistence.payload;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.inject.Inject;
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
+import com.hivemq.configuration.service.InternalConfigurations;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
+import com.hivemq.mqtt.message.publish.PUBLISH;
+import com.hivemq.persistence.ioc.annotation.PayloadPersistence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Daniel Krüger
+ */
+@LazySingleton
+public class PublishPayloadNoopPersistenceImpl implements PublishPayloadPersistence {
+
+    @VisibleForTesting
+    static final Logger log = LoggerFactory.getLogger(PublishPayloadNoopPersistenceImpl.class);
+
+    @Inject
+    public PublishPayloadNoopPersistenceImpl() {
+    }
+
+    @Override
+    public void init() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void add(@NotNull final byte[] payload, final long referenceCount, final long payloadId) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte @NotNull [] get(final long id) {
+        throw new UnsupportedOperationException("With in-memory payloads must not be gotten.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    //this method is allowed to return null
+    @Override
+    public byte @Nullable [] getPayloadOrNull(final long id) {
+        throw new UnsupportedOperationException("With in-memory payloads must not be gotten.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void incrementReferenceCounterOnBootstrap(final long payloadId) {
+        //NOOP
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void decrementReferenceCounter(final long id) {
+        //NOOP
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NotNull
+    public List<Long> getAllIds() {
+        throw new UnsupportedOperationException("getAllIds iys not supported for in-memory persistence");
+    }
+
+    @Override
+    public void closeDB() {
+        //NOOP
+    }
+
+    @NotNull
+    @Override
+    @VisibleForTesting
+    public ImmutableMap<Long, AtomicLong> getReferenceCountersAsMap() {
+        throw new UnsupportedOperationException("getAllIds iys not supported for in-memory persistence");
+    }
+
+
+    public static long createId() {
+        return PUBLISH.PUBLISH_COUNTER.getAndIncrement();
+    }
+
+    @FunctionalInterface
+    private interface BucketAccessCallback {
+        void call();
+    }
+}

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
@@ -116,8 +116,4 @@ public class PublishPayloadNoopPersistenceImpl implements PublishPayloadPersiste
         return PUBLISH.PUBLISH_COUNTER.getAndIncrement();
     }
 
-    @FunctionalInterface
-    private interface BucketAccessCallback {
-        void call();
-    }
 }

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
@@ -21,8 +21,6 @@ import com.google.inject.Inject;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -31,9 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 @LazySingleton
 public class PublishPayloadNoopPersistenceImpl implements PublishPayloadPersistence {
-
-    @VisibleForTesting
-    static final Logger log = LoggerFactory.getLogger(PublishPayloadNoopPersistenceImpl.class);
 
     @Inject
     public PublishPayloadNoopPersistenceImpl() {

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
@@ -47,7 +47,8 @@ public class PublishPayloadNoopPersistenceImpl implements PublishPayloadPersiste
      * {@inheritDoc}
      */
     @Override
-    public void add(@NotNull final byte[] payload, final long referenceCount, final long payloadId) {
+    public boolean add(@NotNull final byte[] payload, final long referenceCount, final long payloadId) {
+        return false;
     }
 
     /**

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadNoopPersistenceImpl.java
@@ -16,30 +16,15 @@
 package com.hivemq.persistence.payload;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.ListenableScheduledFuture;
-import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.inject.Inject;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
-import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
-import com.hivemq.mqtt.message.publish.PUBLISH;
-import com.hivemq.persistence.ioc.annotation.PayloadPersistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedTransferQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Lock;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Daniel Krüger
@@ -109,11 +94,6 @@ public class PublishPayloadNoopPersistenceImpl implements PublishPayloadPersiste
     @VisibleForTesting
     public ImmutableMap<Long, AtomicLong> getReferenceCountersAsMap() {
         throw new UnsupportedOperationException("getAllIds iys not supported for in-memory persistence");
-    }
-
-
-    public static long createId() {
-        return PUBLISH.PUBLISH_COUNTER.getAndIncrement();
     }
 
 }

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistence.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistence.java
@@ -82,14 +82,6 @@ public interface PublishPayloadPersistence {
     void decrementReferenceCounter(long id);
 
     /**
-     * Returns the IDs of all payloads that currently exist in the persistence.
-     *
-     * @return A List off all IDs.
-     */
-    @NotNull
-    List<Long> getAllIds();
-
-    /**
      * close the persistence with all buckets.
      */
     void closeDB();

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistence.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistence.java
@@ -40,9 +40,9 @@ public interface PublishPayloadPersistence {
      * @param payload        The payload that will be persisted.
      * @param referenceCount The initial amount of references for the payload.
      * @param payloadId      The publish ID is used a the payload ID
-     * @return The id associated with the payload.
+     * @return true: payload may be removed from the publish, false: dont remove the payload
      */
-    void add(@NotNull byte[] payload, long referenceCount, long payloadId);
+    boolean add(@NotNull byte[] payload, long referenceCount, long payloadId);
 
     /**
      * Get the persisted payload for an id.

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImpl.java
@@ -215,14 +215,6 @@ public class PublishPayloadPersistenceImpl implements PublishPayloadPersistence 
 
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @NotNull
-    public List<Long> getAllIds() {
-        return localPersistence.getAllIds();
-    }
 
     @Override
     public void closeDB() {

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImpl.java
@@ -103,7 +103,7 @@ public class PublishPayloadPersistenceImpl implements PublishPayloadPersistence 
      * {@inheritDoc}
      */
     @Override
-    public void add(@NotNull final byte[] payload, final long referenceCount, final long payloadId) {
+    public boolean add(@NotNull final byte[] payload, final long referenceCount, final long payloadId) {
         checkNotNull(payload, "Payload must not be null");
         accessBucket(payloadId, () -> {
             final AtomicLong counter = referenceCounter.get(payloadId);
@@ -119,6 +119,7 @@ public class PublishPayloadPersistenceImpl implements PublishPayloadPersistence 
                 localPersistence.put(payloadId, payload);
             }
         });
+        return true;
     }
 
     /**

--- a/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
@@ -18,7 +18,9 @@ package com.hivemq.mqtt.services;
 import com.google.common.primitives.ImmutableIntArray;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.MqttConfigurationService;
+import com.hivemq.configuration.service.PersistenceConfigurationService;
 import com.hivemq.mqtt.handler.publish.PublishStatus;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
@@ -66,6 +68,11 @@ public class PublishDistributorImplTest {
     private ClientSessionPersistence clientSessionPersistence;
     @Mock
     private MqttConfigurationService mqttConfigurationService;
+    @Mock
+    private FullConfigurationService fullConfigurationService;
+
+    @Mock
+    private PersistenceConfigurationService persistenceConfigurationService;
 
     private PublishDistributorImpl publishDistributor;
     private SingleWriterService singleWriterService;
@@ -74,8 +81,10 @@ public class PublishDistributorImplTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         singleWriterService = TestSingleWriterFactory.defaultSingleWriter();
+        when(fullConfigurationService.persistenceConfigurationService()).thenReturn(persistenceConfigurationService);
+        when(persistenceConfigurationService.getMode()).thenReturn(PersistenceConfigurationService.PersistenceMode.IN_MEMORY);
         publishDistributor = new PublishDistributorImpl(payloadPersistence, clientQueuePersistence, clientSessionPersistence,
-                singleWriterService, mqttConfigurationService);
+                singleWriterService, mqttConfigurationService,fullConfigurationService );
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
@@ -84,7 +84,7 @@ public class PublishDistributorImplTest {
         when(fullConfigurationService.persistenceConfigurationService()).thenReturn(persistenceConfigurationService);
         when(persistenceConfigurationService.getMode()).thenReturn(PersistenceConfigurationService.PersistenceMode.IN_MEMORY);
         publishDistributor = new PublishDistributorImpl(payloadPersistence, clientQueuePersistence, clientSessionPersistence,
-                singleWriterService, mqttConfigurationService,fullConfigurationService );
+                singleWriterService, mqttConfigurationService);
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.MqttConfigurationService;
 import com.hivemq.configuration.service.PersistenceConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.mqtt.handler.publish.PublishStatus;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
@@ -58,31 +59,27 @@ import static org.mockito.Mockito.when;
 public class PublishDistributorImplTest {
 
     @Rule
-    public InitFutureUtilsExecutorRule initFutureUtilsExecutorRule = new InitFutureUtilsExecutorRule();
+    public @NotNull InitFutureUtilsExecutorRule initFutureUtilsExecutorRule = new InitFutureUtilsExecutorRule();
 
     @Mock
-    private PublishPayloadPersistence payloadPersistence;
+    private @NotNull PublishPayloadPersistence payloadPersistence;
     @Mock
-    private ClientQueuePersistence clientQueuePersistence;
+    private @NotNull ClientQueuePersistence clientQueuePersistence;
     @Mock
-    private ClientSessionPersistence clientSessionPersistence;
+    private @NotNull ClientSessionPersistence clientSessionPersistence;
     @Mock
-    private MqttConfigurationService mqttConfigurationService;
-    @Mock
-    private FullConfigurationService fullConfigurationService;
+    private @NotNull MqttConfigurationService mqttConfigurationService;
 
-    @Mock
-    private PersistenceConfigurationService persistenceConfigurationService;
+    private @NotNull PublishDistributorImpl publishDistributor;
+    private @NotNull SingleWriterService singleWriterService;
 
-    private PublishDistributorImpl publishDistributor;
-    private SingleWriterService singleWriterService;
+    public PublishDistributorImplTest() {
+    }
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         singleWriterService = TestSingleWriterFactory.defaultSingleWriter();
-        when(fullConfigurationService.persistenceConfigurationService()).thenReturn(persistenceConfigurationService);
-        when(persistenceConfigurationService.getMode()).thenReturn(PersistenceConfigurationService.PersistenceMode.IN_MEMORY);
         publishDistributor = new PublishDistributorImpl(payloadPersistence, clientQueuePersistence, clientSessionPersistence,
                 singleWriterService, mqttConfigurationService);
     }
@@ -177,18 +174,13 @@ public class PublishDistributorImplTest {
         verify(clientQueuePersistence).add(eq("name/topic2"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong());
     }
 
-    private PUBLISH createPublish(final QoS qos) {
+    private PUBLISH createPublish(final @NotNull QoS qos) {
         return new PUBLISHFactory.Mqtt5Builder().withPacketIdentifier(0)
                 .withQoS(qos)
                 .withPayload("message".getBytes())
                 .withTopic("topic")
                 .withHivemqId("hivemqId")
                 .build();
-    }
-
-    private void waitForSingleWriter() {
-        while (singleWriterService.getGlobalTaskCount().get() != 0) {
-        }
     }
 
 }

--- a/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
@@ -73,9 +73,6 @@ public class PublishDistributorImplTest {
     private @NotNull PublishDistributorImpl publishDistributor;
     private @NotNull SingleWriterService singleWriterService;
 
-    public PublishDistributorImplTest() {
-    }
-
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);

--- a/src/test/java/com/hivemq/persistence/ioc/LocalPersistenceModuleTest.java
+++ b/src/test/java/com/hivemq/persistence/ioc/LocalPersistenceModuleTest.java
@@ -24,6 +24,7 @@ import com.google.inject.Injector;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingletonModule;
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.service.*;
+import com.hivemq.configuration.service.impl.PersistenceConfigurationServiceImpl;
 import com.hivemq.configuration.service.impl.RestrictionsConfigurationServiceImpl;
 import com.hivemq.logging.EventLog;
 import com.hivemq.metrics.MetricsHolder;
@@ -130,8 +131,10 @@ public class LocalPersistenceModuleTest {
         when(persistenceInjector.getInstance(PublishPayloadXodusLocalPersistence.class)).thenReturn(mock(
                 PublishPayloadXodusLocalPersistence.class));
 
-        when(persistenceInjector.getInstance(PersistenceStartup.class)).thenReturn(Mockito.mock(PersistenceStartup.class));
+        when(persistenceInjector.getInstance(PublishPayloadNoopPersistenceImpl.class)).thenReturn(new PublishPayloadNoopPersistenceImpl());
 
+        when(persistenceInjector.getInstance(PersistenceStartup.class)).thenReturn(Mockito.mock(PersistenceStartup.class));
+        when(persistenceInjector.getInstance(PersistenceConfigurationService.class)).thenReturn(persistenceConfigurationService);
         when(persistenceConfigurationService.getMode()).thenReturn(PersistenceMode.FILE);
 
     }

--- a/src/test/java/com/hivemq/persistence/local/memory/RetainedMessageMemoryLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/memory/RetainedMessageMemoryLocalPersistenceTest.java
@@ -26,68 +26,35 @@ import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 import com.hivemq.persistence.RetainedMessage;
 import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
-import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 /**
  * @author Lukas Brandl
  */
 public class RetainedMessageMemoryLocalPersistenceTest {
 
-    @Mock
-    private PublishPayloadPersistence payloadPersistence;
-
-    private RetainedMessageMemoryLocalPersistence persistence;
+    private @NotNull RetainedMessageMemoryLocalPersistence persistence;
 
     private final int bucketCount = InternalConfigurations.PERSISTENCE_BUCKET_COUNT.get();
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
-
-        when(payloadPersistence.getPayloadOrNull(0)).thenReturn("message0".getBytes());
-        when(payloadPersistence.get(0)).thenReturn("message0".getBytes());
-        when(payloadPersistence.getPayloadOrNull(1)).thenReturn("message1".getBytes());
-        when(payloadPersistence.get(1)).thenReturn("message1".getBytes());
-        when(payloadPersistence.getPayloadOrNull(2)).thenReturn("message2".getBytes());
-        when(payloadPersistence.get(2)).thenReturn("message2".getBytes());
-        when(payloadPersistence.getPayloadOrNull(3)).thenReturn("message3".getBytes());
-        when(payloadPersistence.get(3)).thenReturn("message3".getBytes());
-        when(payloadPersistence.getPayloadOrNull(4)).thenReturn("message4".getBytes());
-        when(payloadPersistence.get(4)).thenReturn("message4".getBytes());
-
-        persistence = new RetainedMessageMemoryLocalPersistence(payloadPersistence, new MetricRegistry());
-    }
-
-    @Test
-    public void test_persist_get_no_payload_found() {
-
-        persistence.put(new RetainedMessage(new byte[]{1, 2, 3},
-                        QoS.AT_MOST_ONCE,
-                        100L,
-                        MqttConfigurationDefaults.TTL_DISABLED),
-                "topic/0",
-                BucketUtils.getBucket("topic/0", bucketCount));
-
-        assertNull(persistence.get("topic/0", BucketUtils.getBucket("topic/0", bucketCount)));
+        persistence = new RetainedMessageMemoryLocalPersistence(new MetricRegistry());
     }
 
     @Test
     public void test_persist_same_topic() {
-        persistence.put(new RetainedMessage(new byte[]{1, 2, 3}, QoS.AT_MOST_ONCE, 0L, MqttConfigurationDefaults.TTL_DISABLED),
+        persistence.put(new RetainedMessage("message1".getBytes(), QoS.AT_MOST_ONCE, 0L, MqttConfigurationDefaults.TTL_DISABLED),
                 "topic",
                 BucketUtils.getBucket("topic", bucketCount));
         final long firstMessageSize = persistence.currentMemorySize.get();
-        persistence.put(new RetainedMessage(new byte[]{1, 2, 3}, QoS.AT_MOST_ONCE, 0L, MqttConfigurationDefaults.TTL_DISABLED),
+        persistence.put(new RetainedMessage("message2".getBytes(), QoS.AT_MOST_ONCE, 0L, MqttConfigurationDefaults.TTL_DISABLED),
                 "topic",
                 BucketUtils.getBucket("topic", bucketCount));
         final long secondMessageSize = persistence.currentMemorySize.get();
@@ -95,17 +62,17 @@ public class RetainedMessageMemoryLocalPersistenceTest {
         assertEquals(firstMessageSize, secondMessageSize);
 
         //existing entry has newer timestamp, so we expect the "old" value
-        assertEquals("message0",
+        assertEquals("message2",
                 new String(persistence.get("topic", BucketUtils.getBucket("topic", bucketCount)).getMessage()));
 
-        persistence.put(new RetainedMessage(new byte[]{1, 2, 3}, QoS.AT_MOST_ONCE, 3L, MqttConfigurationDefaults.TTL_DISABLED),
+        persistence.put(new RetainedMessage("message3".getBytes(), QoS.AT_MOST_ONCE, 3L, MqttConfigurationDefaults.TTL_DISABLED),
                 "topic",
                 BucketUtils.getBucket("topic", bucketCount));
 
         assertEquals("message3",
                 new String(persistence.get("topic", BucketUtils.getBucket("topic", bucketCount)).getMessage()));
 
-        persistence.put(new RetainedMessage(new byte[]{1, 2, 3}, QoS.AT_MOST_ONCE, 4L, MqttConfigurationDefaults.TTL_DISABLED),
+        persistence.put(new RetainedMessage("message4".getBytes(), QoS.AT_MOST_ONCE, 4L, MqttConfigurationDefaults.TTL_DISABLED),
                 "topic",
                 BucketUtils.getBucket("topic", bucketCount));
 
@@ -159,8 +126,6 @@ public class RetainedMessageMemoryLocalPersistenceTest {
 
         assertEquals(0, persistence.currentMemorySize.get());
 
-        verify(payloadPersistence).decrementReferenceCounter(0);
-        verify(payloadPersistence).decrementReferenceCounter(1);
 
         final Set<String> topics = persistence.topicTrees[0].get("#");
         assertTrue(topics.isEmpty());
@@ -185,9 +150,6 @@ public class RetainedMessageMemoryLocalPersistenceTest {
                 new RetainedMessage(new byte[]{1, 2, 3}, QoS.AT_MOST_ONCE, 1L, MqttConfigurationDefaults.TTL_DISABLED),
                 "topic/1",
                 0);
-
-        verify(payloadPersistence).decrementReferenceCounter(0);
-        verify(payloadPersistence).decrementReferenceCounter(1);
 
         final Set<String> topics = persistence.topicTrees[0].get("#");
         assertEquals(2, topics.size());
@@ -229,9 +191,6 @@ public class RetainedMessageMemoryLocalPersistenceTest {
 
         assertNull(persistence.get("topic", 0));
         assertNotNull(persistence.get("topic2", 0));
-
-        verify(payloadPersistence).decrementReferenceCounter(1L);
-        verify(payloadPersistence, never()).decrementReferenceCounter(2L);
     }
 
     @Test
@@ -300,32 +259,7 @@ public class RetainedMessageMemoryLocalPersistenceTest {
         final Set<String> allEntries = persistence.getAllTopics("#", 0);
         assertEquals(0, allEntries.size());
 
-        verify(payloadPersistence, times(10)).decrementReferenceCounter(anyLong());
-
         assertEquals(0, persistence.currentMemorySize.get());
-    }
-
-    @Test
-    public void test_entry_immutable() {
-        final RetainedMessage originalMessage = new RetainedMessage(new byte[]{1, 2, 3},
-                QoS.AT_MOST_ONCE,
-                0L,
-                MqttConfigurationDefaults.TTL_DISABLED,
-                Mqtt5UserProperties.of(MqttUserProperty.of("name", "value")),
-                "responseTopic",
-                "contentType",
-                new byte[]{1, 2, 3},
-                Mqtt5PayloadFormatIndicator.UTF_8,
-                System.currentTimeMillis());
-        persistence.put(originalMessage, "topic/0", 0);
-        originalMessage.setMessage(new byte[]{2, 3, 4});
-        final RetainedMessage messageFromStore1 = persistence.get("topic/0", 0);
-        assertArrayEquals("message0".getBytes(), messageFromStore1.getMessage());
-
-        messageFromStore1.setMessage(new byte[]{2, 3, 4});
-        final RetainedMessage messageFromStore2 = persistence.get("topic/0", 0);
-
-        assertArrayEquals("message0".getBytes(), messageFromStore2.getMessage());
     }
 
     @Test
@@ -333,7 +267,7 @@ public class RetainedMessageMemoryLocalPersistenceTest {
         final BucketChunkResult<Map<String, @NotNull RetainedMessage>> chunk = persistence.getAllRetainedMessagesChunk(1, null, Integer.MAX_VALUE);
 
         assertEquals(1, chunk.getBucketIndex());
-        assertEquals(null, chunk.getLastKey());
+        assertNull(chunk.getLastKey());
         assertTrue(chunk.isFinished());
         assertTrue(chunk.getValue().isEmpty());
     }
@@ -362,16 +296,5 @@ public class RetainedMessageMemoryLocalPersistenceTest {
         assertEquals(1, chunk.getValue().size());
     }
 
-    @Test
-    public void getAllRetainedMessagesChunk_onlyMessagesWithPayload() {
-        persistence.put(new RetainedMessage(new byte[0], QoS.AT_MOST_ONCE, 1L, 1000), "topic/1", 1);
-        persistence.put(new RetainedMessage(new byte[0], QoS.AT_MOST_ONCE, 2L, 1000), "topic/2", 1);
-        when(payloadPersistence.getPayloadOrNull(2)).thenReturn(null);
 
-        final BucketChunkResult<Map<String, @NotNull RetainedMessage>> chunk = persistence.getAllRetainedMessagesChunk(1, null, Integer.MAX_VALUE);
-
-        assertEquals(1, chunk.getBucketIndex());
-        assertTrue(chunk.isFinished());
-        assertEquals(1, chunk.getValue().size());
-    }
 }


### PR DESCRIPTION
**Motivation**

Resolves  Improves performance with "in-memory" persistence mode

**Changes**

With in-memory mode, payloads will not be extracted unnecessarily from the publish and put into a persistence. Therefor a in-memory no-op PublishPayloadLocalPersistence was created.