### PR TITLE
Improve ShutdownHooks

### DIFF
--- a/src/main/java/com/hivemq/HiveMQServer.java
+++ b/src/main/java/com/hivemq/HiveMQServer.java
@@ -139,8 +139,9 @@ public class HiveMQServer {
                 GuiceBootstrap.persistenceInjector(systemInformation, metricRegistry, hiveMQId, configService);
         //blocks until all persistences started
         persistenceInjector.getInstance(PersistenceStartup.class).finish();
+        final ShutdownHooks shutdownHooks = persistenceInjector.getInstance(ShutdownHooks.class);
 
-        if (ShutdownHooks.SHUTTING_DOWN.get()) {
+        if (shutdownHooks.isShuttingDown()) {
             return;
         }
         if (configService.persistenceConfigurationService().getMode() != PersistenceMode.IN_MEMORY) {
@@ -176,7 +177,7 @@ public class HiveMQServer {
             return;
         }
 
-        if (ShutdownHooks.SHUTTING_DOWN.get()) {
+        if (shutdownHooks.isShuttingDown()) {
             return;
         }
         final HiveMQServer instance = injector.getInstance(HiveMQServer.class);
@@ -189,7 +190,7 @@ public class HiveMQServer {
             log.trace("Finished initial garbage collection after startup in {}ms", System.currentTimeMillis() - start);
         }
 
-        if (ShutdownHooks.SHUTTING_DOWN.get()) {
+        if (shutdownHooks.isShuttingDown()) {
             return;
         }
 
@@ -198,13 +199,13 @@ public class HiveMQServer {
         LoggingBootstrap.addLoglevelModifiers();
         instance.start(null);
 
-        if (ShutdownHooks.SHUTTING_DOWN.get()) {
+        if (shutdownHooks.isShuttingDown()) {
             return;
         }
 
         log.info("Started HiveMQ in {}ms", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
 
-        if (ShutdownHooks.SHUTTING_DOWN.get()) {
+        if (shutdownHooks.isShuttingDown()) {
             return;
         }
 

--- a/src/main/java/com/hivemq/bootstrap/NettyShutdownHook.java
+++ b/src/main/java/com/hivemq/bootstrap/NettyShutdownHook.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 /**
  *
  */
-public class NettyShutdownHook extends HiveMQShutdownHook {
+public class NettyShutdownHook implements HiveMQShutdownHook {
 
     private static final Logger log = LoggerFactory.getLogger(NettyShutdownHook.class);
 

--- a/src/main/java/com/hivemq/common/shutdown/HiveMQShutdownHook.java
+++ b/src/main/java/com/hivemq/common/shutdown/HiveMQShutdownHook.java
@@ -26,17 +26,14 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
  *
  * @author Dominik Obermaier
  */
-public abstract class HiveMQShutdownHook extends Thread {
-
+public interface HiveMQShutdownHook extends Runnable {
 
     /**
      * The name of the shutdown hook. This name is used for logging purposes
      *
      * @return the name of the HiveMQ shutdown hook
      */
-    @NotNull
-    public abstract String name();
-
+    @NotNull String name();
 
     /**
      * The {@link HiveMQShutdownHook.Priority} of the shutdown hook. This is only relevant if the execution of this
@@ -45,8 +42,9 @@ public abstract class HiveMQShutdownHook extends Thread {
      *
      * @return the {@link HiveMQShutdownHook.Priority} of the shutdown hook.
      */
-    @NotNull
-    public abstract Priority priority();
+    default @NotNull Priority priority() {
+        return Priority.DOES_NOT_MATTER;
+    }
 
     /**
      * If the Shutdown hook should be executed asynchronous. This is only
@@ -60,12 +58,11 @@ public abstract class HiveMQShutdownHook extends Thread {
      *
      * @return <code>true</code> if the shutdown hook should be executed asynchronous, <code>false</code> otherwise.
      */
-    public abstract boolean isAsynchronous();
+    default boolean isAsynchronous() {
+        return false;
+    }
 
-    @Override
-    public abstract void run();
-
-    public enum Priority {
+    enum Priority {
         FIRST(Integer.MAX_VALUE),
         CRITICAL(1_000_000),
         VERY_HIGH(500_000),
@@ -75,22 +72,20 @@ public abstract class HiveMQShutdownHook extends Thread {
         VERY_LOW(5_000),
         DOES_NOT_MATTER(Integer.MIN_VALUE);
 
-        private final int intValue;
+        private final int value;
 
-        Priority(final int intValue) {
+        Priority(final int value) {
 
-            this.intValue = intValue;
+            this.value = value;
         }
 
-        public int getIntValue() {
-            return intValue;
+        public int getValue() {
+            return value;
         }
 
         @Override
         public String toString() {
-            return name() + " (" + getIntValue() + ")";
+            return name() + " (" + getValue() + ")";
         }
     }
-
-
 }

--- a/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
+++ b/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
@@ -189,7 +189,7 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
             final long startTime = System.currentTimeMillis();
             final ShutdownHooks shutdownHooks = injector.getInstance(ShutdownHooks.class);
 
-            for (final HiveMQShutdownHook hiveMQShutdownHook : shutdownHooks.getRegistry().values()) {
+            for (final HiveMQShutdownHook hiveMQShutdownHook : shutdownHooks.getSynchronousHooks().values()) {
                 try {
                     // We call run, as we want to execute the hooks now, in this thread
                     //noinspection CallToThreadRun
@@ -204,7 +204,7 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
                 }
             }
 
-            for (final HiveMQShutdownHook hiveMQShutdownHook : shutdownHooks.getAsyncShutdownHooks()) {
+            for (final HiveMQShutdownHook hiveMQShutdownHook : shutdownHooks.getAsyncShutdownHooks().keySet()) {
                 try {
                     // We call run, as we want to execute the hooks now, in this thread
                     //noinspection CallToThreadRun

--- a/src/main/java/com/hivemq/extensions/ExtensionBootstrapImpl.java
+++ b/src/main/java/com/hivemq/extensions/ExtensionBootstrapImpl.java
@@ -111,7 +111,7 @@ public class ExtensionBootstrapImpl implements ExtensionBootstrap {
         // not checking for authenticator safety
     }
 
-    private static class ExtensionSystemShutdownHook extends HiveMQShutdownHook {
+    private static class ExtensionSystemShutdownHook implements HiveMQShutdownHook {
 
         private static final Logger log = LoggerFactory.getLogger(ExtensionSystemShutdownHook.class);
 

--- a/src/main/java/com/hivemq/extensions/executor/PluginOutputAsyncerImpl.java
+++ b/src/main/java/com/hivemq/extensions/executor/PluginOutputAsyncerImpl.java
@@ -84,7 +84,7 @@ public class PluginOutputAsyncerImpl implements PluginOutPutAsyncer {
     }
 
 
-    static class PluginOutputAsyncerShutdownHook extends HiveMQShutdownHook {
+    static class PluginOutputAsyncerShutdownHook implements HiveMQShutdownHook {
         @NotNull
         private final ScheduledExecutorService scheduledExecutor;
 

--- a/src/main/java/com/hivemq/extensions/executor/PluginTaskExecutorServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/executor/PluginTaskExecutorServiceImpl.java
@@ -107,7 +107,7 @@ public class PluginTaskExecutorServiceImpl implements PluginTaskExecutorService 
         return taskExecutors[bucket];
     }
 
-    private static class PluginTaskExecutorServiceShutdownHook extends HiveMQShutdownHook {
+    private static class PluginTaskExecutorServiceShutdownHook implements HiveMQShutdownHook {
 
         private final @NotNull PluginTaskExecutor[] taskExecutors;
 

--- a/src/main/java/com/hivemq/extensions/ioc/ExtensionStartStopExecutorProvider.java
+++ b/src/main/java/com/hivemq/extensions/ioc/ExtensionStartStopExecutorProvider.java
@@ -50,7 +50,7 @@ public class ExtensionStartStopExecutorProvider implements Provider<ExecutorServ
         return executorService;
     }
 
-    private static class ExtensionStartStopExecutorShutdownHook extends HiveMQShutdownHook {
+    private static class ExtensionStartStopExecutorShutdownHook implements HiveMQShutdownHook {
 
         private final ExecutorService executorService;
 

--- a/src/main/java/com/hivemq/extensions/services/executor/ManagedPluginExecutorShutdownHook.java
+++ b/src/main/java/com/hivemq/extensions/services/executor/ManagedPluginExecutorShutdownHook.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * @author Florian Limpöck
  * @since 4.0.0
  */
-public class ManagedPluginExecutorShutdownHook extends HiveMQShutdownHook {
+public class ManagedPluginExecutorShutdownHook implements HiveMQShutdownHook {
 
     private static final Logger log = LoggerFactory.getLogger(ManagedPluginExecutorShutdownHook.class);
 

--- a/src/main/java/com/hivemq/lifecycle/LifecycleHiveMQShutdownHook.java
+++ b/src/main/java/com/hivemq/lifecycle/LifecycleHiveMQShutdownHook.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * @author Dominik Obermaier
  */
-public class LifecycleHiveMQShutdownHook extends HiveMQShutdownHook {
+public class LifecycleHiveMQShutdownHook implements HiveMQShutdownHook {
 
     private static final Logger log = LoggerFactory.getLogger(LifecycleHiveMQShutdownHook.class);
 

--- a/src/main/java/com/hivemq/metrics/MetricsShutdownHook.java
+++ b/src/main/java/com/hivemq/metrics/MetricsShutdownHook.java
@@ -28,7 +28,7 @@ import javax.inject.Singleton;
  * @author Lukas Brandl
  */
 @Singleton
-public class MetricsShutdownHook extends HiveMQShutdownHook {
+public class MetricsShutdownHook implements HiveMQShutdownHook {
 
     private final ShutdownHooks shutdownHooks;
     private final JmxReporterBootstrap jmxReporterBootstrap;

--- a/src/main/java/com/hivemq/persistence/PersistenceShutdownHook.java
+++ b/src/main/java/com/hivemq/persistence/PersistenceShutdownHook.java
@@ -42,7 +42,7 @@ import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENC
 /**
  * @author Lukas Brandl
  */
-public class PersistenceShutdownHook extends HiveMQShutdownHook {
+public class PersistenceShutdownHook implements HiveMQShutdownHook {
 
     private static final Logger log = LoggerFactory.getLogger(PersistenceShutdownHook.class);
 

--- a/src/main/java/com/hivemq/persistence/PersistenceStartup.java
+++ b/src/main/java/com/hivemq/persistence/PersistenceStartup.java
@@ -35,7 +35,7 @@ import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENC
  * @since 4.0.0
  */
 @Singleton
-public class PersistenceStartup extends HiveMQShutdownHook {
+public class PersistenceStartup implements HiveMQShutdownHook {
 
     private static final Logger log = LoggerFactory.getLogger(PersistenceStartup.class);
 

--- a/src/main/java/com/hivemq/throttling/GlobalTrafficShaperExecutorShutdownHook.java
+++ b/src/main/java/com/hivemq/throttling/GlobalTrafficShaperExecutorShutdownHook.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ScheduledExecutorService;
  *
  * @author Florian Limpoeck
  */
-public class GlobalTrafficShaperExecutorShutdownHook extends HiveMQShutdownHook {
+public class GlobalTrafficShaperExecutorShutdownHook implements HiveMQShutdownHook {
 
 
     private final ScheduledExecutorService executor;

--- a/src/test/java/com/hivemq/common/shutdown/ShutdownHooksTest.java
+++ b/src/test/java/com/hivemq/common/shutdown/ShutdownHooksTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.common.shutdown;
 
 import com.google.inject.AbstractModule;

--- a/src/test/java/com/hivemq/common/shutdown/ShutdownHooksTest.java
+++ b/src/test/java/com/hivemq/common/shutdown/ShutdownHooksTest.java
@@ -1,36 +1,18 @@
-/*
- * Copyright 2019-present HiveMQ GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hivemq.common.shutdown;
 
-import com.google.common.collect.Multimap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.hivemq.configuration.info.SystemInformation;
-import com.hivemq.configuration.info.SystemInformationImpl;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 
 public class ShutdownHooksTest {
 
@@ -41,67 +23,72 @@ public class ShutdownHooksTest {
     @Before
     public void setUp() throws Exception {
         executions = new ArrayList<>();
-        shutdownHooks = new ShutdownHooks(new SystemInformationImpl());
+        shutdownHooks = new ShutdownHooks();
         shutdownHooks.postConstruct();
         ShutdownHooks.SHUTTING_DOWN.set(false);
     }
 
+    @After
+    public void tearDown() throws Exception {
+        shutdownHooks.clearRuntime();
+    }
+
     @Test
-    public void test_singleton() throws Exception {
+    public void test_singleton() {
         final Injector injector = Guice.createInjector(new AbstractModule() {
-            @Override
-            protected void configure() {
-                bind(SystemInformation.class).toInstance(new SystemInformationImpl());
-            }
         });
 
         final ShutdownHooks instance = injector.getInstance(ShutdownHooks.class);
         final ShutdownHooks instance2 = injector.getInstance(ShutdownHooks.class);
         assertSame(instance, instance2);
-
     }
 
     @Test
-    public void test_hivemq_shutdown_thread_added() throws Exception {
-
-        assertEquals(0, shutdownHooks.getRegistry().size());
-        assertEquals(true, Runtime.getRuntime().removeShutdownHook(shutdownHooks.hivemqShutdownThread()));
+    public void test_hivemq_shutdown_thread_added() {
+        assertEquals(0, shutdownHooks.getSynchronousHooks().size());
+        assertTrue(Runtime.getRuntime().removeShutdownHook(shutdownHooks.hivemqShutdownThread()));
     }
 
     @Test
-    public void test_added_async_shutdown_hook() throws Exception {
+    public void test_added_async_shutdown_hook() {
 
-        final HiveMQShutdownHook shutdownHook =
-                createShutdownHook("name", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, true);
+        final HiveMQShutdownHook shutdownHook = createShutdownHook("name", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, true);
         shutdownHooks.add(shutdownHook);
 
-        assertEquals(0, shutdownHooks.getRegistry().size());
-        assertEquals(true, Runtime.getRuntime().removeShutdownHook(shutdownHook));
+        final Map<HiveMQShutdownHook, Thread> asyncShutdownHooks = shutdownHooks.getAsyncShutdownHooks();
+        assertEquals(1, asyncShutdownHooks.size());
+        assertEquals(0, shutdownHooks.getSynchronousHooks().size());
+
+        final Thread thread = asyncShutdownHooks.get(shutdownHook);
+        assertTrue(Runtime.getRuntime().removeShutdownHook(thread));
     }
 
     @Test
-    public void test_remove_async_shutdown_hook() throws Exception {
+    public void test_remove_async_shutdown_hook() {
 
-        final HiveMQShutdownHook shutdownHook =
-                createShutdownHook("name", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, true);
+        final HiveMQShutdownHook shutdownHook = createShutdownHook("name", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, true);
         shutdownHooks.add(shutdownHook);
 
-        assertEquals(0, shutdownHooks.getRegistry().size());
-        assertEquals(true, Runtime.getRuntime().removeShutdownHook(shutdownHook));
+        final Map<HiveMQShutdownHook, Thread> asyncShutdownHooks = shutdownHooks.getAsyncShutdownHooks();
+        assertEquals(1, asyncShutdownHooks.size());
+        assertEquals(0, shutdownHooks.getSynchronousHooks().size());
 
         shutdownHooks.remove(shutdownHook);
-        assertEquals(false, Runtime.getRuntime().removeShutdownHook(shutdownHook));
+
+        final Thread thread = asyncShutdownHooks.get(shutdownHook);
+        try {
+            assertFalse(Runtime.getRuntime().removeShutdownHook(thread));
+        } catch (final NullPointerException ignored) {
+            // This is expected as the hook is removed by remove().
+        }
     }
 
     @Test
-    public void test_added_sync_shutdown_hook() throws Exception {
-        final HiveMQShutdownHook shutdownHook =
-                createShutdownHook("name", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, false);
+    public void test_added_sync_shutdown_hook() {
+        final HiveMQShutdownHook shutdownHook = createShutdownHook("name", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, false);
         shutdownHooks.add(shutdownHook);
 
-        assertEquals(1, shutdownHooks.getRegistry().size());
-        //The shutdown hook wasn't added directly
-        assertEquals(false, Runtime.getRuntime().removeShutdownHook(shutdownHook));
+        assertEquals(1, shutdownHooks.getSynchronousHooks().size());
 
         shutdownHooks.hivemqShutdownThread().run();
 
@@ -109,33 +96,27 @@ public class ShutdownHooksTest {
     }
 
     @Test
-    public void test_removed_sync_shutdown_hook() throws Exception {
-        final HiveMQShutdownHook shutdownHook =
-                createShutdownHook("name", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, false);
+    public void test_removed_sync_shutdown_hook() {
+        final HiveMQShutdownHook shutdownHook = createShutdownHook("name", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, false);
         shutdownHooks.add(shutdownHook);
 
-        assertEquals(1, shutdownHooks.getRegistry().size());
-        //The shutdown hook wasn't added directly
-        assertEquals(false, Runtime.getRuntime().removeShutdownHook(shutdownHook));
+        assertEquals(1, shutdownHooks.getSynchronousHooks().size());
 
         shutdownHooks.remove(shutdownHook);
 
-        assertEquals(0, shutdownHooks.getRegistry().size());
+        assertEquals(0, shutdownHooks.getSynchronousHooks().size());
     }
 
     @Test
-    public void test_added_sync_shutdown_hooks_priorities() throws Exception {
-        final HiveMQShutdownHook shutdownHook =
-                createShutdownHook("hook1", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, false);
+    public void test_added_sync_shutdown_hooks_priorities() {
+        final HiveMQShutdownHook shutdownHook = createShutdownHook("hook1", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, false);
         final HiveMQShutdownHook shutdownHook2 = createShutdownHook("hook2", HiveMQShutdownHook.Priority.FIRST, false);
         final HiveMQShutdownHook shutdownHook3 = createShutdownHook("hook3", HiveMQShutdownHook.Priority.HIGH, false);
         shutdownHooks.add(shutdownHook);
         shutdownHooks.add(shutdownHook2);
         shutdownHooks.add(shutdownHook3);
 
-        assertEquals(3, shutdownHooks.getRegistry().size());
-        //The shutdown hook wasn't added directly
-        assertEquals(false, Runtime.getRuntime().removeShutdownHook(shutdownHook));
+        assertEquals(3, shutdownHooks.getSynchronousHooks().size());
 
         shutdownHooks.hivemqShutdownThread().run();
 
@@ -146,9 +127,8 @@ public class ShutdownHooksTest {
     }
 
     @Test
-    public void test_added_sync_shutdown_hooks_priorities_same_priorities() throws Exception {
-        final HiveMQShutdownHook shutdownHook =
-                createShutdownHook("hook1", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, false);
+    public void test_added_sync_shutdown_hooks_priorities_same_priorities() {
+        final HiveMQShutdownHook shutdownHook = createShutdownHook("hook1", HiveMQShutdownHook.Priority.DOES_NOT_MATTER, false);
         final HiveMQShutdownHook shutdownHook2 = createShutdownHook("hook2", HiveMQShutdownHook.Priority.HIGH, false);
         final HiveMQShutdownHook shutdownHook3 = createShutdownHook("hook3", HiveMQShutdownHook.Priority.HIGH, false);
         final HiveMQShutdownHook shutdownHook4 = createShutdownHook("hook4", HiveMQShutdownHook.Priority.HIGH, false);
@@ -157,9 +137,7 @@ public class ShutdownHooksTest {
         shutdownHooks.add(shutdownHook3);
         shutdownHooks.add(shutdownHook4);
 
-        assertEquals(4, shutdownHooks.getRegistry().size());
-        //The shutdown hook wasn't added directly
-        assertEquals(false, Runtime.getRuntime().removeShutdownHook(shutdownHook));
+        assertEquals(4, shutdownHooks.getSynchronousHooks().size());
 
         shutdownHooks.hivemqShutdownThread().run();
 
@@ -171,37 +149,31 @@ public class ShutdownHooksTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void test_add_null_to_shutdown_hooks() throws Exception {
-
+    public void test_add_null_to_shutdown_hooks() {
         shutdownHooks.add(null);
     }
 
     @Test
-    public void test_async_shutdown_hook_available_with_getAsyncShutdownHooks() throws Exception {
+    public void test_async_shutdown_hook_available_with_getAsyncShutdownHooks() {
 
         shutdownHooks.add(createShutdownHook("test", HiveMQShutdownHook.Priority.CRITICAL, true));
-        final Set<HiveMQShutdownHook> asyncShutdownHooks = shutdownHooks.getAsyncShutdownHooks();
-        assertEquals(1, asyncShutdownHooks.size());
 
+        assertEquals(1, shutdownHooks.getAsyncShutdownHooks().size());
         //Async shutdown hooks are not in the registry
-        final Multimap<Integer, HiveMQShutdownHook> registry = shutdownHooks.getRegistry();
-
-        assertEquals(0, registry.size());
-
+        assertEquals(0, shutdownHooks.getSynchronousHooks().size());
     }
 
     private HiveMQShutdownHook createShutdownHook(
             final String name, final HiveMQShutdownHook.Priority priority, final boolean isAsynchronous) {
+
         return new HiveMQShutdownHook() {
-            @NotNull
             @Override
-            public String name() {
+            public @NotNull String name() {
                 return name;
             }
 
-            @NotNull
             @Override
-            public Priority priority() {
+            public @NotNull Priority priority() {
                 return priority;
             }
 
@@ -216,5 +188,4 @@ public class ShutdownHooksTest {
             }
         };
     }
-
 }

--- a/src/test/java/com/hivemq/common/shutdown/ShutdownHooksTest.java
+++ b/src/test/java/com/hivemq/common/shutdown/ShutdownHooksTest.java
@@ -25,7 +25,6 @@ public class ShutdownHooksTest {
         executions = new ArrayList<>();
         shutdownHooks = new ShutdownHooks();
         shutdownHooks.postConstruct();
-        ShutdownHooks.SHUTTING_DOWN.set(false);
     }
 
     @After


### PR DESCRIPTION
**Motivation**
Improve code quality

Resolves #<issue>

**Changes**

Cleanup code: 
- Change HiveMQShutdownHook to an interface. 
- HiveMQShutdownHook extends Runnable instead of Thread. 
- Improve readability of ShutdownHooks.