### PR TITLE
Deactivate Memory Mapped Files by default

### DIFF
--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -196,7 +196,7 @@ public class InternalConfigurations {
      */
     public static final AtomicBoolean ACKNOWLEDGE_AFTER_PERSIST = new AtomicBoolean(true);
 
-    public static final boolean XODUS_LOG_CACHE_USE_NIO = true;
+    public static final boolean XODUS_LOG_CACHE_USE_NIO = false;
 
     /**
      * The live time of a entry in the shared subscription cache in milliseconds


### PR DESCRIPTION
**Motivation**

Resolves an issue where memory mapped files were created by Xodus that lead to OOM

**Changes**

Internal Option is now false (reflects changes from the internal default by Xodus)