### PR TITLE
Improvement/id-2149 option for memtable flushing

### DIFF
--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -402,4 +402,5 @@ public class InternalConfigurations {
      */
     public static final AtomicInteger AUTH_PROCESS_TIMEOUT = new AtomicInteger(30);
 
+    public static final AtomicBoolean PUBLISH_PAYLOAD_FORCE_FLUSH = new AtomicBoolean(true);
 }

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistence.java
@@ -18,11 +18,11 @@ package com.hivemq.persistence.payload;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.exceptions.UnrecoverableException;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.migration.meta.PersistenceType;
 import com.hivemq.persistence.PersistenceStartup;
 import com.hivemq.persistence.local.rocksdb.RocksDBLocalPersistence;
@@ -44,11 +44,14 @@ import static com.hivemq.persistence.payload.PublishPayloadRocksDBSerializer.ser
 @LazySingleton
 public class PublishPayloadRocksDBLocalPersistence extends RocksDBLocalPersistence implements PublishPayloadLocalPersistence {
 
-    private static final Logger log = LoggerFactory.getLogger(PublishPayloadRocksDBLocalPersistence.class);
+    @VisibleForTesting
+    static final Logger log = LoggerFactory.getLogger(PublishPayloadRocksDBLocalPersistence.class);
     private static final FlushOptions FLUSH_OPTIONS = new FlushOptions().setAllowWriteStall(true); // must not be gc´d
 
     public static final String PERSISTENCE_VERSION = "040500_R";
     private final long memtableSize;
+    private final boolean forceFlush;
+
 
     private long maxId = 0;
 
@@ -65,9 +68,10 @@ public class PublishPayloadRocksDBLocalPersistence extends RocksDBLocalPersisten
                 InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_CACHE_SIZE_PORTION.get(),
                 InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_SIZE,
                 InternalConfigurations.PAYLOAD_PERSISTENCE_TYPE.get() == PersistenceType.FILE_NATIVE);
-        memtableSize = PhysicalMemoryUtil.physicalMemory() / InternalConfigurations.PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION.get()
+        this.memtableSize = PhysicalMemoryUtil.physicalMemory() / InternalConfigurations.PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION.get()
                 / InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.get();
-        rocksdbToMemTableSize = new long[InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.get()];
+        this.rocksdbToMemTableSize = new long[InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.get()];
+        this.forceFlush = InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH.get();
     }
 
     @NotNull
@@ -126,21 +130,28 @@ public class PublishPayloadRocksDBLocalPersistence extends RocksDBLocalPersisten
     public void put(final long id, @NotNull final byte[] payload) {
         checkNotNull(payload, "payload must not be null");
         final int index = getBucketIndex(Long.toString(id));
-        final RocksDB bucket = buckets[index];;
+        final RocksDB bucket = buckets[index];
+        ;
         try {
             bucket.put(serializeKey(id), payload);
-            long currentSize = rocksdbToMemTableSize[index];
-            currentSize += payload.length;
-            if (currentSize >= memtableSize) {
-                bucket.flush(FLUSH_OPTIONS);
-                if (log.isDebugEnabled()) {
-                    log.debug("Hard flushing memTable due to exceeding memTable limit {}.", memtableSize);
-                }
-                currentSize = 0L;
+            if (forceFlush) {
+                flushOnMemtableOverflow(bucket, index, payload.length);
             }
-            rocksdbToMemTableSize[index] = currentSize;
         } catch (final RocksDBException e) {
             log.error("Could not put a payload because of an exception: ", e);
+        }
+    }
+
+    private void flushOnMemtableOverflow(final @NotNull RocksDB bucket, final int bucketIndex, final int payloadSize) throws RocksDBException {
+        final long updatedSize = payloadSize + rocksdbToMemTableSize[bucketIndex];
+        if (updatedSize >= memtableSize) {
+            bucket.flush(FLUSH_OPTIONS);
+            if (log.isDebugEnabled()) {
+                log.debug("Hard flushing memTable due to exceeding memTable limit {}.", memtableSize);
+            }
+            rocksdbToMemTableSize[bucketIndex] = 0L;
+        } else {
+            rocksdbToMemTableSize[bucketIndex] = updatedSize;
         }
     }
 

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistence.java
@@ -46,7 +46,7 @@ public class PublishPayloadRocksDBLocalPersistence extends RocksDBLocalPersisten
 
     @VisibleForTesting
     static final Logger log = LoggerFactory.getLogger(PublishPayloadRocksDBLocalPersistence.class);
-    private static final FlushOptions FLUSH_OPTIONS = new FlushOptions().setAllowWriteStall(true); // must not be gc´d
+    private final FlushOptions FLUSH_OPTIONS = new FlushOptions().setAllowWriteStall(true); // must not be gc´d
 
     public static final String PERSISTENCE_VERSION = "040500_R";
     private final long memtableSize;

--- a/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
@@ -26,12 +26,12 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import util.LogbackCapturingAppender;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -47,7 +47,10 @@ public class PublishPayloadRocksDBLocalPersistenceTest {
     @Mock
     LocalPersistenceFileUtil localPersistenceFileUtil;
 
+    private PersistenceStartup persistenceStartup;
     private PublishPayloadRocksDBLocalPersistence persistence;
+    private LogbackCapturingAppender capturingAppender;
+
 
     @Before
     public void before() throws Exception {
@@ -57,15 +60,18 @@ public class PublishPayloadRocksDBLocalPersistenceTest {
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString())).thenReturn(temporaryFolder.newFolder());
         InternalConfigurations.PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION.set(1024);
         InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_CACHE_SIZE_PORTION.set(16);
-
-        persistence = new PublishPayloadRocksDBLocalPersistence(localPersistenceFileUtil, new PersistenceStartup());
+        persistenceStartup = new PersistenceStartup();
+        persistence = new PublishPayloadRocksDBLocalPersistence(localPersistenceFileUtil, persistenceStartup);
         persistence.start();
+        capturingAppender = LogbackCapturingAppender.Factory.weaveInto(PublishPayloadRocksDBLocalPersistence.log);
     }
 
     @After
-    public void cleanUp() {
+    public void cleanUp() throws InterruptedException {
         InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.set(64);
+        InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH.set(true);
         persistence.closeDB();
+        persistenceStartup.finish();
     }
 
     @Test
@@ -174,6 +180,39 @@ public class PublishPayloadRocksDBLocalPersistenceTest {
         for (final long memTableSize : persistence.getRocksdbToMemTableSize()) {
             assertEquals(0L, memTableSize);
         }
+        assertTrue(capturingAppender.getLastCapturedLog().getMessage().contains("Hard flushing memTable due to exceeding memTable limit"));
     }
+
+    @Test
+    public void put_bigPayloads_default_flushing() throws InterruptedException {
+        persistenceStartup.finish();
+        persistence.closeDB();
+        persistenceStartup = new PersistenceStartup();
+        InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH.set(false);
+        persistence = new PublishPayloadRocksDBLocalPersistence(localPersistenceFileUtil, persistenceStartup);
+        persistence.start();
+
+        final long memtableSize = persistence.getMemtableSize();
+        long bytesPuttedIn = 0L;
+        final byte[] payload1 = "payload".getBytes();
+        int counter = 0;
+        while (bytesPuttedIn < memtableSize) {
+            for (final long memTableSize : persistence.getRocksdbToMemTableSize()) {
+                //skip the empty entries
+                if (memTableSize == 0) {
+                    continue;
+                }
+                assertEquals(bytesPuttedIn, memTableSize);
+            }
+            persistence.put(counter++, payload1);
+            bytesPuttedIn += payload1.length;
+        }
+        //after flush memTable must be empty (all -  because the others were empty already)
+        for (final long memTableSize : persistence.getRocksdbToMemTableSize()) {
+            assertEquals(0L, memTableSize);
+        }
+        assertNull(capturingAppender.getLastCapturedLog());
+    }
+
 
 }


### PR DESCRIPTION
**Motivation**

force flushing memTables is now configurable via InternalConfigurations
make the flushOptions not static to prevent loading RocksDB when other persistence mode is used

Resolves #<issue>

**Changes**

add internal option for force flushing memTables
made flushOptions a normal field
