### PR TITLE
Bugfix Avoid false-positive warnings when starting in embedded mode

### DIFF
--- a/src/main/java/com/hivemq/configuration/info/SystemInformationImpl.java
+++ b/src/main/java/com/hivemq/configuration/info/SystemInformationImpl.java
@@ -100,9 +100,9 @@ public class SystemInformationImpl implements SystemInformation {
 
     private void setFolders() {
         setHomeFolder();
-        configFolder = Objects.requireNonNullElse(
+        configFolder = Objects.requireNonNullElseGet(
                 configFolder,
-                setUpHiveMQFolder(
+                () -> setUpHiveMQFolder(
                         SystemProperties.CONFIG_FOLDER,
                         EnvironmentVariables.CONFIG_FOLDER,
                         "conf",
@@ -114,9 +114,9 @@ public class SystemInformationImpl implements SystemInformation {
         // Set log folder property for logger-xml-config
         System.setProperty(SystemProperties.LOG_FOLDER, logFolder.getAbsolutePath());
 
-        dataFolder = Objects.requireNonNullElse(
+        dataFolder = Objects.requireNonNullElseGet(
                 dataFolder,
-                setUpHiveMQFolder(
+                () -> setUpHiveMQFolder(
                         SystemProperties.DATA_FOLDER,
                         EnvironmentVariables.DATA_FOLDER,
                         "data",
@@ -124,9 +124,9 @@ public class SystemInformationImpl implements SystemInformation {
                 )
         );
 
-        pluginFolder = Objects.requireNonNullElse(
+        pluginFolder = Objects.requireNonNullElseGet(
                 pluginFolder,
-                setUpHiveMQFolder(
+                () -> setUpHiveMQFolder(
                         SystemProperties.EXTENSIONS_FOLDER,
                         EnvironmentVariables.EXTENSION_FOLDER,
                         "extensions",


### PR DESCRIPTION
**Motivation**

Resolves #299 by resolving the default folders only when they are not provided. This even fixes some not yet reported bug where when running it while developing some application some folder inside the local maven repository gets created (where `hivemq-community-edition-embedded-2021.2.jar` is stored).

**Changes**

Changed from `Objects.requireNonNullElse` to `Objects.requireNonNullElseGet` in order to evaluate only when object was `null`.