### PR TITLE
ID:1575 Define explicit object names for Dropwizard JMX Reporter

### DIFF
--- a/src/main/java/com/hivemq/metrics/jmx/JmxReporterBootstrap.java
+++ b/src/main/java/com/hivemq/metrics/jmx/JmxReporterBootstrap.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hivemq.metrics.jmx;
 
 import com.codahale.metrics.MetricRegistry;
@@ -25,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 
 /**
  * @author Lukas Brandl
@@ -42,7 +45,6 @@ public class JmxReporterBootstrap {
     @Inject
     public JmxReporterBootstrap(final MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
-
     }
 
     @PostConstruct
@@ -50,7 +52,32 @@ public class JmxReporterBootstrap {
         if (!InternalConfigurations.JMX_REPORTER_ENABLED.get()) {
             return;
         }
-        jmxReporter = JmxReporter.forRegistry(metricRegistry).build();
+        /*
+         * The default object name factory in Dropwizard Metrics for JMX reporter was updated and changes the format.
+         * We need to support the old format as our customers are using them for their integrations.
+         * <p>
+         * - Old name format, that we support:  "metrics:name=kafka-extension.total.success.count"
+         * - New name format:                   "metrics:name=kafka-extension.total.success.count,type=counters"
+         * <p>
+         * The behavior was changed in this commit: https://github.com/dropwizard/metrics/pull/1310/files
+         * The code below was copied also from this commit.
+         */
+        jmxReporter = JmxReporter.forRegistry(metricRegistry).createsObjectNamesWith((type, domain, name) -> {
+            try {
+                ObjectName objectName = new ObjectName(domain, "name", name);
+                if (objectName.isPattern()) {
+                    objectName = new ObjectName(domain, "name", ObjectName.quote(name));
+                }
+                return objectName;
+            } catch (final MalformedObjectNameException e) {
+                try {
+                    return new ObjectName(domain, "name", ObjectName.quote(name));
+                } catch (final MalformedObjectNameException e1) {
+                    log.warn("Unable to register {} {}", type, name, e1);
+                    throw new RuntimeException(e1);
+                }
+            }
+        }).build();
         jmxReporter.start();
         log.debug("Started JMX Metrics Reporting.");
     }

--- a/src/test/java/com/hivemq/metrics/jmx/JmxReporterBootstrapTest.java
+++ b/src/test/java/com/hivemq/metrics/jmx/JmxReporterBootstrapTest.java
@@ -13,11 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hivemq.metrics.jmx;
 
 import com.codahale.metrics.MetricRegistry;
 import org.junit.Test;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -30,5 +37,63 @@ public class JmxReporterBootstrapTest {
         final JmxReporterBootstrap jmxReporterBootstrap = new JmxReporterBootstrap(new MetricRegistry());
         jmxReporterBootstrap.postConstruct();
         assertNotNull(jmxReporterBootstrap.jmxReporter);
+    }
+
+    @Test
+    public void objectNameWhenCounterMetricRequestedThenHasExpectedFormat() throws Exception {
+        final MetricRegistry metricRegistry = new MetricRegistry();
+        final JmxReporterBootstrap jmxReporterBootstrap = new JmxReporterBootstrap(metricRegistry);
+        jmxReporterBootstrap.postConstruct();
+
+        metricRegistry.counter("my-counter").inc();
+
+        final MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+        final ObjectName metricNameObject = new ObjectName("metrics:name=my-counter");
+        final Object attribute = platformMBeanServer.getAttribute(metricNameObject, "Count");
+        assertNotNull(attribute);
+
+        final double metricValue = Double.parseDouble(attribute.toString());
+        assertEquals(1, metricValue, 0);
+
+        jmxReporterBootstrap.stop();
+    }
+
+    @Test
+    public void objectNameWhenGaugeMetricRequestedThenHasExpectedFormat() throws Exception {
+        final MetricRegistry metricRegistry = new MetricRegistry();
+        final JmxReporterBootstrap jmxReporterBootstrap = new JmxReporterBootstrap(metricRegistry);
+        jmxReporterBootstrap.postConstruct();
+
+        final AtomicInteger integer = new AtomicInteger(0);
+        metricRegistry.gauge("my-gauge", () -> () -> integer.incrementAndGet());
+
+        final MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+        final ObjectName metricNameObject = new ObjectName("metrics:name=my-gauge");
+        final Object attribute = platformMBeanServer.getAttribute(metricNameObject, "Value");
+        assertNotNull(attribute);
+
+        final double metricValue = Double.parseDouble(attribute.toString());
+        assertEquals(integer.get(), metricValue, 0);
+
+        jmxReporterBootstrap.stop();
+    }
+
+    @Test
+    public void objectNameWhenHistogramMetricRequestedThenHasExpectedFormat() throws Exception {
+        final MetricRegistry metricRegistry = new MetricRegistry();
+        final JmxReporterBootstrap jmxReporterBootstrap = new JmxReporterBootstrap(metricRegistry);
+        jmxReporterBootstrap.postConstruct();
+
+        metricRegistry.histogram("my-histogram").update(1);
+
+        final MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+        final ObjectName metricNameObject = new ObjectName("metrics:name=my-histogram");
+        final Object attribute = platformMBeanServer.getAttribute(metricNameObject, "Mean");
+        assertNotNull(attribute);
+
+        final double metricValue = Double.parseDouble(attribute.toString());
+        assertEquals(1, metricValue, 0);
+
+        jmxReporterBootstrap.stop();
     }
 }


### PR DESCRIPTION
**Motivation**
The default object name factory in Dropwizard Metrics for JMX reporter was updated and changes the format.

We need to support the old format as our customers are using them for their integrations.
- Old name format, that we support:  "metrics:name=kafka-extension.total.success.count"
- New name format:                   "metrics:name=kafka-extension.total.success.count,type=counters"

The behavior was changed in this commit: https://github.com/dropwizard/metrics/pull/1310/files

Resolves #<issue>

**Changes**
Use old behavior to create generate object names of the metrics.