### PR TITLE
Update to log after the operation is complete

### DIFF
--- a/src/main/java/com/hivemq/bootstrap/LoggingBootstrap.java
+++ b/src/main/java/com/hivemq/bootstrap/LoggingBootstrap.java
@@ -165,7 +165,6 @@ public class LoggingBootstrap {
     private static boolean overrideLogbackXml(final @NotNull File configFolder) {
         final File file = new File(configFolder, "logback.xml");
         if (file.canRead()) {
-            log.info("Log Configuration was overridden by {}", file.getAbsolutePath());
             final LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
             try {
                 context.reset();
@@ -175,6 +174,7 @@ public class LoggingBootstrap {
                 configurator.doConfigure(file);
 
                 context.getLogger(Logger.ROOT_LOGGER_NAME).addAppender(listAppender);
+                log.info("Log Configuration was overridden by {}", file.getAbsolutePath());
                 return true;
             } catch (final JoranException je) {
                 // StatusPrinter will handle this


### PR DESCRIPTION
**Motivation**
This message shouldn't be outputted until after the operation is complete. Also if the operation is successful, the message logged will use the new overriden logger instead of the old one.

**Changes**
Moved log message to a location after the overriding operation.