### PR TITLE
Add retain as published support for shared subscriptions

### DIFF
--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -109,7 +109,7 @@ public class PublishDistributorImpl implements PublishDistributor {
 
         for (final String sharedSubscriber : sharedSubscribers) {
             final SettableFuture<Void> publishFinishedFuture = SettableFuture.create();
-            final ListenableFuture<PublishStatus> future = sendMessageToSubscriber(publish, sharedSubscriber, publish.getQoS().getQosNumber(), true, false, null);
+            final ListenableFuture<PublishStatus> future = sendMessageToSubscriber(publish, sharedSubscriber, publish.getQoS().getQosNumber(), true, true, null);
             publishResultFutureBuilder.add(publishFinishedFuture);
             Futures.addCallback(future, new StandardPublishCallback(sharedSubscriber, publish, publishFinishedFuture), executorService);
         }

--- a/src/main/java/com/hivemq/mqtt/services/PublishPollService.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishPollService.java
@@ -70,11 +70,13 @@ public interface PublishPollService {
      * @param client                 for which the messages are poll
      * @param sharedSubscription     of the queue for which messages are polled
      * @param qos                    of the clients subscription
+     * @param retainAsPublished      of the clients subscription
      * @param subscriptionIdentifier of the clients subscription
      * @param channel                to which the messages are sent
      */
     void pollSharedPublishesForClient(@NotNull String client, @NotNull String sharedSubscription, int qos,
-                                      @Nullable Integer subscriptionIdentifier, @NotNull Channel channel);
+                                      boolean retainAsPublished, @Nullable Integer subscriptionIdentifier,
+                                      @NotNull Channel channel);
 
     /**
      * Remove a message form the client queue.

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionSubscriptionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionSubscriptionPersistenceImpl.java
@@ -351,7 +351,7 @@ public class ClientSessionSubscriptionPersistenceImpl extends AbstractPersistenc
                 final Topic topic = sharedSub.getTopic();
 
                 final String sharedSubId = sharedSub.getSharedGroup() + "/" + topic.getTopic();
-                publishPollService.pollSharedPublishesForClient(clientId, sharedSubId, topic.getQoS().getQosNumber(), topic.getSubscriptionIdentifier(), channel);
+                publishPollService.pollSharedPublishesForClient(clientId, sharedSubId, topic.getQoS().getQosNumber(), topic.isRetainAsPublished(), topic.getSubscriptionIdentifier(), channel);
                 sharedSubscriptionService.invalidateSharedSubscriptionCache(clientId);
                 sharedSubscriptionService.invalidateSharedSubscriberCache(sharedSubId);
                 channel.attr(ChannelAttributes.NO_SHARED_SUBSCRIPTION).set(false);

--- a/src/test/java/com/hivemq/mqtt/services/PublishPollServiceImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/services/PublishPollServiceImplTest.java
@@ -315,7 +315,7 @@ public class PublishPollServiceImplTest {
 
         when(messageIDPool.takeNextId()).thenReturn(1);
 
-        publishPollService.pollSharedPublishesForClient("client", "group/topic", 0, null, channel);
+        publishPollService.pollSharedPublishesForClient("client", "group/topic", 0, false, null, channel);
 
         // Poll and remove
         verify(clientQueuePersistence).removeShared("group/topic", publish.getUniqueId());

--- a/src/test/java/com/hivemq/persistence/clientsession/ClientSessionSubscriptionPersistenceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/clientsession/ClientSessionSubscriptionPersistenceImplTest.java
@@ -132,7 +132,7 @@ public class ClientSessionSubscriptionPersistenceImplTest {
         when(channelPersistence.get("client")).thenReturn(null);
         persistence.invalidateSharedSubscriptionCacheAndPoll("client", ImmutableSet.of());
 
-        verify(publishPollService, never()).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), anyInt(), any(Channel.class));
+        verify(publishPollService, never()).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), anyBoolean(), anyInt(), any(Channel.class));
 
     }
 
@@ -145,7 +145,7 @@ public class ClientSessionSubscriptionPersistenceImplTest {
         when(channelPersistence.get("client")).thenReturn(embeddedChannel);
         persistence.invalidateSharedSubscriptionCacheAndPoll("client", ImmutableSet.of());
 
-        verify(publishPollService, never()).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), anyInt(), any(Channel.class));
+        verify(publishPollService, never()).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), anyBoolean(), anyInt(), any(Channel.class));
 
     }
 
@@ -157,7 +157,7 @@ public class ClientSessionSubscriptionPersistenceImplTest {
         when(channelPersistence.get("client")).thenReturn(embeddedChannel);
         persistence.invalidateSharedSubscriptionCacheAndPoll("client", ImmutableSet.of());
 
-        verify(publishPollService, never()).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), anyInt(), any(Channel.class));
+        verify(publishPollService, never()).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), anyBoolean(), anyInt(), any(Channel.class));
 
         embeddedChannel.close();
 
@@ -171,7 +171,7 @@ public class ClientSessionSubscriptionPersistenceImplTest {
         when(channelPersistence.get("client")).thenReturn(embeddedChannel);
         persistence.invalidateSharedSubscriptionCacheAndPoll("client", ImmutableSet.of(new Subscription(new Topic("topic", QoS.AT_LEAST_ONCE), (byte) 2, "group")));
 
-        verify(publishPollService).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), any(), any(Channel.class));
+        verify(publishPollService).pollSharedPublishesForClient(anyString(), anyString(), anyInt(), anyBoolean(), any(), any(Channel.class));
         verify(sharedSubscriptionService).invalidateSharedSubscriberCache("group/topic");
         verify(sharedSubscriptionService).invalidateSharedSubscriptionCache("client");
 


### PR DESCRIPTION
Shared Subscriptions currently do not support the _retain as published_ feature.
This PR adds the necessary support through the following changes:
- `PublishPollServiceImpl`: Add  retainAsPublished support to `pollSharedPublishesForClient()`
