### PR TITLE
Singleton support in LifecycleModule.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2021.1
+version=2021.2-SNAPSHOT
 #
 # main dependencies
 #

--- a/src/main/java/com/hivemq/codec/encoder/EncoderFactory.java
+++ b/src/main/java/com/hivemq/codec/encoder/EncoderFactory.java
@@ -16,7 +16,6 @@
 package com.hivemq.codec.encoder;
 
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import com.hivemq.codec.encoder.mqtt3.*;
 import com.hivemq.codec.encoder.mqtt5.*;
 import com.hivemq.configuration.service.SecurityConfigurationService;
@@ -48,6 +47,8 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * This factory is used to create encoders and encode messages.
  *
@@ -64,8 +65,8 @@ public class EncoderFactory {
 
     @Inject
     public EncoderFactory(final @NotNull MessageDroppedService messageDroppedService,
-            final @NotNull SecurityConfigurationService securityConfigurationService,
-            final @NotNull MqttServerDisconnector mqttServerDisconnector) {
+                          final @NotNull SecurityConfigurationService securityConfigurationService,
+                          final @NotNull MqttServerDisconnector mqttServerDisconnector) {
         mqtt5Instance = new Mqtt5EncoderFactory(messageDroppedService, securityConfigurationService);
         mqtt3Instance = new Mqtt3EncoderFactory(mqttServerDisconnector);
     }

--- a/src/main/java/com/hivemq/common/shutdown/ShutdownHooks.java
+++ b/src/main/java/com/hivemq/common/shutdown/ShutdownHooks.java
@@ -56,7 +56,6 @@ public class ShutdownHooks {
 
     private static final String SHUTDOWN_HOOK_THREAD_NAME = "shutdown-executor";
 
-    private final @NotNull AtomicBoolean constructed;
     private final @NotNull AtomicBoolean shuttingDown;
     private final @NotNull Map<HiveMQShutdownHook, Thread> asynchronousHooks;
     private final @NotNull Multimap<Integer, HiveMQShutdownHook> synchronousHooks;
@@ -65,7 +64,6 @@ public class ShutdownHooks {
 
     @Inject
     ShutdownHooks() {
-        constructed = new AtomicBoolean(false);
         shuttingDown = new AtomicBoolean(false);
 
         asynchronousHooks = new HashMap<>();
@@ -77,13 +75,6 @@ public class ShutdownHooks {
 
     @PostConstruct
     public void postConstruct() {
-        // During the HiveMQ start we are creating a persistence injector and later than a full injector.
-        // ShutdownHooks is bound in both injectors and each time it is bound the PostConstruct is called by the
-        // LifecycleModule.
-        if (constructed.getAndSet(true)) {
-            return;
-        }
-
         log.trace("Registering synchronous shutdown hook");
         createShutdownThread();
         Runtime.getRuntime().addShutdownHook(hivemqShutdownThread);

--- a/src/main/java/com/hivemq/configuration/HivemqId.java
+++ b/src/main/java/com/hivemq/configuration/HivemqId.java
@@ -15,8 +15,9 @@
  */
 package com.hivemq.configuration;
 
-import com.google.inject.Singleton;
 import org.apache.commons.lang3.RandomStringUtils;
+
+import javax.inject.Singleton;
 
 /**
  * @author Christoph Schäbel

--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -303,7 +303,7 @@ public class InternalConfigurations {
     public static final boolean SYSTEM_METRICS_ENABLED = true;
 
     // register metrics for jmx reporting on startup if enabled
-    public static final boolean JMX_REPORTER_ENABLED = true;
+    public static final AtomicBoolean JMX_REPORTER_ENABLED = new AtomicBoolean(true);
 
     /* *****************
      *      MQTT 5     *

--- a/src/main/java/com/hivemq/diagnostic/DiagnosticMode.java
+++ b/src/main/java/com/hivemq/diagnostic/DiagnosticMode.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -36,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author Dominik Obermaier
  */
+@Singleton
 public class DiagnosticMode {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(DiagnosticMode.class);
@@ -47,7 +49,6 @@ public class DiagnosticMode {
     private final DiagnosticData diagnosticData;
     private final SystemInformation systemInformation;
     private final MetricRegistry metricRegistry;
-
 
     @Inject
     DiagnosticMode(final DiagnosticData diagnosticData,

--- a/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
+++ b/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
@@ -34,6 +34,7 @@ import com.hivemq.embedded.EmbeddedExtension;
 import com.hivemq.embedded.EmbeddedHiveMQ;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
+import com.hivemq.lifecycle.LifecycleModule;
 import com.hivemq.persistence.PersistenceStartup;
 import com.hivemq.util.ThreadFactoryUtil;
 import org.slf4j.Logger;
@@ -148,7 +149,7 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
                 try {
                     configurationService = ConfigurationBootstrap.bootstrapConfig(systemInformation);
 
-                    if(configurationService.persistenceConfigurationService().getMode().equals(PersistenceConfigurationService.PersistenceMode.FILE)){
+                    if (configurationService.persistenceConfigurationService().getMode().equals(PersistenceConfigurationService.PersistenceMode.FILE)) {
                         log.info("Starting with file persistence mode.");
                     } else {
                         log.info("Starting with in-memory persistence mode.");
@@ -257,10 +258,12 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
     private void bootstrapInjector() {
         if (injector == null) {
             final HivemqId hiveMQId = new HivemqId();
+            final LifecycleModule lifecycleModule = new LifecycleModule();
             final Injector persistenceInjector = GuiceBootstrap.persistenceInjector(systemInformation,
                     metricRegistry,
                     hiveMQId,
-                    configurationService);
+                    configurationService,
+                    lifecycleModule);
 
             try {
                 persistenceInjector.getInstance(PersistenceStartup.class).finish();
@@ -272,7 +275,8 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
                     metricRegistry,
                     hiveMQId,
                     configurationService,
-                    persistenceInjector);
+                    persistenceInjector,
+                    lifecycleModule);
         }
     }
 

--- a/src/main/java/com/hivemq/extensions/handler/DisconnectInterceptorHandler.java
+++ b/src/main/java/com/hivemq/extensions/handler/DisconnectInterceptorHandler.java
@@ -17,7 +17,6 @@
 package com.hivemq.extensions.handler;
 
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.client.parameter.ClientInformation;
@@ -42,10 +41,14 @@ import com.hivemq.extensions.packets.disconnect.ModifiableOutboundDisconnectPack
 import com.hivemq.mqtt.message.disconnect.DISCONNECT;
 import com.hivemq.util.ChannelAttributes;
 import com.hivemq.util.Exceptions;
-import io.netty.channel.*;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPromise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/main/java/com/hivemq/extensions/handler/PluginAuthenticatorServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/handler/PluginAuthenticatorServiceImpl.java
@@ -18,7 +18,6 @@ package com.hivemq.extensions.handler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import com.hivemq.bootstrap.netty.ChannelDependencies;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.InternalConfigurations;
@@ -52,6 +51,7 @@ import com.hivemq.util.ReasonStrings;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 
+import javax.inject.Singleton;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 

--- a/src/main/java/com/hivemq/extensions/ioc/ExtensionStartStopExecutorProvider.java
+++ b/src/main/java/com/hivemq/extensions/ioc/ExtensionStartStopExecutorProvider.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.extensions.ioc;
 
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.common.shutdown.HiveMQShutdownHook;
 import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -31,6 +32,7 @@ import java.util.concurrent.ThreadFactory;
 /**
  * @author Georg Held
  */
+@LazySingleton
 public class ExtensionStartStopExecutorProvider implements Provider<ExecutorService> {
 
     private static final @NotNull Logger log = LoggerFactory.getLogger(ExtensionStartStopExecutorProvider.class);

--- a/src/main/java/com/hivemq/extensions/services/admin/AdminServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/admin/AdminServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.extensions.services.admin;
 
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.client.parameter.ServerInformation;
 import com.hivemq.extension.sdk.api.services.admin.AdminService;
@@ -27,6 +28,7 @@ import javax.inject.Inject;
 /**
  * @author Lukas Brandl
  */
+@LazySingleton
 public class AdminServiceImpl implements AdminService {
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/services/cluster/ClusterServiceNoopImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/cluster/ClusterServiceNoopImpl.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.extensions.services.cluster;
 
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.services.cluster.ClusterDiscoveryCallback;
 import com.hivemq.extension.sdk.api.services.cluster.ClusterService;
@@ -22,6 +23,7 @@ import com.hivemq.extension.sdk.api.services.cluster.ClusterService;
 /**
  * @author Silvio Giebl
  */
+@LazySingleton
 public class ClusterServiceNoopImpl implements ClusterService {
 
     @Override

--- a/src/main/java/com/hivemq/extensions/services/interceptor/GlobalInterceptorRegistryImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/interceptor/GlobalInterceptorRegistryImpl.java
@@ -16,6 +16,7 @@
 package com.hivemq.extensions.services.interceptor;
 
 import com.google.common.base.Preconditions;
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.connack.ConnackOutboundInterceptorProvider;
 import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptorProvider;
@@ -27,6 +28,7 @@ import javax.inject.Inject;
  * @author Lukas Brandl
  * @since 4.2.0
  */
+@LazySingleton
 public class GlobalInterceptorRegistryImpl implements GlobalInterceptorRegistry {
 
     @NotNull

--- a/src/main/java/com/hivemq/extensions/services/interceptor/InterceptorsImpl.java
+++ b/src/main/java/com/hivemq/extensions/services/interceptor/InterceptorsImpl.java
@@ -17,6 +17,7 @@
 package com.hivemq.extensions.services.interceptor;
 
 import com.google.common.collect.ImmutableMap;
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.interceptor.connack.ConnackOutboundInterceptorProvider;
 import com.hivemq.extension.sdk.api.interceptor.connect.ConnectInboundInterceptorProvider;
@@ -35,6 +36,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * @author Lukas Brandl
  * @author Florian Limpöck
  */
+@LazySingleton
 public class InterceptorsImpl implements Interceptors {
 
     @NotNull

--- a/src/main/java/com/hivemq/lifecycle/LifecycleModule.java
+++ b/src/main/java/com/hivemq/lifecycle/LifecycleModule.java
@@ -36,7 +36,7 @@ import java.lang.reflect.Modifier;
 /**
  * The Guice module which allows to use lifecycle annotations.
  * Lifecycle annotations which are supported at the moment are
- * <br/>
+ * <br>
  * * {@link javax.annotation.PostConstruct}
  * * {@link javax.annotation.PreDestroy}
  *
@@ -49,6 +49,10 @@ public class LifecycleModule extends SingletonModule<Class<LifecycleModule>> {
 
     private final @NotNull LifecycleRegistry lifecycleRegistry;
 
+    /**
+     * This class stores in the LifecycleRegistry for Singleton classes if their lifecycle methods are already invoked.
+     * Therefore should only one LifecycleModule object exist for the lifetime of the Application.
+     */
     public LifecycleModule() {
         super(LifecycleModule.class);
 

--- a/src/main/java/com/hivemq/lifecycle/LifecycleModule.java
+++ b/src/main/java/com/hivemq/lifecycle/LifecycleModule.java
@@ -23,6 +23,7 @@ import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
 import com.hivemq.bootstrap.ioc.SingletonModule;
 import com.hivemq.exceptions.UnrecoverableException;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,14 +32,12 @@ import javax.annotation.PreDestroy;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * The Guice module which allows to use lifecycle annotations.
  * Lifecycle annotations which are supported at the moment are
  * <br/>
- * <br/>
- * * {@link javax.annotation.PostConstruct} <br/>
+ * * {@link javax.annotation.PostConstruct}
  * * {@link javax.annotation.PreDestroy}
  *
  * @author Dominik Obermaier
@@ -48,57 +47,61 @@ public class LifecycleModule extends SingletonModule<Class<LifecycleModule>> {
 
     private static final Logger log = LoggerFactory.getLogger(LifecycleModule.class);
 
-    private static final AtomicReference<LifecycleModule> instance = new AtomicReference<>();
+    private final @NotNull LifecycleRegistry lifecycleRegistry;
 
-    private final AtomicReference<LifecycleRegistry> lifecycleRegistry = new AtomicReference<>();
-
-    public static LifecycleModule get() {
-        instance.compareAndSet(null, new LifecycleModule());
-        return instance.get();
-    }
-
-    private LifecycleModule() {
+    public LifecycleModule() {
         super(LifecycleModule.class);
+
+        lifecycleRegistry = new LifecycleRegistry();
     }
 
     @Override
     protected void configure() {
 
-        final boolean newRegistry = lifecycleRegistry.compareAndSet(null, new LifecycleRegistry());
-        bind(LifecycleRegistry.class).toInstance(lifecycleRegistry.get());
-
-        if (newRegistry) {
-            bind(LifecycleShutdownRegistration.class).asEagerSingleton();
-        }
+        bind(LifecycleRegistry.class).toInstance(lifecycleRegistry);
+        bind(LifecycleShutdownRegistration.class).asEagerSingleton();
 
         bindListener(Matchers.any(), new TypeListener() {
             @Override
             public <I> void hear(final TypeLiteral<I> type, final TypeEncounter<I> encounter) {
-                executePostConstruct(encounter, type.getRawType(), lifecycleRegistry.get());
+                executePostConstruct(encounter, type.getRawType());
             }
         });
     }
 
-    private <I> void executePostConstruct(final TypeEncounter<I> encounter, final Class<? super I> rawType,
-                                          final LifecycleRegistry lifecycleRegistry) {
+    private <I> void executePostConstruct(
+            final @NotNull TypeEncounter<I> encounter, final @NotNull Class<? super I> rawType) {
+
         //We're going recursive up to every superclass until we hit Object.class
         if (rawType.getSuperclass() != null) {
-            executePostConstruct(encounter, rawType.getSuperclass(), lifecycleRegistry);
+            executePostConstruct(encounter, rawType.getSuperclass());
         }
 
+        final boolean singleton = isSingleton(rawType);
         final Method postConstructFound = findPostConstruct(rawType);
         final Method preDestroy = findPreDestroy(rawType);
 
-        if (postConstructFound != null) {
-            invokePostConstruct(encounter, postConstructFound);
+        if (singleton) {
+            lifecycleRegistry.addSingletonClass(rawType);
         }
 
-        if (preDestroy != null) {
+        if (postConstructFound != null) {
+            if (lifecycleRegistry.canInvokePostConstruct(rawType)) {
+                invokePostConstruct(encounter, postConstructFound);
+            }
+        }
+        if (preDestroy != null && lifecycleRegistry.canInvokePreDestroy(rawType)) {
             addPreDestroyToRegistry(encounter, preDestroy, lifecycleRegistry);
         }
     }
 
-    private <I> Method findPostConstruct(final Class<? super I> rawType) {
+    private static <I> boolean isSingleton(final @NotNull Class<? super I> rawType) {
+        return rawType.isAnnotationPresent(javax.inject.Singleton.class)
+                || rawType.isAnnotationPresent(com.google.inject.Singleton.class)
+                || rawType.isAnnotationPresent(com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton.class);
+    }
+
+    private static <I> Method findPostConstruct(final @NotNull Class<? super I> rawType) {
         Method postConstructFound = null;
         for (final Method method : rawType.getDeclaredMethods()) {
             if (method.isAnnotationPresent(PostConstruct.class)) {
@@ -120,7 +123,7 @@ public class LifecycleModule extends SingletonModule<Class<LifecycleModule>> {
         return postConstructFound;
     }
 
-    private <I> Method findPreDestroy(final Class<? super I> rawType) {
+    private static <I> Method findPreDestroy(final @NotNull Class<? super I> rawType) {
         Method predestroyFound = null;
         for (final Method method : rawType.getDeclaredMethods()) {
             if (method.isAnnotationPresent(PreDestroy.class)) {
@@ -136,33 +139,29 @@ public class LifecycleModule extends SingletonModule<Class<LifecycleModule>> {
         return predestroyFound;
     }
 
-    private <I> void invokePostConstruct(final TypeEncounter<I> encounter, final Method postConstruct) {
-        encounter.register(new InjectionListener<I>() {
-            @Override
-            public void afterInjection(final I injectee) {
-                try {
-                    postConstruct.setAccessible(true);
-                    postConstruct.invoke(injectee);
-                } catch (final IllegalAccessException | InvocationTargetException e) {
-                    if (e.getCause() instanceof UnrecoverableException) {
-                        if (((UnrecoverableException) e.getCause()).isShowException()) {
-                            log.error("An unrecoverable Exception occurred. Exiting HiveMQ", e);
-                        }
-                        System.exit(1);
+    private static <I> void invokePostConstruct(
+            final @NotNull TypeEncounter<I> encounter, final @NotNull Method postConstruct) {
+
+        encounter.register((InjectionListener<I>) injectee -> {
+            try {
+                postConstruct.setAccessible(true);
+                postConstruct.invoke(injectee);
+            } catch (final IllegalAccessException | InvocationTargetException e) {
+                if (e.getCause() instanceof UnrecoverableException) {
+                    if (((UnrecoverableException) e.getCause()).isShowException()) {
+                        log.error("An unrecoverable Exception occurred. Exiting HiveMQ", e);
                     }
-                    throw new ProvisionException("An error occurred while calling @PostConstruct", e);
+                    System.exit(1);
                 }
+                throw new ProvisionException("An error occurred while calling @PostConstruct", e);
             }
         });
     }
 
-    private <I> void addPreDestroyToRegistry(final TypeEncounter<I> encounter, final Method preDestroy, final LifecycleRegistry registry) {
-        encounter.register(new InjectionListener<I>() {
-            @Override
-            public void afterInjection(final I injectee) {
-                registry.addPreDestroyMethod(preDestroy, injectee);
-
-            }
-        });
+    private static <I> void addPreDestroyToRegistry(
+            final @NotNull TypeEncounter<I> encounter,
+            final @NotNull Method preDestroy,
+            final @NotNull LifecycleRegistry lifecycleRegistry) {
+        encounter.register((InjectionListener<I>) injectionListener -> lifecycleRegistry.addPreDestroyMethod(preDestroy, injectionListener));
     }
 }

--- a/src/main/java/com/hivemq/lifecycle/LifecycleShutdownRegistration.java
+++ b/src/main/java/com/hivemq/lifecycle/LifecycleShutdownRegistration.java
@@ -19,10 +19,12 @@ import com.hivemq.common.shutdown.ShutdownHooks;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * @author Dominik Obermaier
  */
+@Singleton
 public class LifecycleShutdownRegistration {
 
     private final ShutdownHooks shutdownHooks;

--- a/src/main/java/com/hivemq/metrics/ioc/provider/OpenConnectionsGaugeProvider.java
+++ b/src/main/java/com/hivemq/metrics/ioc/provider/OpenConnectionsGaugeProvider.java
@@ -22,10 +22,12 @@ import io.netty.channel.group.ChannelGroup;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
 /**
  * @author Christoph Schäbel
  */
+@Singleton
 public class OpenConnectionsGaugeProvider implements Provider<OpenConnectionsGauge> {
 
     private final MetricRegistry metricRegistry;

--- a/src/main/java/com/hivemq/metrics/ioc/provider/RetainedMessagesGaugeProvider.java
+++ b/src/main/java/com/hivemq/metrics/ioc/provider/RetainedMessagesGaugeProvider.java
@@ -27,6 +27,7 @@ import javax.inject.Singleton;
 /**
  * @author Christoph Schäbel
  */
+@Singleton
 public class RetainedMessagesGaugeProvider implements Provider<RetainedMessagesGauge> {
 
     private final RetainedMessagePersistence retainedMessagePersistence;

--- a/src/main/java/com/hivemq/metrics/ioc/provider/SessionsGaugeProvider.java
+++ b/src/main/java/com/hivemq/metrics/ioc/provider/SessionsGaugeProvider.java
@@ -27,6 +27,7 @@ import javax.inject.Singleton;
 /**
  * @author Christoph Schäbel
  */
+@Singleton
 public class SessionsGaugeProvider implements Provider<SessionsGauge> {
 
     private final MetricRegistry metricRegistry;

--- a/src/main/java/com/hivemq/metrics/jmx/JmxReporterBootstrap.java
+++ b/src/main/java/com/hivemq/metrics/jmx/JmxReporterBootstrap.java
@@ -47,7 +47,7 @@ public class JmxReporterBootstrap {
 
     @PostConstruct
     public void postConstruct() {
-        if (!InternalConfigurations.JMX_REPORTER_ENABLED) {
+        if (!InternalConfigurations.JMX_REPORTER_ENABLED.get()) {
             return;
         }
         jmxReporter = JmxReporter.forRegistry(metricRegistry).build();

--- a/src/main/java/com/hivemq/metrics/jmx/JmxReporterBootstrap.java
+++ b/src/main/java/com/hivemq/metrics/jmx/JmxReporterBootstrap.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Lukas Brandl
@@ -36,8 +35,6 @@ public class JmxReporterBootstrap {
     private static final Logger log = LoggerFactory.getLogger(JmxReporterBootstrap.class);
 
     private final MetricRegistry metricRegistry;
-
-    private static final AtomicBoolean constructed = new AtomicBoolean(false);
 
     @VisibleForTesting
     JmxReporter jmxReporter;
@@ -50,9 +47,6 @@ public class JmxReporterBootstrap {
 
     @PostConstruct
     public void postConstruct() {
-        if (!constructed.compareAndSet(false, true)) {
-            return;
-        }
         if (!InternalConfigurations.JMX_REPORTER_ENABLED) {
             return;
         }

--- a/src/main/java/com/hivemq/mqtt/handler/connect/NoConnectIdleHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connect/NoConnectIdleHandler.java
@@ -16,7 +16,6 @@
 package com.hivemq.mqtt.handler.connect;
 
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.logging.EventLog;
 import com.hivemq.mqtt.message.connect.CONNECT;
@@ -29,6 +28,7 @@ import io.netty.handler.timeout.IdleStateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.NoSuchElementException;
 
 import static com.hivemq.bootstrap.netty.ChannelHandlerNames.NEW_CONNECTION_IDLE_HANDLER;

--- a/src/main/java/com/hivemq/mqtt/message/dropping/MessageDroppedServiceProvider.java
+++ b/src/main/java/com/hivemq/mqtt/message/dropping/MessageDroppedServiceProvider.java
@@ -20,10 +20,12 @@ import com.hivemq.metrics.MetricsHolder;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
 /**
  * @author Georg Held
  */
+@Singleton
 public class MessageDroppedServiceProvider implements Provider<MessageDroppedService> {
 
     private final MetricsHolder metricsHolder;

--- a/src/main/java/com/hivemq/mqtt/topic/tree/TopicTreeImpl.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/TopicTreeImpl.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -50,6 +51,7 @@ import static com.hivemq.configuration.service.InternalConfigurations.TOPIC_TREE
  *
  * @author Dominik Obermaier
  */
+@Singleton
 public class TopicTreeImpl implements LocalTopicTree {
 
 

--- a/src/main/java/com/hivemq/mqtt/topic/tree/TopicTreeStartup.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/TopicTreeStartup.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Set;
 
 import static com.hivemq.mqtt.message.connect.Mqtt5CONNECT.SESSION_EXPIRE_ON_DISCONNECT;
@@ -38,6 +39,7 @@ import static com.hivemq.persistence.clientsession.SharedSubscriptionServiceImpl
  *
  * @author Dominik Obermaier
  */
+@Singleton
 public class TopicTreeStartup {
 
     private static final Logger log = LoggerFactory.getLogger(TopicTreeStartup.class);

--- a/src/main/java/com/hivemq/persistence/ChannelPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/ChannelPersistenceImpl.java
@@ -20,6 +20,7 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import io.netty.channel.Channel;
 
+import javax.inject.Singleton;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @author Dominik Obermaier
  */
+@Singleton
 public class ChannelPersistenceImpl implements ChannelPersistence {
 
     private final @NotNull Map<String, Channel> channelMap;

--- a/src/main/java/com/hivemq/persistence/CleanUpService.java
+++ b/src/main/java/com/hivemq/persistence/CleanUpService.java
@@ -18,7 +18,6 @@ package com.hivemq.persistence;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.*;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
 import com.hivemq.persistence.clientsession.ClientSessionPersistence;
@@ -30,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/com/hivemq/persistence/PersistenceShutdownHookInstaller.java
+++ b/src/main/java/com/hivemq/persistence/PersistenceShutdownHookInstaller.java
@@ -20,10 +20,12 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.common.shutdown.ShutdownHooks;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
 
 /**
  * @author Lukas Brandl
  */
+@Singleton
 public class PersistenceShutdownHookInstaller {
 
     private final @NotNull ShutdownHooks shutdownHooks;

--- a/src/main/java/com/hivemq/persistence/PersistenceStartupShutdownHookInstaller.java
+++ b/src/main/java/com/hivemq/persistence/PersistenceStartupShutdownHookInstaller.java
@@ -20,10 +20,12 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.common.shutdown.ShutdownHooks;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
 
 /**
  * @author Florian Limpöck
  */
+@Singleton
 public class PersistenceStartupShutdownHookInstaller {
 
     private final @NotNull ShutdownHooks shutdownHooks;

--- a/src/main/java/com/hivemq/persistence/SingleWriterServiceImpl.java
+++ b/src/main/java/com/hivemq/persistence/SingleWriterServiceImpl.java
@@ -56,7 +56,6 @@ public class SingleWriterServiceImpl implements SingleWriterService {
     private final int creditsPerExecution;
     private final long shutdownGracePeriod;
 
-    private final @NotNull AtomicBoolean postConstruct = new AtomicBoolean(true);
     private final @NotNull AtomicLong nonemptyQueueCounter = new AtomicLong(0);
     private final @NotNull AtomicInteger runningThreadsCount = new AtomicInteger(0);
     private final @NotNull AtomicLong globalTaskCount = new AtomicLong(0);
@@ -106,11 +105,6 @@ public class SingleWriterServiceImpl implements SingleWriterService {
 
     @PostConstruct
     public void postConstruct() {
-
-        if (!postConstruct.getAndSet(false)) {
-            return;
-        }
-
         // Periodically check if there are pending tasks in the queues
         checkScheduler.scheduleAtFixedRate(() -> {
             try {

--- a/src/main/java/com/hivemq/persistence/ioc/provider/local/ClientSessionLocalProvider.java
+++ b/src/main/java/com/hivemq/persistence/ioc/provider/local/ClientSessionLocalProvider.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
 /**
  * The provider which is responsible for creating and providing the
@@ -30,6 +31,7 @@ import javax.inject.Provider;
  *
  * @author Dominik Obermaier
  */
+@Singleton
 public class ClientSessionLocalProvider implements Provider<ClientSessionLocalPersistence> {
 
     private static final Logger log = LoggerFactory.getLogger(ClientSessionLocalProvider.class);

--- a/src/main/java/com/hivemq/persistence/ioc/provider/local/ClientSessionSubscriptionLocalProvider.java
+++ b/src/main/java/com/hivemq/persistence/ioc/provider/local/ClientSessionSubscriptionLocalProvider.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
 /**
  * The provider which is responsible for creating and providing the
@@ -29,6 +30,7 @@ import javax.inject.Provider;
  *
  * @author Dominik Obermaier
  */
+@Singleton
 public class ClientSessionSubscriptionLocalProvider implements Provider<ClientSessionSubscriptionLocalPersistence> {
 
     private static final Logger log = LoggerFactory.getLogger(ClientSessionSubscriptionLocalProvider.class);

--- a/src/main/java/com/hivemq/persistence/ioc/provider/local/IncomingMessageFlowPersistenceLocalProvider.java
+++ b/src/main/java/com/hivemq/persistence/ioc/provider/local/IncomingMessageFlowPersistenceLocalProvider.java
@@ -16,6 +16,7 @@
 package com.hivemq.persistence.ioc.provider.local;
 
 
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.persistence.local.IncomingMessageFlowInMemoryLocalPersistence;
 import com.hivemq.persistence.local.IncomingMessageFlowLocalPersistence;
 import org.slf4j.Logger;
@@ -30,6 +31,7 @@ import javax.inject.Provider;
  *
  * @author Dominik Obermaier
  */
+@LazySingleton
 public class IncomingMessageFlowPersistenceLocalProvider implements Provider<IncomingMessageFlowLocalPersistence> {
 
     private static final Logger log = LoggerFactory.getLogger(IncomingMessageFlowPersistenceLocalProvider.class);

--- a/src/main/java/com/hivemq/persistence/local/rocksdb/RocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/rocksdb/RocksDBLocalPersistence.java
@@ -15,11 +15,11 @@
  */
 package com.hivemq.persistence.local.rocksdb;
 
-import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.exceptions.UnrecoverableException;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.persistence.FilePersistence;
 import com.hivemq.persistence.LocalPersistence;
-import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.persistence.PersistenceStartup;
 import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
 import com.hivemq.util.LocalPersistenceFileUtil;
@@ -42,7 +42,6 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
     protected final @NotNull RocksDB[] buckets;
     private final @NotNull LocalPersistenceFileUtil localPersistenceFileUtil;
     private final @NotNull PersistenceStartup persistenceStartup;
-    private final AtomicBoolean constructed = new AtomicBoolean(false);
     private final int bucketCount;
     private final int memtableSizePortion;
     private final int blockCacheSizePortion;
@@ -84,11 +83,6 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
     }
 
     protected void postConstruct() {
-
-        //Protect from multiple calls to post construct
-        if (constructed.getAndSet(true)) {
-            return;
-        }
         RocksDB.loadLibrary();
         if (enabled) {
             persistenceStartup.submitPersistenceStart(this);
@@ -193,7 +187,6 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
         init();
 
     }
-
 
 
     protected abstract void init();

--- a/src/main/java/com/hivemq/persistence/local/xodus/XodusLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/xodus/XodusLocalPersistence.java
@@ -15,8 +15,8 @@
  */
 package com.hivemq.persistence.local.xodus;
 
-import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.exceptions.UnrecoverableException;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.persistence.FilePersistence;
 import com.hivemq.persistence.LocalPersistence;
 import com.hivemq.persistence.PersistenceStartup;
@@ -44,7 +44,6 @@ public abstract class XodusLocalPersistence implements LocalPersistence, FilePer
     private final @NotNull EnvironmentUtil environmentUtil;
     private final @NotNull LocalPersistenceFileUtil localPersistenceFileUtil;
     private final @NotNull PersistenceStartup persistenceStartup;
-    private final AtomicBoolean constructed = new AtomicBoolean(false);
     protected final AtomicBoolean stopped = new AtomicBoolean(false);
 
     protected @NotNull Bucket[] buckets;
@@ -89,12 +88,7 @@ public abstract class XodusLocalPersistence implements LocalPersistence, FilePer
     protected abstract Logger getLogger();
 
     protected void postConstruct() {
-
-        //Protect from multiple calls to post construct
-        if (constructed.getAndSet(true)) {
-            return;
-        }
-        if(enabled) {
+        if (enabled) {
             persistenceStartup.submitPersistenceStart(this);
         } else {
             startExternal();

--- a/src/main/java/com/hivemq/persistence/retained/RetainedMessagePersistenceProvider.java
+++ b/src/main/java/com/hivemq/persistence/retained/RetainedMessagePersistenceProvider.java
@@ -23,6 +23,7 @@ import javax.inject.Provider;
 /**
  * @author Christoph Schäbel
  */
+@LazySingleton
 public class RetainedMessagePersistenceProvider implements Provider<RetainedMessagePersistence> {
 
     private final Provider<RetainedMessagePersistenceImpl> provider;

--- a/src/main/java/com/hivemq/persistence/util/FutureUtilsImpl.java
+++ b/src/main/java/com/hivemq/persistence/util/FutureUtilsImpl.java
@@ -23,12 +23,14 @@ import com.google.inject.Inject;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.persistence.ioc.annotation.Persistence;
 
+import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.Set;
 
 /**
  * @author Lukas Brandl
  */
+@Singleton
 public class FutureUtilsImpl extends AbstractFutureUtils {
 
     private final @NotNull ListeningExecutorService persistenceExecutorService;

--- a/src/main/java/com/hivemq/security/ssl/SslContextStore.java
+++ b/src/main/java/com/hivemq/security/ssl/SslContextStore.java
@@ -20,6 +20,7 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.inject.Inject;
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.configuration.service.entity.Tls;
 import com.hivemq.exceptions.UnrecoverableException;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -49,6 +50,7 @@ import static com.hivemq.configuration.service.InternalConfigurations.SSL_RELOAD
 /**
  * @author Christoph Schäbel
  */
+@LazySingleton
 public class SslContextStore {
 
     private static final @NotNull Logger log = LoggerFactory.getLogger(SslContextStore.class);

--- a/src/main/java/com/hivemq/security/ssl/SslFactory.java
+++ b/src/main/java/com/hivemq/security/ssl/SslFactory.java
@@ -18,6 +18,7 @@ package com.hivemq.security.ssl;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.configuration.service.entity.Listener;
 import com.hivemq.configuration.service.entity.Tls;
 import com.hivemq.exceptions.UnrecoverableException;
@@ -41,6 +42,7 @@ import java.util.Set;
 /**
  * @author Christoph Schäbel
  */
+@LazySingleton
 public class SslFactory {
 
     private final @NotNull SslContextStore sslContextStore;

--- a/src/main/java/com/hivemq/throttling/ioc/GlobalTrafficShapingProvider.java
+++ b/src/main/java/com/hivemq/throttling/ioc/GlobalTrafficShapingProvider.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -37,6 +38,7 @@ import java.util.concurrent.ThreadFactory;
  * @author Florian Limpoeck
  * @author Dominik Obermaier
  */
+@Singleton
 public class GlobalTrafficShapingProvider implements Provider<GlobalTrafficShapingHandler> {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalTrafficShapingProvider.class);
@@ -44,14 +46,12 @@ public class GlobalTrafficShapingProvider implements Provider<GlobalTrafficShapi
     private final @NotNull ShutdownHooks registry;
     private final @NotNull RestrictionsConfigurationService restrictionsConfigurationService;
 
-
     @Inject
     GlobalTrafficShapingProvider(final @NotNull ShutdownHooks registry,
                                  final @NotNull RestrictionsConfigurationService restrictionsConfigurationService) {
 
         this.registry = registry;
         this.restrictionsConfigurationService = restrictionsConfigurationService;
-
     }
 
     @Override

--- a/src/main/java/com/hivemq/util/EnvVarUtil.java
+++ b/src/main/java/com/hivemq/util/EnvVarUtil.java
@@ -15,13 +15,13 @@
  */
 package com.hivemq.util;
 
-import com.google.inject.Singleton;
+import com.hivemq.exceptions.UnrecoverableException;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
-import com.hivemq.exceptions.UnrecoverableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/test/java/com/hivemq/bootstrap/LoggingBootstrapTest.java
+++ b/src/test/java/com/hivemq/bootstrap/LoggingBootstrapTest.java
@@ -60,6 +60,7 @@ public class LoggingBootstrapTest {
 
     @After
     public void tearDown() throws Exception {
+        LogbackCapturingAppender.Factory.cleanUp();
         final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
         logger.setLevel(level);

--- a/src/test/java/com/hivemq/codec/decoder/mqtt5/AbstractMqttDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt5/AbstractMqttDecoderTest.java
@@ -36,6 +36,7 @@ public class AbstractMqttDecoderTest {
 
     @After
     public void tearDown() {
+        LogbackCapturingAppender.Factory.cleanUp();
         channel.close();
     }
 

--- a/src/test/java/com/hivemq/configuration/service/impl/SecurityConfigurationServiceImplTest.java
+++ b/src/test/java/com/hivemq/configuration/service/impl/SecurityConfigurationServiceImplTest.java
@@ -17,6 +17,7 @@ package com.hivemq.configuration.service.impl;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,11 @@ public class SecurityConfigurationServiceImplTest {
         initMocks(this);
         final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         logCapture = LogbackCapturingAppender.Factory.weaveInto(logger);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LogbackCapturingAppender.Factory.cleanUp();
     }
 
     @Test

--- a/src/test/java/com/hivemq/lifecycle/LifecycleModuleTest.java
+++ b/src/test/java/com/hivemq/lifecycle/LifecycleModuleTest.java
@@ -62,7 +62,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void postConstructWhenNormalClassThenEveryTime() throws Exception {
+    public void postConstruct_whenNormalClass_thenEveryTime() throws Exception {
 
         final WithPostConstruct instance = injector.getInstance(WithPostConstruct.class);
         assertEquals(0, instance.getLatch().getCount());
@@ -74,7 +74,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void postConstructWhenJavaxSingletonClassThenOnce() throws Exception {
+    public void postConstruct_whenJavaxSingletonClass_thenOnce() throws Exception {
 
         final JavaxSingletonWithPostConstruct instance = injector.getInstance(JavaxSingletonWithPostConstruct.class);
         assertEquals(0, instance.getLatch().getCount());
@@ -86,7 +86,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void postConstructWhenGoogleSingletonClassThenOnce() throws Exception {
+    public void postConstruct_whenGoogleSingletonClass_thenOnce() throws Exception {
 
         final GoogleSingletonWithPostConstruct instance = injector.getInstance(GoogleSingletonWithPostConstruct.class);
         assertEquals(0, instance.getLatch().getCount());
@@ -98,7 +98,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void postConstructWhenLazySingletonClassThenOnce() throws Exception {
+    public void postConstruct_whenLazySingletonClass_thenOnce() throws Exception {
 
         final LazySingletonWithPostConstruct instance = injector.getInstance(LazySingletonWithPostConstruct.class);
         assertEquals(0, instance.getLatch().getCount());
@@ -362,7 +362,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void preDestroyWhenNormalClassThenEveryTime() throws Exception {
+    public void preDestroy_whenNormalClass_thenEveryTime() throws Exception {
 
         final WithPreDestroy instance = injector.getInstance(WithPreDestroy.class);
 
@@ -382,7 +382,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void preDestroyWhenJavaxSingletonClassThenOnce() throws Exception {
+    public void preDestroy_whenJavaxSingletonClass_thenOnce() throws Exception {
 
         final JavaxSingletonWithPreDestroy instance = injector.getInstance(JavaxSingletonWithPreDestroy.class);
 
@@ -402,7 +402,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void preDestroyWhenGoogleSingletonClassThenOnce() throws Exception {
+    public void preDestroy_whenGoogleSingletonClass_thenOnce() throws Exception {
 
         final GoogleSingletonWithPreDestroy instance = injector.getInstance(GoogleSingletonWithPreDestroy.class);
 
@@ -422,7 +422,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void preDestroyWhenLazySingletonClassThenOnce() throws Exception {
+    public void preDestroy_whenLazySingletonClass_thenOnce() throws Exception {
 
         final LazySingletonWithPreDestroy instance = injector.getInstance(LazySingletonWithPreDestroy.class);
 
@@ -560,7 +560,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void lifecycleMethodsWhenNormalClassThenEveryTime() throws Exception {
+    public void lifecycleMethods_whenNormalClass_thenEveryTime() throws Exception {
         final WithPreDestroyAndPostConstruct instance = injector.getInstance(WithPreDestroyAndPostConstruct.class);
         assertEquals(1, instance.getPreDestroyLatch().getCount());
         assertEquals(0, instance.getPostConstructLatch().getCount());
@@ -583,7 +583,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void lifecycleMethodsWhenJavaxSingletonClassThenOnce() throws Exception {
+    public void lifecycleMethods_whenJavaxSingletonClass_thenOnce() throws Exception {
         final JavaxSingletonWithPreDestroyAndPostConstruct instance = injector.getInstance(JavaxSingletonWithPreDestroyAndPostConstruct.class);
         assertEquals(1, instance.getPreDestroyLatch().getCount());
         assertEquals(0, instance.getPostConstructLatch().getCount());
@@ -605,7 +605,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void lifecycleMethodsWhenGoogleSingletonClassThenOnce() throws Exception {
+    public void lifecycleMethods_whenGoogleSingletonClass_thenOnce() throws Exception {
         final GoogleSingletonWithPreDestroyAndPostConstruct instance = injector.getInstance(GoogleSingletonWithPreDestroyAndPostConstruct.class);
         assertEquals(1, instance.getPreDestroyLatch().getCount());
         assertEquals(0, instance.getPostConstructLatch().getCount());
@@ -627,7 +627,7 @@ public class LifecycleModuleTest {
     }
 
     @Test
-    public void lifecycleMethodsWhenLazySingletonClassThenOnce() throws Exception {
+    public void lifecycleMethods_whenLazySingletonClass_thenOnce() throws Exception {
         final LazySingletonWithPreDestroyAndPostConstruct instance = injector.getInstance(LazySingletonWithPreDestroyAndPostConstruct.class);
         assertEquals(1, instance.getPreDestroyLatch().getCount());
         assertEquals(0, instance.getPostConstructLatch().getCount());

--- a/src/test/java/com/hivemq/logging/EventLogTest.java
+++ b/src/test/java/com/hivemq/logging/EventLogTest.java
@@ -19,6 +19,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.hivemq.util.ChannelAttributes;
 import io.netty.channel.Channel;
 import io.netty.util.Attribute;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -75,6 +76,11 @@ public class EventLogTest {
         when(channel.attr(ChannelAttributes.DISCONNECT_EVENT_LOGGED)).thenReturn(attributeDisconnectEventLogged);
 
         logMessageBuffer = new StringBuffer();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LogbackCapturingAppender.Factory.cleanUp();
     }
 
     @Test

--- a/src/test/java/com/hivemq/metrics/jmx/JmxReporterBootstrapTest.java
+++ b/src/test/java/com/hivemq/metrics/jmx/JmxReporterBootstrapTest.java
@@ -1,45 +1,19 @@
-/*
- * Copyright 2019-present HiveMQ GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hivemq.metrics.jmx;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.jmx.JmxReporter;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Lukas Brandl
  */
 public class JmxReporterBootstrapTest {
 
-    @Before
-    public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void test_post_construct_twice() {
+    public void postConstructWhenEnabledThenReporterIsCreated() {
         final JmxReporterBootstrap jmxReporterBootstrap = new JmxReporterBootstrap(new MetricRegistry());
         jmxReporterBootstrap.postConstruct();
-        final JmxReporter firstReporter = jmxReporterBootstrap.jmxReporter;
-        jmxReporterBootstrap.postConstruct();
-        final JmxReporter secondReporter = jmxReporterBootstrap.jmxReporter;
-        assertSame(firstReporter, secondReporter);
+        assertNotNull(jmxReporterBootstrap.jmxReporter);
     }
 }

--- a/src/test/java/com/hivemq/metrics/jmx/JmxReporterBootstrapTest.java
+++ b/src/test/java/com/hivemq/metrics/jmx/JmxReporterBootstrapTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.metrics.jmx;
 
 import com.codahale.metrics.MetricRegistry;

--- a/src/test/java/com/hivemq/migration/logging/PayloadExceptionLoggingTest.java
+++ b/src/test/java/com/hivemq/migration/logging/PayloadExceptionLoggingTest.java
@@ -18,6 +18,7 @@ package com.hivemq.migration.logging;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.hivemq.migration.Migrations;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -43,7 +44,11 @@ public class PayloadExceptionLoggingTest {
         payloadExceptionLogging = new PayloadExceptionLogging();
         migrationLogger = LoggerFactory.getLogger(Migrations.MIGRATION_LOGGER_NAME);
         capturingAppender = LogbackCapturingAppender.Factory.weaveInto(migrationLogger);
+    }
 
+    @After
+    public void tearDown() throws Exception {
+        LogbackCapturingAppender.Factory.cleanUp();
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/hivemq/migration/persistence/payload/PublishPayloadTypeMigrationTest.java
+++ b/src/test/java/com/hivemq/migration/persistence/payload/PublishPayloadTypeMigrationTest.java
@@ -25,6 +25,7 @@ import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.InternalConfigurations;
+import com.hivemq.lifecycle.LifecycleModule;
 import com.hivemq.migration.MigrationUnit;
 import com.hivemq.migration.Migrations;
 import com.hivemq.migration.meta.MetaFileService;
@@ -105,7 +106,7 @@ public class PublishPayloadTypeMigrationTest {
         assertEquals(PersistenceType.FILE_NATIVE, migrations.get(MigrationUnit.FILE_PERSISTENCE_PUBLISH_PAYLOAD));
 
         final Injector persistenceInjector =
-                GuiceBootstrap.persistenceInjector(systemInformation, new MetricRegistry(), new HivemqId(), configurationService);
+                GuiceBootstrap.persistenceInjector(systemInformation, new MetricRegistry(), new HivemqId(), configurationService, new LifecycleModule());
         final PersistenceStartup persistenceStartup = persistenceInjector.getInstance(PersistenceStartup.class);
         persistenceStartup.finish();
 
@@ -143,7 +144,7 @@ public class PublishPayloadTypeMigrationTest {
         assertEquals(1, migrations.size());
         assertEquals(PersistenceType.FILE, migrations.get(MigrationUnit.FILE_PERSISTENCE_PUBLISH_PAYLOAD));
 
-        final Injector persistenceInjector = GuiceBootstrap.persistenceInjector(systemInformation, new MetricRegistry(), new HivemqId(), configurationService);
+        final Injector persistenceInjector = GuiceBootstrap.persistenceInjector(systemInformation, new MetricRegistry(), new HivemqId(), configurationService, new LifecycleModule());
         final PersistenceStartup persistenceStartup = persistenceInjector.getInstance(PersistenceStartup.class);
         persistenceStartup.finish();
 
@@ -181,7 +182,7 @@ public class PublishPayloadTypeMigrationTest {
         assertEquals(1, migrations.size());
         assertFalse(migrations.containsKey(MigrationUnit.FILE_PERSISTENCE_PUBLISH_PAYLOAD));
 
-        final Injector persistenceInjector = GuiceBootstrap.persistenceInjector(systemInformation, new MetricRegistry(), new HivemqId(), configurationService);
+        final Injector persistenceInjector = GuiceBootstrap.persistenceInjector(systemInformation, new MetricRegistry(), new HivemqId(), configurationService, new LifecycleModule());
         final PersistenceStartup persistenceStartup = persistenceInjector.getInstance(PersistenceStartup.class);
         persistenceStartup.finish();
 

--- a/src/test/java/com/hivemq/migration/persistence/retained/RetainedMessageTypeMigrationTest.java
+++ b/src/test/java/com/hivemq/migration/persistence/retained/RetainedMessageTypeMigrationTest.java
@@ -25,6 +25,7 @@ import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.service.FullConfigurationService;
 import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.lifecycle.LifecycleModule;
 import com.hivemq.migration.MigrationUnit;
 import com.hivemq.migration.Migrations;
 import com.hivemq.migration.logging.PayloadExceptionLogging;
@@ -159,7 +160,8 @@ public class RetainedMessageTypeMigrationTest {
         final Injector persistenceInjector = GuiceBootstrap.persistenceInjector(systemInformation,
                 new MetricRegistry(),
                 new HivemqId(),
-                configurationService);
+                configurationService,
+                new LifecycleModule());
         final PersistenceStartup persistenceStartup = persistenceInjector.getInstance(PersistenceStartup.class);
         persistenceStartup.finish();
 
@@ -210,7 +212,8 @@ public class RetainedMessageTypeMigrationTest {
         final Injector persistenceInjector = GuiceBootstrap.persistenceInjector(systemInformation,
                 new MetricRegistry(),
                 new HivemqId(),
-                configurationService);
+                configurationService,
+                new LifecycleModule());
         final PersistenceStartup persistenceStartup = persistenceInjector.getInstance(PersistenceStartup.class);
         persistenceStartup.finish();
 
@@ -266,7 +269,8 @@ public class RetainedMessageTypeMigrationTest {
         final Injector persistenceInjector = GuiceBootstrap.persistenceInjector(systemInformation,
                 new MetricRegistry(),
                 new HivemqId(),
-                configurationService);
+                configurationService,
+                new LifecycleModule());
         final PersistenceStartup persistenceStartup = persistenceInjector.getInstance(PersistenceStartup.class);
         persistenceStartup.finish();
 
@@ -292,7 +296,6 @@ public class RetainedMessageTypeMigrationTest {
         assertEquals(RetainedMessageXodusLocalPersistence.PERSISTENCE_VERSION,
                 metaInformation.getRetainedMessagesPersistenceVersion());
         InternalConfigurations.RETAINED_MESSAGE_PERSISTENCE_TYPE.set(PersistenceType.FILE_NATIVE);
-
     }
 
     @NotNull

--- a/src/test/java/com/hivemq/mqtt/handler/connack/MqttConnackerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connack/MqttConnackerTest.java
@@ -69,6 +69,7 @@ public class MqttConnackerTest {
 
     @After
     public void tearDown() throws Exception {
+        LogbackCapturingAppender.Factory.cleanUp();
         InternalConfigurations.CONNACK_WITH_REASON_CODE.set(true);
         InternalConfigurations.CONNACK_WITH_REASON_STRING.set(true);
     }

--- a/src/test/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandlerTest.java
@@ -27,6 +27,7 @@ import com.hivemq.util.ChannelAttributes;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -63,6 +64,11 @@ public class MessageExpiryHandlerTest {
         channel.pipeline().addLast(messageExpiryHandler);
         when(ctx.channel()).thenReturn(channel);
         logCapture = LogbackCapturingAppender.Factory.weaveInto(MessageExpiryHandler.log);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LogbackCapturingAppender.Factory.cleanUp();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImplTest.java
@@ -18,6 +18,7 @@ package com.hivemq.persistence.payload;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.hivemq.configuration.service.InternalConfigurations;
 import net.openhft.hashing.LongHashFunction;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -61,6 +62,11 @@ public class PublishPayloadPersistenceImplTest {
         persistence = new PublishPayloadPersistenceImpl(localPersistence, scheduledExecutorService);
         persistence.init();
         logCapture = LogbackCapturingAppender.Factory.weaveInto(PublishPayloadPersistenceImpl.log);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LogbackCapturingAppender.Factory.cleanUp();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
@@ -68,6 +68,7 @@ public class PublishPayloadRocksDBLocalPersistenceTest {
 
     @After
     public void cleanUp() throws InterruptedException {
+        LogbackCapturingAppender.Factory.cleanUp();
         InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.set(64);
         InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH.set(true);
         persistence.closeDB();

--- a/src/test/java/com/hivemq/security/ssl/SslFactoryTest.java
+++ b/src/test/java/com/hivemq/security/ssl/SslFactoryTest.java
@@ -27,6 +27,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -74,6 +75,11 @@ public class SslFactoryTest {
         when(socketChannel.alloc()).thenReturn(byteBufAllocator);
 
         testKeyStoreGenerator = new TestKeyStoreGenerator();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LogbackCapturingAppender.Factory.cleanUp();
     }
 
     @Test

--- a/src/test/java/util/LogbackCapturingAppender.java
+++ b/src/test/java/util/LogbackCapturingAppender.java
@@ -42,9 +42,13 @@ import java.util.List;
  *
  * @author Dominik Obermaier
  */
-public class LogbackCapturingAppender extends AppenderBase<ILoggingEvent> {
+public final class LogbackCapturingAppender extends AppenderBase<ILoggingEvent> {
     public static class Factory {
+
         private static final List<LogbackCapturingAppender> ALL = new ArrayList<LogbackCapturingAppender>();
+
+        private Factory() {
+        }
 
         public static LogbackCapturingAppender weaveInto(final org.slf4j.Logger sl4jLogger) {
             final LogbackCapturingAppender appender = new LogbackCapturingAppender(sl4jLogger);
@@ -58,7 +62,6 @@ public class LogbackCapturingAppender extends AppenderBase<ILoggingEvent> {
                 appender.cleanUp();
             }
         }
-
     }
 
     private final Logger log;
@@ -67,7 +70,7 @@ public class LogbackCapturingAppender extends AppenderBase<ILoggingEvent> {
     private final List<ILoggingEvent> allCaptured = new ArrayList<ILoggingEvent>();
 
     public LogbackCapturingAppender(final org.slf4j.Logger sl4jLogger) {
-        this.log = (Logger) sl4jLogger;
+        log = (Logger) sl4jLogger;
         addAppender(log);
         detachDefaultConsoleAppender();
     }
@@ -85,7 +88,7 @@ public class LogbackCapturingAppender extends AppenderBase<ILoggingEvent> {
     private void addAppender(final Logger logger) {
         logger.setLevel(Level.ALL);
         logger.addAppender(this);
-        this.start();
+        start();
     }
 
     public ILoggingEvent getLastCapturedLog() {


### PR DESCRIPTION
**Motivation**
The LifecycleModule adds support for PostConstruct and PreDestroy lifecycle methods for classes that are bound in an Injector. Currently we are guarding these lifecycle methods of Singleton classes with a boolean to avoid invoking them a second time. The functionality to avoid a second invocation can be moved into the LifecycleModule.

Resolves #<issue>

**Changes**
The LifecycleRegistry stores now all singleton classes and the invoke status of their lifecycle methods. They are then invoked based on their status.
