### PR TITLE
Bugfix 146 - Scaling Shared Subscribers

### DIFF
--- a/src/main/java/com/hivemq/extensions/services/publish/PublishServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/publish/PublishServiceImpl.java
@@ -119,7 +119,7 @@ public class PublishServiceImpl implements PublishService {
         final PUBLISH internalPublish = publishToPUBLISH((PublishImpl) publish);
 
         final SettableFuture<PublishToClientResult> sendPublishFuture = SettableFuture.create();
-        final SubscriberWithIdentifiers subscriber = topicTree.getSubscriber(clientId, publish.getTopic());
+        final SubscriberWithIdentifiers subscriber = topicTree.findSubscriber(clientId, publish.getTopic());
 
         if (subscriber == null) {
             sendPublishFuture.set(PublishToClientResult.NOT_SUBSCRIBED);

--- a/src/main/java/com/hivemq/mqtt/services/InternalPublishServiceImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/InternalPublishServiceImpl.java
@@ -71,7 +71,7 @@ public class InternalPublishServiceImpl implements InternalPublishService {
     }
 
     @NotNull
-    public ListenableFuture<PublishReturnCode> publish(@NotNull final PUBLISH publish, @NotNull final ExecutorService executorService, @Nullable final String sender) {
+    public ListenableFuture<PublishReturnCode> publish(final @NotNull PUBLISH publish, final @NotNull ExecutorService executorService, final @Nullable String sender) {
 
         Preconditions.checkNotNull(publish, "PUBLISH can not be null");
         Preconditions.checkNotNull(executorService, "executorService can not be null");
@@ -109,12 +109,12 @@ public class InternalPublishServiceImpl implements InternalPublishService {
 
                 Futures.addCallback(persistFuture, new FutureCallback<>() {
                     @Override
-                    public void onSuccess(@Nullable final Void aVoid) {
+                    public void onSuccess(final @Nullable Void aVoid) {
                         persistSettableFuture.set(null);
                     }
 
                     @Override
-                    public void onFailure(@NotNull final Throwable throwable) {
+                    public void onFailure(final @NotNull Throwable throwable) {
                         Exceptions.rethrowError("Unable able to store retained message for topic " + publish.getTopic()
                                 + " with message id " + publish.getUniqueId() + ".", throwable);
                         persistSettableFuture.set(null);
@@ -130,13 +130,13 @@ public class InternalPublishServiceImpl implements InternalPublishService {
     }
 
     @NotNull
-    private ListenableFuture<PublishReturnCode> handlePublish(@NotNull final PUBLISH publish, @NotNull final ExecutorService executorService, @Nullable final String sender) {
+    private ListenableFuture<PublishReturnCode> handlePublish(final @NotNull PUBLISH publish, final @NotNull ExecutorService executorService, final @Nullable String sender) {
 
         final TopicSubscribers topicSubscribers = topicTree.findTopicSubscribers(publish.getTopic());
         final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicSubscribers.getSubscribers();
         final ImmutableSet<String> sharedSubscriptions = topicSubscribers.getSharedSubscriptions();
 
-        if (subscribers.size() < 1 && sharedSubscriptions.size() < 1) {
+        if (subscribers.isEmpty() && sharedSubscriptions.isEmpty()) {
             return Futures.immediateFuture(PublishReturnCode.NO_MATCHING_SUBSCRIBERS);
         }
 
@@ -151,11 +151,11 @@ public class InternalPublishServiceImpl implements InternalPublishService {
         return returnCodeFuture;
     }
 
-    private void deliverPublish(@NotNull final TopicSubscribers topicSubscribers,
-                                @Nullable final String sender,
-                                @NotNull final PUBLISH publish,
-                                @NotNull final ExecutorService executorService,
-                                @Nullable final SettableFuture<PublishReturnCode> returnCodeFuture) {
+    private void deliverPublish(final @NotNull TopicSubscribers topicSubscribers,
+                                final @Nullable String sender,
+                                final @NotNull PUBLISH publish,
+                                final @NotNull ExecutorService executorService,
+                                final @Nullable SettableFuture<PublishReturnCode> returnCodeFuture) {
         final Set<String> sharedSubscriptions = topicSubscribers.getSharedSubscriptions();
         final Map<String, SubscriberWithIdentifiers> notSharedSubscribers = new HashMap<>(topicSubscribers.getSubscribers().size());
 
@@ -184,14 +184,14 @@ public class InternalPublishServiceImpl implements InternalPublishService {
 
         Futures.addCallback(FutureUtils.mergeVoidFutures(publishFinishedFutureNonShared, publishFinishedFutureShared), new FutureCallback<>() {
             @Override
-            public void onSuccess(@Nullable final Void result) {
+            public void onSuccess(final @Nullable Void result) {
                 if (returnCodeFuture != null) {
                     returnCodeFuture.set(PublishReturnCode.DELIVERED);
                 }
             }
 
             @Override
-            public void onFailure(@NotNull final Throwable throwable) {
+            public void onFailure(final @NotNull Throwable throwable) {
                 Exceptions.rethrowError("Unable to publish message for topic " + publish.getTopic() + " with message id" + publish.getUniqueId() + ".", throwable);
                 if (returnCodeFuture != null) {
                     returnCodeFuture.set(PublishReturnCode.FAILED);

--- a/src/main/java/com/hivemq/mqtt/services/InternalPublishServiceImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/InternalPublishServiceImpl.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -133,7 +132,7 @@ public class InternalPublishServiceImpl implements InternalPublishService {
     @NotNull
     private ListenableFuture<PublishReturnCode> handlePublish(@NotNull final PUBLISH publish, @NotNull final ExecutorService executorService, @Nullable final String sender) {
 
-        final TopicSubscribers topicSubscribers = topicTree.getTopicSubscribers(publish.getTopic());
+        final TopicSubscribers topicSubscribers = topicTree.findTopicSubscribers(publish.getTopic());
         final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicSubscribers.getSubscribers();
         final ImmutableSet<String> sharedSubscriptions = topicSubscribers.getSharedSubscriptions();
 

--- a/src/main/java/com/hivemq/mqtt/topic/tree/LocalTopicTree.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/LocalTopicTree.java
@@ -37,7 +37,10 @@ public interface LocalTopicTree {
      * @return the subscribers interested in this topic with all their identifiers
      */
     @NotNull
-    ImmutableSet<SubscriberWithIdentifiers> getSubscribers(@NotNull String topic);
+    TopicSubscribers getTopicSubscribers(@NotNull String topic);
+
+    @NotNull
+    TopicSubscribers getTopicSubscribers(@NotNull String topic, boolean excludeRootLevelWildcard);
 
     /**
      * All subscribers that have subscribed to this exact topic filter
@@ -60,7 +63,6 @@ public interface LocalTopicTree {
     ImmutableSet<String> getSubscribersForTopic(@NotNull String topic, @NotNull ItemFilter itemFilter, boolean excludeRootLevelWildcard);
 
     @NotNull
-    ImmutableSet<SubscriberWithIdentifiers> getSubscribers(@NotNull String topic, boolean excludeRootLevelWildcard);
 
     /**
      * Remove a subscription for a client

--- a/src/main/java/com/hivemq/mqtt/topic/tree/LocalTopicTree.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/LocalTopicTree.java
@@ -37,10 +37,10 @@ public interface LocalTopicTree {
      * @return the subscribers interested in this topic with all their identifiers
      */
     @NotNull
-    TopicSubscribers getTopicSubscribers(@NotNull String topic);
+    TopicSubscribers findTopicSubscribers(@NotNull String topic);
 
     @NotNull
-    TopicSubscribers getTopicSubscribers(@NotNull String topic, boolean excludeRootLevelWildcard);
+    TopicSubscribers findTopicSubscribers(@NotNull String topic, boolean excludeRootLevelWildcard);
 
     /**
      * All subscribers that have subscribed to this exact topic filter
@@ -93,7 +93,7 @@ public interface LocalTopicTree {
      * or null if no subscription match for the client
      */
     @Nullable
-    SubscriberWithIdentifiers getSubscriber(@NotNull String client, @NotNull String topic);
+    SubscriberWithIdentifiers findSubscriber(@NotNull String client, @NotNull String topic);
 
 
     interface ItemFilter {
@@ -103,6 +103,6 @@ public interface LocalTopicTree {
          * @param subscriber the current subscriber
          * @return true if the current subscriber should be added to the result set, false if not
          */
-        boolean checkItem(@NotNull final SubscriberWithQoS subscriber);
+        boolean checkItem(final @NotNull SubscriberWithQoS subscriber);
     }
 }

--- a/src/main/java/com/hivemq/mqtt/topic/tree/TopicSubscribers.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/TopicSubscribers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.mqtt.topic.tree;
 
 import com.google.common.collect.ImmutableSet;

--- a/src/main/java/com/hivemq/mqtt/topic/tree/TopicSubscribers.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/TopicSubscribers.java
@@ -1,0 +1,26 @@
+package com.hivemq.mqtt.topic.tree;
+
+import com.google.common.collect.ImmutableSet;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
+
+/**
+ * @author Till Seeberger
+ */
+public class TopicSubscribers {
+
+    private final ImmutableSet<SubscriberWithIdentifiers> subscriber;
+    private final ImmutableSet<String> sharedSubscriptions;
+
+    public TopicSubscribers(@NotNull final ImmutableSet<SubscriberWithIdentifiers> subscriber,
+                            @NotNull final ImmutableSet<String> sharedSubscriptions) {
+        this.subscriber = subscriber;
+        this.sharedSubscriptions = sharedSubscriptions;
+    }
+
+    @NotNull
+    public ImmutableSet<SubscriberWithIdentifiers> getSubscribers() { return subscriber; }
+
+    @NotNull
+    public ImmutableSet<String> getSharedSubscriptions() { return sharedSubscriptions; }
+}

--- a/src/main/java/com/hivemq/mqtt/topic/tree/TopicSubscribers.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/TopicSubscribers.java
@@ -28,7 +28,7 @@ public class TopicSubscribers {
     private final @NotNull ImmutableSet<String> sharedSubscriptions;
 
     public TopicSubscribers(final @NotNull ImmutableSet<SubscriberWithIdentifiers> subscriber,
-                            final @NotNull  ImmutableSet<String> sharedSubscriptions) {
+                            final @NotNull ImmutableSet<String> sharedSubscriptions) {
         this.subscriber = subscriber;
         this.sharedSubscriptions = sharedSubscriptions;
     }

--- a/src/main/java/com/hivemq/mqtt/topic/tree/TopicSubscribers.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/TopicSubscribers.java
@@ -24,11 +24,11 @@ import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
  */
 public class TopicSubscribers {
 
-    private final ImmutableSet<SubscriberWithIdentifiers> subscriber;
-    private final ImmutableSet<String> sharedSubscriptions;
+    private final @NotNull ImmutableSet<SubscriberWithIdentifiers> subscriber;
+    private final @NotNull ImmutableSet<String> sharedSubscriptions;
 
-    public TopicSubscribers(@NotNull final ImmutableSet<SubscriberWithIdentifiers> subscriber,
-                            @NotNull final ImmutableSet<String> sharedSubscriptions) {
+    public TopicSubscribers(final @NotNull ImmutableSet<SubscriberWithIdentifiers> subscriber,
+                            final @NotNull  ImmutableSet<String> sharedSubscriptions) {
         this.subscriber = subscriber;
         this.sharedSubscriptions = sharedSubscriptions;
     }

--- a/src/main/java/com/hivemq/mqtt/topic/tree/TopicTreeImpl.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/TopicTreeImpl.java
@@ -68,7 +68,7 @@ public class TopicTreeImpl implements LocalTopicTree {
     private final int mapCreationThreshold;
 
     @Inject
-    public TopicTreeImpl(@NotNull final MetricsHolder metricsHolder) {
+    public TopicTreeImpl(final @NotNull MetricsHolder metricsHolder) {
 
         this.subscriptionCounter = metricsHolder.getSubscriptionCounter();
         this.mapCreationThreshold = TOPIC_TREE_MAP_CREATION_THRESHOLD.get();
@@ -85,7 +85,7 @@ public class TopicTreeImpl implements LocalTopicTree {
      * {@inheritDoc}
      */
     @Override
-    public boolean addTopic(@NotNull final String subscriber, @NotNull final Topic topic, final byte flags, @Nullable final String sharedGroup) {
+    public boolean addTopic(final @NotNull String subscriber, final @NotNull Topic topic, final byte flags, @Nullable final String sharedGroup) {
 
         checkNotNull(subscriber, "Subscriber must not be null");
         checkNotNull(topic, "Topic must not be null");
@@ -141,7 +141,7 @@ public class TopicTreeImpl implements LocalTopicTree {
         }
     }
 
-    private boolean addNode(@NotNull final SubscriberWithQoS subscriber, @NotNull final String[] contents, @NotNull final Node node, final int i) {
+    private boolean addNode(final @NotNull SubscriberWithQoS subscriber, final @NotNull String[] contents, final @NotNull Node node, final int i) {
 
         final String content = contents[i];
 
@@ -168,12 +168,12 @@ public class TopicTreeImpl implements LocalTopicTree {
      */
     @Override
     @NotNull
-    public TopicSubscribers getTopicSubscribers(@NotNull final String topic) {
-        return getTopicSubscribers(topic, false);
+    public TopicSubscribers findTopicSubscribers(final @NotNull String topic) {
+        return findTopicSubscribers(topic, false);
     }
 
     @NotNull
-    public TopicSubscribers getTopicSubscribers(@NotNull final String topic, final boolean excludeRootLevelWildcard) {
+    public TopicSubscribers findTopicSubscribers(final @NotNull String topic, final boolean excludeRootLevelWildcard) {
         final ImmutableList.Builder<SubscriberWithQoS> subscribers = ImmutableList.builder();
         final ImmutableSet.Builder<String> sharedSubscriptions = ImmutableSet.builder();
 
@@ -181,7 +181,7 @@ public class TopicTreeImpl implements LocalTopicTree {
             addWithTopicFilter(subscribers, sharedSubscriptions, subscriberWithQoS, topicFilter);
         };
 
-        getTopicSubscribers(topic, excludeRootLevelWildcard, subscriberConsumer);
+        findTopicSubscribers(topic, excludeRootLevelWildcard, subscriberConsumer);
 
         final ImmutableSet<SubscriberWithIdentifiers> distinctSubscribers = createDistinctSubscribers(subscribers.build());
 
@@ -189,8 +189,8 @@ public class TopicTreeImpl implements LocalTopicTree {
     }
 
     @NotNull
-    private void getTopicSubscribers(@NotNull final String topic, final boolean excludeRootLevelWildcard,
-                                     @NotNull final BiConsumer<SubscriberWithQoS, String> subscriberAndTopicConsumer) {
+    private void findTopicSubscribers(final @NotNull String topic, final boolean excludeRootLevelWildcard,
+                                      final @NotNull BiConsumer<SubscriberWithQoS, String> subscriberAndTopicConsumer) {
 
         checkNotNull(topic, "Topic must not be null");
 
@@ -244,10 +244,10 @@ public class TopicTreeImpl implements LocalTopicTree {
      * Add a subscriber to the first given builder.
      * In case it is a shared subscription, the shared subscription string is added to the second builder.
      */
-    private void addWithTopicFilter(@NotNull final ImmutableList.Builder<SubscriberWithQoS> subscribersBuilder,
-                                    @NotNull final ImmutableSet.Builder<String> sharedSubscriptionsBuilder,
-                                    @NotNull final SubscriberWithQoS subscriber,
-                                    @NotNull final String topicFilter) {
+    private void addWithTopicFilter(final @NotNull ImmutableList.Builder<SubscriberWithQoS> subscribersBuilder,
+                                    final @NotNull ImmutableSet.Builder<String> sharedSubscriptionsBuilder,
+                                    final @NotNull SubscriberWithQoS subscriber,
+                                    final @NotNull String topicFilter) {
 
         if (subscriber.isSharedSubscription()) {
             final String sharedSubscription = subscriber.getSharedName() + "/" + topicFilter;
@@ -261,8 +261,8 @@ public class TopicTreeImpl implements LocalTopicTree {
      * Add a subscriber to the given builder.
      * In case it is a shared subscription, the subscriber is copied and the topic filter is added to the copy.
      */
-    private void addWithTopicFilter(@NotNull final ImmutableList.Builder<SubscriberWithQoS> builder, final SubscriberWithQoS subscriber,
-                                    @NotNull final String[] topicParts, final int topicIndex, @NotNull final String topicPrefix) {
+    private void addWithTopicFilter(final @NotNull ImmutableList.Builder<SubscriberWithQoS> builder, final SubscriberWithQoS subscriber,
+                                    final @NotNull String[] topicParts, final int topicIndex, final @NotNull String topicPrefix) {
         if (!subscriber.isSharedSubscription()) {
             builder.add(subscriber);
             return;
@@ -289,7 +289,7 @@ public class TopicTreeImpl implements LocalTopicTree {
      * @return a immutable Set of distinct Subscribers with the maximum QoS.
      */
     @NotNull
-    private ImmutableSet<SubscriberWithIdentifiers> createDistinctSubscribers(@NotNull final ImmutableList<SubscriberWithQoS> subscribers) {
+    private ImmutableSet<SubscriberWithIdentifiers> createDistinctSubscribers(final @NotNull ImmutableList<SubscriberWithQoS> subscribers) {
 
 
         final ImmutableSet.Builder<SubscriberWithIdentifiers> newSet = ImmutableSet.builder();
@@ -334,15 +334,15 @@ public class TopicTreeImpl implements LocalTopicTree {
         return newSet.build();
     }
 
-    private boolean equalSubscription(@NotNull final SubscriberWithQoS first, @NotNull final SubscriberWithIdentifiers second) {
+    private boolean equalSubscription(final @NotNull SubscriberWithQoS first, final @NotNull SubscriberWithIdentifiers second) {
         return equalSubscription(first, second.getSubscriber(), second.getTopicFilter(), second.getSharedName());
     }
 
-    private boolean equalSubscription(@NotNull final SubscriberWithQoS first, @NotNull final SubscriberWithQoS second) {
+    private boolean equalSubscription(final @NotNull SubscriberWithQoS first, final @NotNull SubscriberWithQoS second) {
         return equalSubscription(first, second.getSubscriber(), second.getTopicFilter(), second.getSharedName());
     }
 
-    private boolean equalSubscription(@NotNull final SubscriberWithQoS first, @NotNull final String secondClient, @Nullable final String secondTopicFilter, @Nullable final String secondSharedName) {
+    private boolean equalSubscription(final @NotNull SubscriberWithQoS first, final @NotNull String secondClient, @Nullable final String secondTopicFilter, @Nullable final String secondSharedName) {
         if (!first.getSubscriber().equals(secondClient)) {
             return false;
         }
@@ -353,7 +353,7 @@ public class TopicTreeImpl implements LocalTopicTree {
     }
 
 
-    private void traverseTree(@NotNull final Node node, @NotNull final BiConsumer<SubscriberWithQoS, String> subscriberAndTopicConsumer,
+    private void traverseTree(final @NotNull Node node, final @NotNull BiConsumer<SubscriberWithQoS, String> subscriberAndTopicConsumer,
                               final String[] topicPart, final int depth, @NotNull String topic) {
 
         if (!topicPart[depth].equals(node.getTopicPart()) && !"+".equals(node.getTopicPart())) {
@@ -456,7 +456,7 @@ public class TopicTreeImpl implements LocalTopicTree {
      * @param subscriber the clientId
      * @return if there was already a subscription for this client
      */
-    private boolean removeRootWildcardSubscriber(@NotNull final String subscriber, @Nullable final String sharedName) {
+    private boolean removeRootWildcardSubscriber(final @NotNull String subscriber, @Nullable final String sharedName) {
         final ImmutableList.Builder<SubscriberWithQoS> foundSubscribers = ImmutableList.builder();
         for (final SubscriberWithQoS rootWildcardSubscriber : rootWildcardSubscribers) {
             if (rootWildcardSubscriber.getSubscriber().equals(subscriber) &&
@@ -479,7 +479,7 @@ public class TopicTreeImpl implements LocalTopicTree {
      * {@inheritDoc}
      */
     @Override
-    public void removeSubscriber(@NotNull final String subscriber, @NotNull final String topic, @Nullable final String sharedName) {
+    public void removeSubscriber(final @NotNull String subscriber, final @NotNull String topic, @Nullable final String sharedName) {
         checkNotNull(subscriber);
         checkNotNull(topic);
 
@@ -571,7 +571,7 @@ public class TopicTreeImpl implements LocalTopicTree {
     }
 
     @Nullable
-    private Node getLastNode(@NotNull final Node[] nodes) {
+    private Node getLastNode(final @NotNull Node[] nodes) {
         //Search for the last node which is not null
         for (int i = nodes.length - 1; i >= 0; i--) {
             final Node node = nodes[i];
@@ -594,7 +594,7 @@ public class TopicTreeImpl implements LocalTopicTree {
      * @param results    the result array
      * @param depth      the current topic level depth
      */
-    private void iterateChildNodesForSubscriberRemoval(@NotNull final Node node, @NotNull final String[] topicParts, @NotNull final Node[] results, final int depth) {
+    private void iterateChildNodesForSubscriberRemoval(final @NotNull Node node, final @NotNull String[] topicParts, final @NotNull Node[] results, final int depth) {
 
         //Note dobermai: We don't need to check for "+" subscribers explicitly, because unsubscribes are always absolute
 
@@ -640,7 +640,7 @@ public class TopicTreeImpl implements LocalTopicTree {
      */
     @Override
     @NotNull
-    public ImmutableSet<SubscriberWithQoS> getSharedSubscriber(@NotNull final String group, @NotNull final String topicFilter) {
+    public ImmutableSet<SubscriberWithQoS> getSharedSubscriber(final @NotNull String group, final @NotNull String topicFilter) {
         return getSubscriptionsByTopicFilter(topicFilter, subscriber -> {
             return subscriber.isSharedSubscription()
                     && subscriber.getSharedName() != null
@@ -650,12 +650,12 @@ public class TopicTreeImpl implements LocalTopicTree {
 
     @Override
     @NotNull
-    public ImmutableSet<String> getSubscribersWithFilter(@NotNull final String topicFilter, @NotNull final ItemFilter itemFilter) {
+    public ImmutableSet<String> getSubscribersWithFilter(final @NotNull String topicFilter, final @NotNull ItemFilter itemFilter) {
         return createDistinctSubscriberIds(getSubscriptionsByTopicFilter(topicFilter, itemFilter));
     }
 
     @Override
-    public @NotNull ImmutableSet<String> getSubscribersForTopic(@NotNull final String topic, @NotNull final ItemFilter itemFilter, final boolean excludeRootLevelWildcard) {
+    public @NotNull ImmutableSet<String> getSubscribersForTopic(final @NotNull String topic, final @NotNull ItemFilter itemFilter, final boolean excludeRootLevelWildcard) {
         checkNotNull(topic, "Topic must not be null");
 
         final ImmutableSet.Builder<String> subscribers = ImmutableSet.builder();
@@ -707,8 +707,8 @@ public class TopicTreeImpl implements LocalTopicTree {
     }
 
 
-    private void traverseTreeWithFilter(@NotNull final Node node, @NotNull final ImmutableSet.Builder<String> subscribers,
-                                        final String[] topicPart, final int depth, @NotNull final ItemFilter itemFilter) {
+    private void traverseTreeWithFilter(final @NotNull Node node, final @NotNull ImmutableSet.Builder<String> subscribers,
+                                        final String[] topicPart, final int depth, final @NotNull ItemFilter itemFilter) {
 
         if (!topicPart[depth].equals(node.getTopicPart()) && !"+".equals(node.getTopicPart())) {
             return;
@@ -803,7 +803,7 @@ public class TopicTreeImpl implements LocalTopicTree {
     }
 
     @NotNull
-    private ImmutableSet<SubscriberWithQoS> getSubscriptionsByTopicFilter(@NotNull final String topicFilter, @NotNull final ItemFilter itemFilter) {
+    private ImmutableSet<SubscriberWithQoS> getSubscriptionsByTopicFilter(final @NotNull String topicFilter, final @NotNull ItemFilter itemFilter) {
         final ImmutableSet.Builder<SubscriberWithQoS> subscribers = ImmutableSet.builder();
         if (topicFilter.equals("#")) {
             for (final SubscriberWithQoS rootWildcardSubscriber : rootWildcardSubscribers) {
@@ -888,8 +888,8 @@ public class TopicTreeImpl implements LocalTopicTree {
         }
     }
 
-    private void addAfterCallback(@NotNull final ItemFilter itemFilter,
-                                  @NotNull final ImmutableSet.Builder<SubscriberWithQoS> subscribers,
+    private void addAfterCallback(final @NotNull ItemFilter itemFilter,
+                                  final @NotNull ImmutableSet.Builder<SubscriberWithQoS> subscribers,
                                   @Nullable final SubscriberWithQoS subscriber) {
         if (subscriber != null) {
             if (itemFilter.checkItem(subscriber)) {
@@ -898,8 +898,8 @@ public class TopicTreeImpl implements LocalTopicTree {
         }
     }
 
-    private void addAfterItemCallback(@NotNull final ItemFilter itemFilter,
-                                      @NotNull final ImmutableSet.Builder<String> subscribers,
+    private void addAfterItemCallback(final @NotNull ItemFilter itemFilter,
+                                      final @NotNull ImmutableSet.Builder<String> subscribers,
                                       @Nullable final SubscriberWithQoS subscriber) {
         if (subscriber != null) {
             if (itemFilter.checkItem(subscriber)) {
@@ -913,7 +913,7 @@ public class TopicTreeImpl implements LocalTopicTree {
      */
     @Override
     @Nullable
-    public SubscriberWithIdentifiers getSubscriber(@NotNull final String client, @NotNull final String topic) {
+    public SubscriberWithIdentifiers findSubscriber(final @NotNull String client, final @NotNull String topic) {
 
         class SubscriberConsumer implements BiConsumer<SubscriberWithQoS, String> {
 
@@ -948,7 +948,7 @@ public class TopicTreeImpl implements LocalTopicTree {
 
         final SubscriberConsumer subscriberConsumer = new SubscriberConsumer();
 
-        getTopicSubscribers(topic, false, subscriberConsumer);
+        findTopicSubscribers(topic, false, subscriberConsumer);
 
         return subscriberConsumer.getMatchingSubscriber();
     }

--- a/src/main/java/com/hivemq/mqtt/topic/tree/TopicTreeImpl.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/TopicTreeImpl.java
@@ -915,7 +915,7 @@ public class TopicTreeImpl implements LocalTopicTree {
     @Nullable
     public SubscriberWithIdentifiers findSubscriber(final @NotNull String client, final @NotNull String topic) {
 
-        final FindSubscriberConsumer subscriberConsumer = new FindSubscriberConsumer(client);
+        final FindSubscriberConsumer subscriberConsumer = new FindSubscriberConsumer(client, this);
 
         findTopicSubscribers(topic, false, subscriberConsumer);
 
@@ -990,15 +990,17 @@ public class TopicTreeImpl implements LocalTopicTree {
         return true;
     }
 
-    class FindSubscriberConsumer implements BiConsumer<SubscriberWithQoS, String> {
+    static class FindSubscriberConsumer implements BiConsumer<SubscriberWithQoS, String> {
 
         private final @NotNull String client;
+        private final @NotNull TopicTreeImpl topicTree;
         private @Nullable SubscriberWithIdentifiers sharedSubscriber = null;
         private final @NotNull ImmutableList.Builder<SubscriberWithQoS> subscribers = ImmutableList.builder();
         private boolean normalSubscriberFound = false;
 
-        public FindSubscriberConsumer(final @NotNull String client) {
+        public FindSubscriberConsumer(final @NotNull String client, final @NotNull TopicTreeImpl topicTree) {
             this.client = client;
+            this.topicTree = topicTree;
         }
 
         @Override
@@ -1017,7 +1019,7 @@ public class TopicTreeImpl implements LocalTopicTree {
         public SubscriberWithIdentifiers getMatchingSubscriber() {
             final ImmutableList<SubscriberWithQoS> subscribers = this.subscribers.build();
             if (!subscribers.isEmpty()) {
-                final ImmutableSet<SubscriberWithIdentifiers> distinctSubscribers = createDistinctSubscribers(subscribers);
+                final ImmutableSet<SubscriberWithIdentifiers> distinctSubscribers = topicTree.createDistinctSubscribers(subscribers);
                 return distinctSubscribers.asList().get(0);
             }
             else {

--- a/src/test/java/com/hivemq/extensions/services/publish/PublishServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/publish/PublishServiceImplTest.java
@@ -148,7 +148,7 @@ public class PublishServiceImplTest {
     public void test_publish_to_client() throws Exception {
         final byte subscriptionFlags = SubscriptionFlags.getDefaultFlags(false, false, false);
         final Publish publish = new PublishBuilderImpl(fullConfigurationService).topic("topic").payload(ByteBuffer.wrap("message".getBytes())).build();
-        when(topicTree.getSubscriber("client", "topic")).thenReturn(
+        when(topicTree.findSubscriber("client", "topic")).thenReturn(
                 new SubscriberWithIdentifiers("client", 1, subscriptionFlags, null));
         when(publishDistributor.sendMessageToSubscriber(any(PUBLISH.class), anyString(), anyInt(), anyBoolean(), anyBoolean(),
                 any(ImmutableIntArray.class))).thenReturn(Futures.immediateFuture(PublishStatus.DELIVERED));
@@ -159,7 +159,7 @@ public class PublishServiceImplTest {
     @Test(timeout = 10000)
     public void test_publish_to_client_not_subscribed() throws Exception {
         final Publish publish = new PublishBuilderImpl(fullConfigurationService).topic("topic").payload(ByteBuffer.wrap("message".getBytes())).build();
-        when(topicTree.getSubscriber("client", "topic")).thenReturn(null);
+        when(topicTree.findSubscriber("client", "topic")).thenReturn(null);
         final PublishToClientResult result = publishService.publishToClient(publish, "client").get();
         assertEquals(PublishToClientResult.NOT_SUBSCRIBED, result);
     }

--- a/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
@@ -91,7 +91,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_retained_message_remove() throws Exception {
 
-        when(topicTree.getTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
+        when(topicTree.findTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
         publishService = new InternalPublishServiceImpl(retainedMessagePersistence, topicTree, publishDistributor);
 
         final PUBLISH publish = TestMessageUtil.createMqtt3Publish("hivemqId", "subonly", QoS.AT_LEAST_ONCE, new byte[0], true);
@@ -107,7 +107,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_retained_message_remove_failed() throws Exception {
 
-        when(topicTree.getTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
+        when(topicTree.findTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
         publishService = new InternalPublishServiceImpl(retainedMessagePersistence, topicTree, publishDistributor);
 
         final PUBLISH publish = TestMessageUtil.createMqtt3Publish("hivemqId", "subonly", QoS.AT_LEAST_ONCE, new byte[0], true);
@@ -122,7 +122,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_no_subs() throws ExecutionException, InterruptedException {
 
-        when(topicTree.getTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
+        when(topicTree.findTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -140,7 +140,7 @@ public class InternalPublishServiceImplTest {
         final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, noLocalFlag, null);
         final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
+        when(topicTree.findTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -162,7 +162,7 @@ public class InternalPublishServiceImplTest {
         final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 0, null);
         final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
+        when(topicTree.findTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -184,7 +184,7 @@ public class InternalPublishServiceImplTest {
         final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 0, null);
         final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
+        when(topicTree.findTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
         publish.setDuplicateDelivery(true);
@@ -205,7 +205,7 @@ public class InternalPublishServiceImplTest {
         final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 0, null);
         final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
+        when(topicTree.findTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -219,7 +219,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_shared_subs_different_groups() {
 
-        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of("group1/topic", "group2/topic")));
+        when(topicTree.findTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of("group1/topic", "group2/topic")));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -239,7 +239,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_shared_subs_same_group() {
 
-        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of("group1/topic", "group1/#")));
+        when(topicTree.findTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of("group1/topic", "group1/#")));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -261,7 +261,7 @@ public class InternalPublishServiceImplTest {
 
         final SubscriberWithIdentifiers sub = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub), ImmutableSet.of("group1/topic")));
+        when(topicTree.findTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub), ImmutableSet.of("group1/topic")));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 

--- a/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
@@ -26,6 +26,7 @@ import com.hivemq.mqtt.services.PublishDistributor;
 import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.mqtt.topic.SubscriptionFlags;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.mqtt.topic.tree.TopicSubscribers;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
 import org.junit.Before;
 import org.junit.Rule;
@@ -90,7 +91,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_retained_message_remove() throws Exception {
 
-        when(topicTree.getSubscribers(anyString())).thenReturn(ImmutableSet.of());
+        when(topicTree.getTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
         publishService = new InternalPublishServiceImpl(retainedMessagePersistence, topicTree, publishDistributor);
 
         final PUBLISH publish = TestMessageUtil.createMqtt3Publish("hivemqId", "subonly", QoS.AT_LEAST_ONCE, new byte[0], true);
@@ -106,7 +107,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_retained_message_remove_failed() throws Exception {
 
-        when(topicTree.getSubscribers(anyString())).thenReturn(ImmutableSet.of());
+        when(topicTree.getTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
         publishService = new InternalPublishServiceImpl(retainedMessagePersistence, topicTree, publishDistributor);
 
         final PUBLISH publish = TestMessageUtil.createMqtt3Publish("hivemqId", "subonly", QoS.AT_LEAST_ONCE, new byte[0], true);
@@ -121,7 +122,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_no_subs() throws ExecutionException, InterruptedException {
 
-        when(topicTree.getSubscribers(anyString())).thenReturn(ImmutableSet.of());
+        when(topicTree.getTopicSubscribers(anyString())).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -139,7 +140,7 @@ public class InternalPublishServiceImplTest {
         final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, noLocalFlag, null);
         final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getSubscribers("topic")).thenReturn(ImmutableSet.of(sub1, sub2));
+        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -161,7 +162,7 @@ public class InternalPublishServiceImplTest {
         final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 0, null);
         final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getSubscribers("topic")).thenReturn(ImmutableSet.of(sub1, sub2));
+        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -183,7 +184,7 @@ public class InternalPublishServiceImplTest {
         final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 0, null);
         final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getSubscribers("topic")).thenReturn(ImmutableSet.of(sub1, sub2));
+        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
         publish.setDuplicateDelivery(true);
@@ -204,7 +205,7 @@ public class InternalPublishServiceImplTest {
         final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 0, null);
         final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getSubscribers("topic")).thenReturn(ImmutableSet.of(sub1, sub2));
+        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub1, sub2), ImmutableSet.of()));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -218,10 +219,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_shared_subs_different_groups() {
 
-        final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 2, "group1", null, "topic");
-        final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 2, "group2", null, "topic");
-
-        when(topicTree.getSubscribers("topic")).thenReturn(ImmutableSet.of(sub1, sub2));
+        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of("group1/topic", "group2/topic")));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -241,10 +239,7 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_shared_subs_same_group() {
 
-        final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 2, "group1", null, "topic");
-        final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 2, "group1", null, "#");
-
-        when(topicTree.getSubscribers("topic")).thenReturn(ImmutableSet.of(sub1, sub2));
+        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of("group1/topic", "group1/#")));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 
@@ -264,10 +259,9 @@ public class InternalPublishServiceImplTest {
     @Test(timeout = 20000)
     public void test_mixed_subs() {
 
-        final SubscriberWithIdentifiers sub1 = new SubscriberWithIdentifiers("sub1", 1, (byte) 2, "group1", null, "topic");
-        final SubscriberWithIdentifiers sub2 = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
+        final SubscriberWithIdentifiers sub = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
 
-        when(topicTree.getSubscribers("topic")).thenReturn(ImmutableSet.of(sub1, sub2));
+        when(topicTree.getTopicSubscribers("topic")).thenReturn(new TopicSubscribers(ImmutableSet.of(sub), ImmutableSet.of("group1/topic")));
 
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
 

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestAddToTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestAddToTopicTreeImpl.java
@@ -345,7 +345,7 @@ public class TestAddToTopicTreeImpl {
         topicTree.addTopic("subscriber2", new Topic("topic1/+", QoS.AT_LEAST_ONCE), SubscriptionFlags.getDefaultFlags(false, true, true), null);
         topicTree.addTopic("subscriber3", new Topic("+/1", QoS.AT_LEAST_ONCE), SubscriptionFlags.getDefaultFlags(false, false, false), null);
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("topic1/1").getSubscribers();
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("topic1/1").getSubscribers();
         assertEquals(3, subscribers.size());
     }
 }

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestAddToTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestAddToTopicTreeImpl.java
@@ -345,7 +345,7 @@ public class TestAddToTopicTreeImpl {
         topicTree.addTopic("subscriber2", new Topic("topic1/+", QoS.AT_LEAST_ONCE), SubscriptionFlags.getDefaultFlags(false, true, true), null);
         topicTree.addTopic("subscriber3", new Topic("+/1", QoS.AT_LEAST_ONCE), SubscriptionFlags.getDefaultFlags(false, false, false), null);
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("topic1/1");
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("topic1/1").getSubscribers();
         assertEquals(3, subscribers.size());
     }
 }

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersFromTopicWithFilterTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersFromTopicWithFilterTopicTreeImpl.java
@@ -56,7 +56,7 @@ public class TestGetSubscribersFromTopicWithFilterTopicTreeImpl {
     @Test
     public void test_empty_topic_tree_get_subscribers() throws Exception {
 
-        final Set<SubscriberWithIdentifiers> any = topicTree.getTopicSubscribers("any").getSubscribers();
+        final Set<SubscriberWithIdentifiers> any = topicTree.findTopicSubscribers("any").getSubscribers();
         assertEquals(true, any.isEmpty());
     }
 

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersFromTopicWithFilterTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersFromTopicWithFilterTopicTreeImpl.java
@@ -56,7 +56,7 @@ public class TestGetSubscribersFromTopicWithFilterTopicTreeImpl {
     @Test
     public void test_empty_topic_tree_get_subscribers() throws Exception {
 
-        final Set<SubscriberWithIdentifiers> any = topicTree.getSubscribers("any");
+        final Set<SubscriberWithIdentifiers> any = topicTree.getTopicSubscribers("any").getSubscribers();
         assertEquals(true, any.isEmpty());
     }
 

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersWithFilterFromTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersWithFilterFromTopicTreeImpl.java
@@ -24,7 +24,6 @@ import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5RetainHandling;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
-import com.hivemq.mqtt.topic.SubscriberWithQoS;
 import com.hivemq.mqtt.topic.SubscriptionFlags;
 import org.junit.Before;
 import org.junit.Test;
@@ -417,7 +416,7 @@ public class TestGetSubscribersWithFilterFromTopicTreeImpl {
         topicTree.addTopic("client", new Topic("topic/+", QoS.AT_LEAST_ONCE), sharedFlag, "group");
         topicTree.addTopic("client", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group");
 
-        final TopicSubscribers topicSubscribers = topicTree.getTopicSubscribers("topic/a");
+        final TopicSubscribers topicSubscribers = topicTree.findTopicSubscribers("topic/a");
         assertEquals(0, topicSubscribers.getSubscribers().size());
         assertEquals(3, topicSubscribers.getSharedSubscriptions().size());
     }
@@ -430,7 +429,7 @@ public class TestGetSubscribersWithFilterFromTopicTreeImpl {
         topicTree.addTopic("client1", new Topic("topic/a", QoS.AT_MOST_ONCE, false, false, Mqtt5RetainHandling.SEND, 1), sharedFlag, null);
         topicTree.addTopic("client1", new Topic("topic/+", QoS.AT_LEAST_ONCE, false, false, Mqtt5RetainHandling.SEND, 2), sharedFlag, "group");
 
-        final SubscriberWithIdentifiers subscribers = topicTree.getSubscriber("client1", "topic/a");
+        final SubscriberWithIdentifiers subscribers = topicTree.findSubscriber("client1", "topic/a");
 
         assertEquals(1, subscribers.getSubscriptionIdentifier().length());
         assertTrue(subscribers.getSubscriptionIdentifier().contains(2));
@@ -443,7 +442,7 @@ public class TestGetSubscribersWithFilterFromTopicTreeImpl {
         topicTree.addTopic("client1", new Topic("topic/a", QoS.AT_MOST_ONCE, false, false, Mqtt5RetainHandling.SEND, 1), notSharedFlag, null);
         topicTree.addTopic("client1", new Topic("topic/+", QoS.AT_LEAST_ONCE, false, false, Mqtt5RetainHandling.SEND, 2), notSharedFlag, null);
 
-        final SubscriberWithIdentifiers subscribers = topicTree.getSubscriber("client1", "topic/a");
+        final SubscriberWithIdentifiers subscribers = topicTree.findSubscriber("client1", "topic/a");
 
         assertEquals(2, subscribers.getSubscriptionIdentifier().length());
         assertTrue(subscribers.getSubscriptionIdentifier().contains(1));
@@ -458,7 +457,7 @@ public class TestGetSubscribersWithFilterFromTopicTreeImpl {
         topicTree.addTopic("client1", new Topic("topic/a", QoS.AT_MOST_ONCE, false, false, Mqtt5RetainHandling.SEND, 1), notSharedFlag, null);
         topicTree.addTopic("client1", new Topic("topic/+", QoS.AT_LEAST_ONCE, false, false, Mqtt5RetainHandling.SEND, 2), sharedFlag, "group");
 
-        final SubscriberWithIdentifiers subscribers = topicTree.getSubscriber("client1", "topic/a");
+        final SubscriberWithIdentifiers subscribers = topicTree.findSubscriber("client1", "topic/a");
 
         assertEquals(1, subscribers.getSubscriptionIdentifier().length());
         assertEquals(1, subscribers.getSubscriptionIdentifier().get(0));
@@ -473,7 +472,7 @@ public class TestGetSubscribersWithFilterFromTopicTreeImpl {
         topicTree.addTopic("client", new Topic("topic", QoS.AT_LEAST_ONCE), notSharedFlag, null);
         topicTree.addTopic("client", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "name");
 
-        final TopicSubscribers topicSubscribers = topicTree.getTopicSubscribers("topic");
+        final TopicSubscribers topicSubscribers = topicTree.findTopicSubscribers("topic");
         assertEquals(1, topicSubscribers.getSubscribers().size());
         assertEquals(1, topicSubscribers.getSharedSubscriptions().size());
     }

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersWithFilterFromTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestGetSubscribersWithFilterFromTopicTreeImpl.java
@@ -417,8 +417,9 @@ public class TestGetSubscribersWithFilterFromTopicTreeImpl {
         topicTree.addTopic("client", new Topic("topic/+", QoS.AT_LEAST_ONCE), sharedFlag, "group");
         topicTree.addTopic("client", new Topic("#", QoS.AT_LEAST_ONCE), sharedFlag, "group");
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("topic/a");
-        assertEquals(3, subscribers.size());
+        final TopicSubscribers topicSubscribers = topicTree.getTopicSubscribers("topic/a");
+        assertEquals(0, topicSubscribers.getSubscribers().size());
+        assertEquals(3, topicSubscribers.getSharedSubscriptions().size());
     }
 
 
@@ -472,8 +473,9 @@ public class TestGetSubscribersWithFilterFromTopicTreeImpl {
         topicTree.addTopic("client", new Topic("topic", QoS.AT_LEAST_ONCE), notSharedFlag, null);
         topicTree.addTopic("client", new Topic("topic", QoS.AT_LEAST_ONCE), sharedFlag, "name");
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("topic");
-        assertEquals(2, subscribers.size());
+        final TopicSubscribers topicSubscribers = topicTree.getTopicSubscribers("topic");
+        assertEquals(1, topicSubscribers.getSubscribers().size());
+        assertEquals(1, topicSubscribers.getSharedSubscriptions().size());
     }
 
     @Test
@@ -538,11 +540,6 @@ public class TestGetSubscribersWithFilterFromTopicTreeImpl {
 
     @NotNull
     public LocalTopicTree.ItemFilter getMatchAllFilter() {
-        return new LocalTopicTree.ItemFilter() {
-            @Override
-            public boolean checkItem(@NotNull final SubscriberWithQoS subscriber) {
-                return true;
-            }
-        };
+        return subscriber -> true;
     }
 }

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestTopicTreeImplEdgeCases.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestTopicTreeImplEdgeCases.java
@@ -54,7 +54,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
 
-        assertEquals(0, topicTree.getSubscribers("").size());
+        assertEquals(0, topicTree.getTopicSubscribers("").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -68,7 +68,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("subscriber", new Topic("a/d", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber", new Topic("a/e", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        assertEquals(0, topicTree.getSubscribers("a/c").size());
+        assertEquals(0, topicTree.getTopicSubscribers("a/c").getSubscribers().size());
 
         assertEquals(3, topicTree.subscriptionCounter.getCount());
     }
@@ -82,7 +82,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.removeSubscriber("subscriber", "/+", null);
 
-        assertEquals(0, topicTree.getSubscribers("/a").size());
+        assertEquals(0, topicTree.getTopicSubscribers("/a").getSubscribers().size());
 
         assertEquals(2, topicTree.subscriptionCounter.getCount());
     }
@@ -94,7 +94,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("subscriber2", new Topic("a/test", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber3", new Topic("+/test", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("a/test");
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/test").getSubscribers();
         assertEquals(3, subscribers.size());
     }
 
@@ -105,7 +105,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("subscriber2", new Topic("a/b/test", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber3", new Topic("a/+/test", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("a/b/test");
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/b/test").getSubscribers();
         assertEquals(3, subscribers.size());
     }
 
@@ -116,7 +116,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("subscriber2", new Topic("a/test/b", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber3", new Topic("a/test/+", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("a/test/b");
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/test/b").getSubscribers();
         assertEquals(3, subscribers.size());
     }
 
@@ -125,7 +125,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("/", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("/");
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("/").getSubscribers();
         assertEquals(false, subscribers.isEmpty());
         assertThat(subscribers, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
     }
@@ -133,7 +133,7 @@ public class TestTopicTreeImplEdgeCases {
     @Test
     public void test_edge_case_slash_topic_wildcard_match() throws Exception {
         topicTree.addTopic("subscriber", new Topic("+/+", QoS.AT_MOST_ONCE), (byte) 0, null);
-        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getSubscribers("/");
+        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getTopicSubscribers("/").getSubscribers();
 
         assertEquals(false, subscribers2.isEmpty());
         assertThat(subscribers2, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
@@ -144,11 +144,11 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("/////", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("/////");
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("/////").getSubscribers();
         assertEquals(false, subscribers.isEmpty());
         assertThat(subscribers, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
-        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getSubscribers("////");
+        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getTopicSubscribers("////").getSubscribers();
         assertEquals(true, subscribers2.isEmpty());
     }
 
@@ -157,19 +157,19 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("+/+/+/+/+/+", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("/////");
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("/////").getSubscribers();
         assertEquals(false, subscribers.isEmpty());
         assertThat(subscribers, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
         topicTree.addTopic("subscriber2", new Topic("+/+/+/+/+/", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getSubscribers("/////");
+        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getTopicSubscribers("/////").getSubscribers();
         assertEquals(false, subscribers2.isEmpty());
         assertThat(subscribers2, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
         topicTree.addTopic("subscriber3", new Topic("/+/+/+/+/", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers3 = topicTree.getSubscribers("/////");
+        final Set<SubscriberWithIdentifiers> subscribers3 = topicTree.getTopicSubscribers("/////").getSubscribers();
         assertEquals(false, subscribers3.isEmpty());
         assertThat(subscribers3, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
@@ -182,12 +182,12 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("a/+/b", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("a//b");
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a//b").getSubscribers();
         assertEquals(false, subscribers.isEmpty());
         assertThat(subscribers, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
         topicTree.addTopic("subscriber2", new Topic("a/b/+", QoS.AT_MOST_ONCE), (byte) 0, null);
-        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getSubscribers("a/b/");
+        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getTopicSubscribers("a/b/").getSubscribers();
         assertEquals(false, subscribers2.isEmpty());
         assertThat(subscribers2, hasItem(new SubscriberWithIdentifiers("subscriber2", 0, (byte) 0, null, ImmutableList.of(), null)));
     }
@@ -202,7 +202,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic(topic, QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers(topic);
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers(topic).getSubscribers();
 
         assertEquals(0, subscribers.size());
     }
@@ -213,7 +213,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getSubscribers("any").size());
+        assertEquals(1, topicTree.getTopicSubscribers("any").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -225,7 +225,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("#", QoS.AT_LEAST_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getSubscribers("any").size());
+        assertEquals(1, topicTree.getTopicSubscribers("any").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -240,22 +240,22 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client3", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client3", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(3, topicTree.getSubscribers("#").size());
+        assertEquals(3, topicTree.getTopicSubscribers("#").getSubscribers().size());
         assertEquals(3, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client3", "#", null);
 
-        assertEquals(2, topicTree.getSubscribers("#").size());
+        assertEquals(2, topicTree.getTopicSubscribers("#").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client2", "#", null);
 
-        assertEquals(1, topicTree.getSubscribers("#").size());
+        assertEquals(1, topicTree.getTopicSubscribers("#").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
 
         topicTree.addTopic("client3", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(2, topicTree.getSubscribers("#").size());
+        assertEquals(2, topicTree.getTopicSubscribers("#").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
     }
 
@@ -265,7 +265,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getSubscribers("a/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -277,7 +277,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("a/b", QoS.AT_LEAST_ONCE), (byte) 0, null);
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("a/b");
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/b").getSubscribers();
         assertEquals(1, subscribers.size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
@@ -297,7 +297,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("client1", new Topic("a/b", QoS.AT_LEAST_ONCE), (byte) 0, null);
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getSubscribers("a/b");
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/b").getSubscribers();
         assertEquals(33, subscribers.size());
 
         assertEquals(33, topicTree.subscriptionCounter.getCount());
@@ -325,22 +325,22 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(3, topicTree.getSubscribers("a/b").size());
+        assertEquals(3, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(3, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client3", "a/b", null);
 
-        assertEquals(2, topicTree.getSubscribers("a/b").size());
+        assertEquals(2, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client2", "a/b", null);
 
-        assertEquals(1, topicTree.getSubscribers("a/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
 
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(2, topicTree.getSubscribers("a/b").size());
+        assertEquals(2, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
     }
 
@@ -350,7 +350,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getSubscribers("a/+/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -365,22 +365,22 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client3", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client3", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(3, topicTree.getSubscribers("a/+/b").size());
+        assertEquals(3, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
         assertEquals(3, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client3", "a/+/b", null);
 
-        assertEquals(2, topicTree.getSubscribers("a/+/b").size());
+        assertEquals(2, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client2", "a/+/b", null);
 
-        assertEquals(1, topicTree.getSubscribers("a/+/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
 
         topicTree.addTopic("client3", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(2, topicTree.getSubscribers("a/+/b").size());
+        assertEquals(2, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
     }
 
@@ -389,17 +389,17 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getSubscribers("a/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client3", "a/b", null);
 
-        assertEquals(0, topicTree.getSubscribers("a/b").size());
+        assertEquals(0, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(0, topicTree.subscriptionCounter.getCount());
 
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getSubscribers("a/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
 
@@ -407,11 +407,11 @@ public class TestTopicTreeImplEdgeCases {
     public void test_remove_wildcard() throws Exception {
 
         topicTree.addTopic("client", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
-        assertEquals(1, topicTree.getSubscribers("a/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         topicTree.addTopic("client", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
-        assertEquals(1, topicTree.getSubscribers("a/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
         topicTree.removeSubscriber("client", "#", null);
-        assertEquals(1, topicTree.getSubscribers("a/b").size());
+        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
     }
 
     @Test
@@ -422,8 +422,8 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.removeSubscriber("client1", "a/b", null);
 
         topicTree.addTopic("client2", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
-        assertEquals(QoS.EXACTLY_ONCE.getQosNumber(), topicTree.getSubscribers("a/b").asList().get(0).getQos());
-        assertEquals("client2", topicTree.getSubscribers("a/b").asList().get(0).getSubscriber());
+        assertEquals(QoS.EXACTLY_ONCE.getQosNumber(), topicTree.getTopicSubscribers("a/b").getSubscribers().asList().get(0).getQos());
+        assertEquals("client2", topicTree.getTopicSubscribers("a/b").getSubscribers().asList().get(0).getSubscriber());
 
     }
 

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestTopicTreeImplEdgeCases.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestTopicTreeImplEdgeCases.java
@@ -54,7 +54,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 0, null);
 
-        assertEquals(0, topicTree.getTopicSubscribers("").getSubscribers().size());
+        assertEquals(0, topicTree.findTopicSubscribers("").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -68,7 +68,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("subscriber", new Topic("a/d", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber", new Topic("a/e", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        assertEquals(0, topicTree.getTopicSubscribers("a/c").getSubscribers().size());
+        assertEquals(0, topicTree.findTopicSubscribers("a/c").getSubscribers().size());
 
         assertEquals(3, topicTree.subscriptionCounter.getCount());
     }
@@ -82,7 +82,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.removeSubscriber("subscriber", "/+", null);
 
-        assertEquals(0, topicTree.getTopicSubscribers("/a").getSubscribers().size());
+        assertEquals(0, topicTree.findTopicSubscribers("/a").getSubscribers().size());
 
         assertEquals(2, topicTree.subscriptionCounter.getCount());
     }
@@ -94,7 +94,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("subscriber2", new Topic("a/test", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber3", new Topic("+/test", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/test").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("a/test").getSubscribers();
         assertEquals(3, subscribers.size());
     }
 
@@ -105,7 +105,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("subscriber2", new Topic("a/b/test", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber3", new Topic("a/+/test", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/b/test").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("a/b/test").getSubscribers();
         assertEquals(3, subscribers.size());
     }
 
@@ -116,7 +116,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("subscriber2", new Topic("a/test/b", QoS.AT_MOST_ONCE), (byte) 0, null);
         topicTree.addTopic("subscriber3", new Topic("a/test/+", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/test/b").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("a/test/b").getSubscribers();
         assertEquals(3, subscribers.size());
     }
 
@@ -125,7 +125,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("/", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("/").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("/").getSubscribers();
         assertEquals(false, subscribers.isEmpty());
         assertThat(subscribers, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
     }
@@ -133,7 +133,7 @@ public class TestTopicTreeImplEdgeCases {
     @Test
     public void test_edge_case_slash_topic_wildcard_match() throws Exception {
         topicTree.addTopic("subscriber", new Topic("+/+", QoS.AT_MOST_ONCE), (byte) 0, null);
-        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getTopicSubscribers("/").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.findTopicSubscribers("/").getSubscribers();
 
         assertEquals(false, subscribers2.isEmpty());
         assertThat(subscribers2, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
@@ -144,11 +144,11 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("/////", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("/////").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("/////").getSubscribers();
         assertEquals(false, subscribers.isEmpty());
         assertThat(subscribers, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
-        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getTopicSubscribers("////").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.findTopicSubscribers("////").getSubscribers();
         assertEquals(true, subscribers2.isEmpty());
     }
 
@@ -157,19 +157,19 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("+/+/+/+/+/+", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("/////").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("/////").getSubscribers();
         assertEquals(false, subscribers.isEmpty());
         assertThat(subscribers, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
         topicTree.addTopic("subscriber2", new Topic("+/+/+/+/+/", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getTopicSubscribers("/////").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.findTopicSubscribers("/////").getSubscribers();
         assertEquals(false, subscribers2.isEmpty());
         assertThat(subscribers2, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
         topicTree.addTopic("subscriber3", new Topic("/+/+/+/+/", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers3 = topicTree.getTopicSubscribers("/////").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers3 = topicTree.findTopicSubscribers("/////").getSubscribers();
         assertEquals(false, subscribers3.isEmpty());
         assertThat(subscribers3, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
@@ -182,12 +182,12 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic("a/+/b", QoS.AT_MOST_ONCE), (byte) 0, null);
 
-        final Set<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a//b").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("a//b").getSubscribers();
         assertEquals(false, subscribers.isEmpty());
         assertThat(subscribers, hasItem(new SubscriberWithIdentifiers("subscriber", 0, (byte) 0, null, ImmutableList.of(), null)));
 
         topicTree.addTopic("subscriber2", new Topic("a/b/+", QoS.AT_MOST_ONCE), (byte) 0, null);
-        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.getTopicSubscribers("a/b/").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribers2 = topicTree.findTopicSubscribers("a/b/").getSubscribers();
         assertEquals(false, subscribers2.isEmpty());
         assertThat(subscribers2, hasItem(new SubscriberWithIdentifiers("subscriber2", 0, (byte) 0, null, ImmutableList.of(), null)));
     }
@@ -202,7 +202,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("subscriber", new Topic(topic, QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers(topic).getSubscribers();
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers(topic).getSubscribers();
 
         assertEquals(0, subscribers.size());
     }
@@ -213,7 +213,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("any").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("any").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -225,7 +225,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("#", QoS.AT_LEAST_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("any").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("any").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -240,22 +240,22 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client3", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client3", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(3, topicTree.getTopicSubscribers("#").getSubscribers().size());
+        assertEquals(3, topicTree.findTopicSubscribers("#").getSubscribers().size());
         assertEquals(3, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client3", "#", null);
 
-        assertEquals(2, topicTree.getTopicSubscribers("#").getSubscribers().size());
+        assertEquals(2, topicTree.findTopicSubscribers("#").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client2", "#", null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("#").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("#").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
 
         topicTree.addTopic("client3", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(2, topicTree.getTopicSubscribers("#").getSubscribers().size());
+        assertEquals(2, topicTree.findTopicSubscribers("#").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
     }
 
@@ -265,7 +265,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -277,7 +277,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("a/b", QoS.AT_LEAST_ONCE), (byte) 0, null);
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/b").getSubscribers();
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("a/b").getSubscribers();
         assertEquals(1, subscribers.size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
@@ -297,7 +297,7 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("client1", new Topic("a/b", QoS.AT_LEAST_ONCE), (byte) 0, null);
 
-        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.getTopicSubscribers("a/b").getSubscribers();
+        final ImmutableSet<SubscriberWithIdentifiers> subscribers = topicTree.findTopicSubscribers("a/b").getSubscribers();
         assertEquals(33, subscribers.size());
 
         assertEquals(33, topicTree.subscriptionCounter.getCount());
@@ -325,22 +325,22 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(3, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(3, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(3, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client3", "a/b", null);
 
-        assertEquals(2, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(2, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client2", "a/b", null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
 
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(2, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(2, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
     }
 
@@ -350,7 +350,7 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client1", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client1", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/+/b").getSubscribers().size());
 
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
@@ -365,22 +365,22 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.addTopic("client3", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
         topicTree.addTopic("client3", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(3, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
+        assertEquals(3, topicTree.findTopicSubscribers("a/+/b").getSubscribers().size());
         assertEquals(3, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client3", "a/+/b", null);
 
-        assertEquals(2, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
+        assertEquals(2, topicTree.findTopicSubscribers("a/+/b").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client2", "a/+/b", null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/+/b").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
 
         topicTree.addTopic("client3", new Topic("a/+/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(2, topicTree.getTopicSubscribers("a/+/b").getSubscribers().size());
+        assertEquals(2, topicTree.findTopicSubscribers("a/+/b").getSubscribers().size());
         assertEquals(2, topicTree.subscriptionCounter.getCount());
     }
 
@@ -389,17 +389,17 @@ public class TestTopicTreeImplEdgeCases {
 
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
 
         topicTree.removeSubscriber("client3", "a/b", null);
 
-        assertEquals(0, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(0, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(0, topicTree.subscriptionCounter.getCount());
 
         topicTree.addTopic("client3", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
 
-        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         assertEquals(1, topicTree.subscriptionCounter.getCount());
     }
 
@@ -407,11 +407,11 @@ public class TestTopicTreeImplEdgeCases {
     public void test_remove_wildcard() throws Exception {
 
         topicTree.addTopic("client", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
-        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         topicTree.addTopic("client", new Topic("#", QoS.EXACTLY_ONCE), (byte) 0, null);
-        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
         topicTree.removeSubscriber("client", "#", null);
-        assertEquals(1, topicTree.getTopicSubscribers("a/b").getSubscribers().size());
+        assertEquals(1, topicTree.findTopicSubscribers("a/b").getSubscribers().size());
     }
 
     @Test
@@ -422,8 +422,8 @@ public class TestTopicTreeImplEdgeCases {
         topicTree.removeSubscriber("client1", "a/b", null);
 
         topicTree.addTopic("client2", new Topic("a/b", QoS.EXACTLY_ONCE), (byte) 0, null);
-        assertEquals(QoS.EXACTLY_ONCE.getQosNumber(), topicTree.getTopicSubscribers("a/b").getSubscribers().asList().get(0).getQos());
-        assertEquals("client2", topicTree.getTopicSubscribers("a/b").getSubscribers().asList().get(0).getSubscriber());
+        assertEquals(QoS.EXACTLY_ONCE.getQosNumber(), topicTree.findTopicSubscribers("a/b").getSubscribers().asList().get(0).getQos());
+        assertEquals("client2", topicTree.findTopicSubscribers("a/b").getSubscribers().asList().get(0).getSubscriber());
 
     }
 

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TopicTreeStartupTest.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TopicTreeStartupTest.java
@@ -94,9 +94,9 @@ public class TopicTreeStartupTest {
 
         topicTreeStartup.postConstruct();
 
-        final Set<SubscriberWithIdentifiers> subscribersForTopic1 = topicTree.getSubscribers("topic1");
-        final Set<SubscriberWithIdentifiers> subscribersForTopic2 = topicTree.getSubscribers("topic2");
-        final Set<SubscriberWithIdentifiers> subscribersForTopic3 = topicTree.getSubscribers("topic3");
+        final Set<SubscriberWithIdentifiers> subscribersForTopic1 = topicTree.getTopicSubscribers("topic1").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribersForTopic2 = topicTree.getTopicSubscribers("topic2").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribersForTopic3 = topicTree.getTopicSubscribers("topic3").getSubscribers();
 
         assertThat(subscribersForTopic1, hasItems(new SubscriberWithIdentifiers("client1", 1, (byte) 0, null, ImmutableList.of(), null),
                 new SubscriberWithIdentifiers("client2", 1, (byte) 0, null, ImmutableList.of(), null)));
@@ -117,8 +117,8 @@ public class TopicTreeStartupTest {
         verify(clientSessionSubscriptionPersistence).removeAllLocally("client1");
         verify(clientSessionSubscriptionPersistence).removeAllLocally("client2");
 
-        final Set<SubscriberWithIdentifiers> subscribersForTopic1 = topicTree.getSubscribers("topic1");
-        final Set<SubscriberWithIdentifiers> subscribersForTopic2 = topicTree.getSubscribers("topic2");
+        final Set<SubscriberWithIdentifiers> subscribersForTopic1 = topicTree.getTopicSubscribers("topic1").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribersForTopic2 = topicTree.getTopicSubscribers("topic2").getSubscribers();
 
         assertTrue(subscribersForTopic1.isEmpty());
         assertTrue(subscribersForTopic2.isEmpty());

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TopicTreeStartupTest.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TopicTreeStartupTest.java
@@ -94,9 +94,9 @@ public class TopicTreeStartupTest {
 
         topicTreeStartup.postConstruct();
 
-        final Set<SubscriberWithIdentifiers> subscribersForTopic1 = topicTree.getTopicSubscribers("topic1").getSubscribers();
-        final Set<SubscriberWithIdentifiers> subscribersForTopic2 = topicTree.getTopicSubscribers("topic2").getSubscribers();
-        final Set<SubscriberWithIdentifiers> subscribersForTopic3 = topicTree.getTopicSubscribers("topic3").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribersForTopic1 = topicTree.findTopicSubscribers("topic1").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribersForTopic2 = topicTree.findTopicSubscribers("topic2").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribersForTopic3 = topicTree.findTopicSubscribers("topic3").getSubscribers();
 
         assertThat(subscribersForTopic1, hasItems(new SubscriberWithIdentifiers("client1", 1, (byte) 0, null, ImmutableList.of(), null),
                 new SubscriberWithIdentifiers("client2", 1, (byte) 0, null, ImmutableList.of(), null)));
@@ -117,8 +117,8 @@ public class TopicTreeStartupTest {
         verify(clientSessionSubscriptionPersistence).removeAllLocally("client1");
         verify(clientSessionSubscriptionPersistence).removeAllLocally("client2");
 
-        final Set<SubscriberWithIdentifiers> subscribersForTopic1 = topicTree.getTopicSubscribers("topic1").getSubscribers();
-        final Set<SubscriberWithIdentifiers> subscribersForTopic2 = topicTree.getTopicSubscribers("topic2").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribersForTopic1 = topicTree.findTopicSubscribers("topic1").getSubscribers();
+        final Set<SubscriberWithIdentifiers> subscribersForTopic2 = topicTree.findTopicSubscribers("topic2").getSubscribers();
 
         assertTrue(subscribersForTopic1.isEmpty());
         assertTrue(subscribersForTopic2.isEmpty());


### PR DESCRIPTION
**Motivation**

When shared subscribers for a topic are scaled and clients are constantly publishing to this topic with a high rate (~3000 publishes per second), all the shared subscribers in the Topic Tree have to be queried for each publish, even though we just need the shared subscription string. 

**Changes**
- Introduce a class `TopicSubscribers` which directly holds reference to the shared subscription Strings in addition to the normal subscribers which do not hold a shared subscription.
- Refactor `public ImmutableSet<SubsriberWithIdentifiers> getSubscribers(String topic)` to `public TopicSubscribers getTopicSubscribers(String topic)`
- Refactor `public ImmutableSet<SubsriberWithIdentifiers> getSubscribers(String topic, boolean excludeRootLevelWildcards)` to `public TopicSubscribers getTopicSubscribers(String topic, boolean excludeRootLevelWildcards)`