### PR TITLE
[REFACTORING] Added units to internal config names

### DIFF
--- a/src/main/java/com/hivemq/HiveMQServer.java
+++ b/src/main/java/com/hivemq/HiveMQServer.java
@@ -200,7 +200,7 @@ public class HiveMQServer {
 
         final HiveMQInstance instance = injector.getInstance(HiveMQInstance.class);
 
-        if (InternalConfigurations.GC_AFTER_STARTUP) {
+        if (InternalConfigurations.GC_AFTER_STARTUP_ENABLED) {
             log.trace("Starting initial garbage collection after startup");
             final long start = System.currentTimeMillis();
             //Start garbage collection of objects we don't need anymore after starting up

--- a/src/main/java/com/hivemq/bootstrap/HiveMQNettyBootstrap.java
+++ b/src/main/java/com/hivemq/bootstrap/HiveMQNettyBootstrap.java
@@ -69,8 +69,8 @@ public class HiveMQNettyBootstrap {
     public @NotNull ListenableFuture<List<ListenerStartupInformation>> bootstrapServer() {
 
         //Adding shutdown hook for graceful shutdown
-        final int shutdownTimeout = InternalConfigurations.EVENT_LOOP_GROUP_SHUTDOWN_TIMEOUT;
-        final int channelsShutdownTimeout = InternalConfigurations.CHANNEL_PERSISTENCE_SHUTDOWN_TIMEOUT;
+        final int shutdownTimeout = InternalConfigurations.EVENT_LOOP_GROUP_SHUTDOWN_TIMEOUT_SEC;
+        final int channelsShutdownTimeout = InternalConfigurations.CONNECTION_PERSISTENCE_SHUTDOWN_TIMEOUT_SEC;
         shutdownHooks.add(new NettyShutdownHook(
                 nettyConfiguration.getChildEventLoopGroup(),
                 nettyConfiguration.getParentEventLoopGroup(),
@@ -203,8 +203,8 @@ public class HiveMQNettyBootstrap {
      */
     private void setAdvancedOptions(final @NotNull ServerBootstrap b) {
 
-        final int sendBufferSize = InternalConfigurations.LISTENER_SOCKET_SEND_BUFFER_SIZE;
-        final int receiveBufferSize = InternalConfigurations.LISTENER_SOCKET_RECEIVE_BUFFER_SIZE;
+        final int sendBufferSize = InternalConfigurations.LISTENER_SOCKET_SEND_BUFFER_SIZE_BYTES;
+        final int receiveBufferSize = InternalConfigurations.LISTENER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES;
 
         if (sendBufferSize > -1) {
             b.childOption(ChannelOption.SO_SNDBUF, sendBufferSize);
@@ -213,8 +213,8 @@ public class HiveMQNettyBootstrap {
             b.childOption(ChannelOption.SO_RCVBUF, receiveBufferSize);
         }
 
-        final int writeBufferHigh = InternalConfigurations.LISTENER_CLIENT_WRITE_BUFFER_HIGH_THRESHOLD;
-        final int writeBufferLow = InternalConfigurations.LISTENER_CLIENT_WRITE_BUFFER_LOW_THRESHOLD;
+        final int writeBufferHigh = InternalConfigurations.LISTENER_CLIENT_WRITE_BUFFER_HIGH_THRESHOLD_BYTES;
+        final int writeBufferLow = InternalConfigurations.LISTENER_CLIENT_WRITE_BUFFER_LOW_THRESHOLD_BYTES;
 
         final ClientWriteBufferProperties properties =
                 Validators.validateWriteBufferProperties(new ClientWriteBufferProperties(writeBufferHigh,

--- a/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
+++ b/src/main/java/com/hivemq/bootstrap/netty/initializer/AbstractChannelInitializer.java
@@ -53,7 +53,7 @@ public abstract class AbstractChannelInitializer extends ChannelInitializer<Chan
         this.channelDependencies = channelDependencies;
         this.listener = listener;
         final boolean incomingEnabled = channelDependencies.getRestrictionsConfigurationService().incomingLimit() > 0;
-        final boolean outgoingEnabled = InternalConfigurations.OUTGOING_BANDWIDTH_THROTTLING_DEFAULT > 0;
+        final boolean outgoingEnabled = InternalConfigurations.OUTGOING_BANDWIDTH_THROTTLING_DEFAULT_BYTES_PER_SEC > 0;
         legacyNettyShutdown = InternalConfigurations.NETTY_SHUTDOWN_LEGACY;
         throttlingEnabled = incomingEnabled || outgoingEnabled;
     }

--- a/src/main/java/com/hivemq/codec/decoder/AbstractMqttConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/AbstractMqttConnectDecoder.java
@@ -58,7 +58,7 @@ public abstract class AbstractMqttConnectDecoder extends MqttDecoder<CONNECT> {
         this.mqttConnacker = mqttConnacker;
         this.clientIds = clientIds;
         validateUTF8 = configurationService.securityConfiguration().validateUTF8();
-        maxUserPropertiesLength = InternalConfigurations.USER_PROPERTIES_MAX_SIZE;
+        maxUserPropertiesLength = InternalConfigurations.USER_PROPERTIES_MAX_SIZE_BYTES;
         maxSessionExpiryInterval = configurationService.mqttConfiguration().maxSessionExpiryInterval();
         allowAssignedClientId = configurationService.securityConfiguration().allowServerAssignedClientId();
     }

--- a/src/main/java/com/hivemq/codec/decoder/AbstractMqttDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/AbstractMqttDecoder.java
@@ -65,7 +65,7 @@ public abstract class AbstractMqttDecoder<T extends Message> extends MqttDecoder
         this.disconnector = disconnector;
         validateUTF8 = configurationService.securityConfiguration().validateUTF8();
         maxMessageExpiryInterval = configurationService.mqttConfiguration().maxMessageExpiryInterval();
-        maxUserPropertiesLength = InternalConfigurations.USER_PROPERTIES_MAX_SIZE;
+        maxUserPropertiesLength = InternalConfigurations.USER_PROPERTIES_MAX_SIZE_BYTES;
         subscriptionIdentifiersAvailable = configurationService.mqttConfiguration().subscriptionIdentifierEnabled();
     }
 

--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -159,8 +159,19 @@ public class InternalConfigurations {
     // The bucket count for the payload persistence.
     public static final AtomicInteger PAYLOAD_PERSISTENCE_BUCKET_COUNT = new AtomicInteger(64);
 
+    public static final AtomicBoolean PUBLISH_PAYLOAD_FORCE_FLUSH_ENABLED = new AtomicBoolean(true);
+
     //The type of storage underlying the payload persistence (for example, rocks db or xodus).
     public static final AtomicReference<PersistenceType> PAYLOAD_PERSISTENCE_TYPE = new AtomicReference<>(PersistenceType.FILE_NATIVE);
+
+    //The memory that is used for rocksdb memtable as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+    public static final AtomicInteger PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION = new AtomicInteger(32);
+
+    //The memory that is used for rocksdb block-cache as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+    public static final AtomicInteger PAYLOAD_PERSISTENCE_BLOCK_CACHE_SIZE_PORTION = new AtomicInteger(64);
+
+    //The block size used by rocksdb for the retained message persistence
+    public static final int PAYLOAD_PERSISTENCE_BLOCK_SIZE_BYTES = 32 * 1024; // 32 KB
 
     // If this flag is true, then on an attempt to decrement a reference counter that was already zero, a stacktrace will be logged to warn (by default logged to debug)
     public static final boolean LOG_REFERENCE_COUNTING_STACKTRACE_AS_WARNING = false;
@@ -187,15 +198,6 @@ public class InternalConfigurations {
     public static final long SHARED_SUBSCRIPTION_CACHE_TIME_TO_LIVE_MSEC = 1000;
 
     public static final int SHARED_SUBSCRIPTION_CACHE_MAX_SIZE_SUBSCRIPTIONS = 10000;
-
-    //The memory that is used for rocksdb memtable as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
-    public static final AtomicInteger PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION = new AtomicInteger(32);
-
-    //The memory that is used for rocksdb block-cache as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
-    public static final AtomicInteger PAYLOAD_PERSISTENCE_BLOCK_CACHE_SIZE_PORTION = new AtomicInteger(64);
-
-    //The block size used by rocksdb for the retained message persistence
-    public static final int PAYLOAD_PERSISTENCE_BLOCK_SIZE_BYTES = 32 * 1024; // 32 KB
 
     // The period with which stats are written to the LOG file. Periodic writes are disabled when set to '0'.
     public static final int ROCKSDB_STATS_PERSIST_PERIOD_SEC = 0;
@@ -314,5 +316,4 @@ public class InternalConfigurations {
 
     public static final AtomicInteger AUTH_PROCESS_TIMEOUT_SEC = new AtomicInteger(30);
 
-    public static final AtomicBoolean PUBLISH_PAYLOAD_FORCE_FLUSH_ENABLED = new AtomicBoolean(true);
 }

--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -251,18 +251,15 @@ public class InternalConfigurations {
      *******************/
 
     public static final boolean SSL_RELOAD_ENABLED = true;
-    public static final int SSL_RELOAD_INTERVAL = 10;
+    public static final int SSL_RELOAD_INTERVAL_SEC = 10;
 
-    /**
-     * Executes a Garbage collection after the initialization of HiveMQ
-     */
-    public static final boolean GC_AFTER_STARTUP = true;
+    public static final boolean GC_AFTER_STARTUP_ENABLED = true;
 
     /* *****************
      *      Metrics     *
      *******************/
 
-    //Toggles for system metrics via oshi
+    //Toggles for system metrics via OSHI
     public static final boolean SYSTEM_METRICS_ENABLED = true;
 
     // register metrics for jmx reporting on startup if enabled
@@ -272,98 +269,50 @@ public class InternalConfigurations {
      *      MQTT 5     *
      *******************/
 
-    /**
-     * the global memory hard limit topic aliases may use in bytes.
-     */
-    public static final AtomicInteger TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT = new AtomicInteger(1024 * 1024 * 200); //200Mb
+    public static final AtomicInteger TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT_BYTES = new AtomicInteger(1024 * 1024 * 200); //200Mb
+    public static final AtomicInteger TOPIC_ALIAS_GLOBAL_MEMORY_SOFT_LIMIT_BYTES = new AtomicInteger(1024 * 1024 * 50); //50Mb
 
-    /**
-     * the global memory soft limit topic aliases may use in bytes.
-     */
-    public static final AtomicInteger TOPIC_ALIAS_GLOBAL_MEMORY_SOFT_LIMIT = new AtomicInteger(1024 * 1024 * 50); //50Mb
-    /**
-     * Disconnect Client with reason code?
-     */
-    public static final AtomicBoolean DISCONNECT_WITH_REASON_CODE = new AtomicBoolean(true);
+    public static final AtomicBoolean DISCONNECT_WITH_REASON_CODE_ENABLED = new AtomicBoolean(true);
+    public static final AtomicBoolean DISCONNECT_WITH_REASON_STRING_ENABLED = new AtomicBoolean(true);
 
-    /**
-     * Disconnect Client with reason string?
-     */
-    public static final AtomicBoolean DISCONNECT_WITH_REASON_STRING = new AtomicBoolean(true);
+    public static final AtomicBoolean CONNACK_WITH_REASON_CODE_ENABLED = new AtomicBoolean(true);
+    public static final AtomicBoolean CONNACK_WITH_REASON_STRING_ENABLED = new AtomicBoolean(true);
 
-    /**
-     * Send CONNACK with reason code?
-     */
-    public static final AtomicBoolean CONNACK_WITH_REASON_CODE = new AtomicBoolean(true);
+    public static final int USER_PROPERTIES_MAX_SIZE_BYTES = 1024 * 1024 * 5; //5Mb
 
-    /**
-     * Send CONNACK with reason string?
-     */
-    public static final AtomicBoolean CONNACK_WITH_REASON_STRING = new AtomicBoolean(true);
-
-    /**
-     * The maximum allowed size of the user properties in bytes
-     */
-    public static final int USER_PROPERTIES_MAX_SIZE = 1024 * 1024 * 5; //5Mb
-
-
-    /**
-     * Log the clients reason string when they send a DISCONNECT?
-     */
-    public static final boolean LOG_CLIENT_REASON_STRING_ON_DISCONNECT = true;
+    public static final boolean LOG_CLIENT_REASON_STRING_ON_DISCONNECT_ENABLED = true;
 
     /* *****************
      *    Statistics   *
      *******************/
 
-    /**
-     * Interval in minutes for the anonymous usage statistics
-     */
-    public static final int STATISTICS_SEND_EVERY_MINUTES = 1440; //24h
+    public static final int USAGE_STATISTICS_SEND_INTERVAL_MINUTES = 1440; //24h
 
 
     /* ***********************
      *    Extension System   *
      *************************/
 
-    /**
-     * Amount of threads used for the extension task queues
-     */
-    public static final AtomicInteger PLUGIN_TASK_QUEUE_EXECUTOR_COUNT = new AtomicInteger(AVAILABLE_PROCESSORS);
+    public static final AtomicInteger EXTENSION_TASK_QUEUE_EXECUTOR_THREADS_COUNT = new AtomicInteger(AVAILABLE_PROCESSORS);
+    public static final AtomicInteger MANAGED_EXTENSION_THREAD_POOL_KEEP_ALIVE_SEC = new AtomicInteger(30);
+    public static final AtomicInteger MANAGED_EXTENSION_THREAD_POOL_THREADS_COUNT = new AtomicInteger(AVAILABLE_PROCESSORS);
 
     /**
-     * The keep alive of the managed extension executor service thread pool
+     * The amount of time the extension executor shutdown awaits task termination until shutdownNow() is called.
      */
-    public static final AtomicInteger MANAGED_PLUGIN_THREAD_POOL_KEEP_ALIVE_SECONDS = new AtomicInteger(30);
+    public static final AtomicInteger MANAGED_EXTENSION_EXECUTOR_SHUTDOWN_TIMEOUT_SEC = new AtomicInteger(180);
 
-    /**
-     * Amount of threads used for the managed extension executor service
-     */
-    public static final AtomicInteger MANAGED_PLUGIN_THREAD_POOL_SIZE = new AtomicInteger(AVAILABLE_PROCESSORS);
-
-    /**
-     * The amount of time the extension executor shutdown awaits task termination until shutdownNow() is called. In
-     * seconds.
-     */
-    public static final AtomicInteger MANAGED_PLUGIN_EXECUTOR_SHUTDOWN_TIMEOUT = new AtomicInteger(180);
-
-    /**
-     * The amount of service calls the extension system is allowed to do per second.
-     */
-    public static final AtomicInteger PLUGIN_SERVICE_RATE_LIMIT = new AtomicInteger(0); //unlimited
+    public static final AtomicInteger EXTENSION_SERVICE_CALL_RATE_LIMIT_PER_SEC = new AtomicInteger(0); //unlimited
 
     /* ********************
      *        Auth        *
      **********************/
     /**
-     * Denies the bypassing of authentication if no authenticator is registered
+     * Denies bypassing of authentication if no authenticator is registered.
      */
     public static final AtomicBoolean AUTH_DENY_UNAUTHENTICATED_CONNECTIONS = new AtomicBoolean(true);
 
-    /**
-     * The timeout in seconds between two auth steps
-     */
-    public static final AtomicInteger AUTH_PROCESS_TIMEOUT = new AtomicInteger(30);
+    public static final AtomicInteger AUTH_PROCESS_TIMEOUT_SEC = new AtomicInteger(30);
 
-    public static final AtomicBoolean PUBLISH_PAYLOAD_FORCE_FLUSH = new AtomicBoolean(true);
+    public static final AtomicBoolean PUBLISH_PAYLOAD_FORCE_FLUSH_ENABLED = new AtomicBoolean(true);
 }

--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -50,14 +50,14 @@ public class InternalConfigurations {
      *****************/
 
     // The "persistence shutdown grace period" represents the time span,
-    // in which single writer tasks are still processed after the persistence shutdown hook was called (in milliseconds).
-    public static final AtomicInteger PERSISTENCE_SHUTDOWN_GRACE_PERIOD = new AtomicInteger(2000);
+    // in which single writer tasks are still processed after the persistence shutdown hook was called.
+    public static final AtomicInteger PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC = new AtomicInteger(2000);
 
-    //timeout to wait in seconds for persistence shutdown to finish on HiveMQ shutdown
-    public static final AtomicInteger PERSISTENCE_SHUTDOWN_TIMEOUT = new AtomicInteger(300);
+    //timeout to wait for persistence shutdown to finish on HiveMQ shutdown
+    public static final AtomicInteger PERSISTENCE_SHUTDOWN_TIMEOUT_SEC = new AtomicInteger(300);
 
-    //timeout to wait in seconds for persistence startup executors shutdown to finish on HiveMQ shutdown
-    public static final AtomicInteger PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT = new AtomicInteger(300);
+    //timeout to wait for persistence startup executors shutdown to finish on HiveMQ shutdown
+    public static final AtomicInteger PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT_SEC = new AtomicInteger(300);
 
     //the factor to multiply core size with to calculate thread count for initializing persistences
     public static final AtomicInteger PERSISTENCE_STARTUP_THREAD_POOL_SIZE = new AtomicInteger(AVAILABLE_PROCESSORS_TIMES_FOUR);
@@ -65,10 +65,10 @@ public class InternalConfigurations {
     public static final AtomicInteger PERSISTENCE_BUCKET_COUNT = new AtomicInteger(64);
     public static final AtomicInteger SINGLE_WRITER_THREAD_POOL_SIZE = new AtomicInteger(AVAILABLE_PROCESSORS_TIMES_TWO);
     public static final AtomicInteger SINGLE_WRITER_CREDITS_PER_EXECUTION = new AtomicInteger(65);
-    public static final AtomicInteger SINGLE_WRITER_CHECK_SCHEDULE = new AtomicInteger(500);
+    public static final AtomicInteger SINGLE_WRITER_INTERVAL_TO_CHECK_PENDING_TASKS_AND_SCHEDULE_MSEC = new AtomicInteger(500);
 
     public static final AtomicInteger PERSISTENCE_CLOSE_RETRIES = new AtomicInteger(500);
-    public static final AtomicInteger PERSISTENCE_CLOSE_RETRY_INTERVAL = new AtomicInteger(100);
+    public static final AtomicInteger PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC = new AtomicInteger(100);
 
     //max amount of subscriptions to pull from the peristence for extension iterate chunk
     public static final int PERSISTENCE_SUBSCRIPTIONS_MAX_CHUNK_SIZE = 2000;
@@ -77,7 +77,7 @@ public class InternalConfigurations {
     public static final int PERSISTENCE_CLIENT_SESSIONS_MAX_CHUNK_SIZE = 2000;
 
     //max amount of memory for retained messages to pull from the peristence for extension iterate chunk
-    public static final int PERSISTENCE_RETAINED_MESSAGES_MAX_CHUNK_MEMORY = 10485760; //10 MByte
+    public static final int PERSISTENCE_RETAINED_MESSAGES_MAX_CHUNK_MEMORY_BYTES = 10485760; //10 MByte
 
     //The threshold at which the topic tree starts to map entries instead of storing them in an array
     public static final AtomicInteger TOPIC_TREE_MAP_CREATION_THRESHOLD = new AtomicInteger(16);
@@ -85,49 +85,45 @@ public class InternalConfigurations {
     public static final AtomicInteger QOS_0_MEMORY_HARD_LIMIT_DIVISOR = new AtomicInteger(4);
 
     // The configuration for qos 0 memory limit per client, must be greater than 0.
-    public static final AtomicInteger QOS_0_MEMORY_LIMIT_PER_CLIENT = new AtomicInteger(1024 * 1024 * 5);
+    public static final AtomicInteger QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES = new AtomicInteger(1024 * 1024 * 5);
 
     // The configuration for shared sub caching of publish without packet-id
-    public static final AtomicInteger SHARED_SUBSCRIPTION_WITHOUT_PACKET_ID_CACHE_MAX_SIZE = new AtomicInteger(10000);
-
-    // The  expiry in seconds for entries of the cache for the first publish without packetId for shared subscriptions
-    public static final AtomicInteger SHARED_SUBSCRIPTION_WITHOUT_PACKET_ID_CACHE_EXPIRY_SECONDS = new AtomicInteger(60);
+    public static final AtomicInteger SHARED_SUBSCRIPTION_WITHOUT_PACKET_ID_CACHE_MAX_SIZE_ENTRIES = new AtomicInteger(10000);
 
     // The amount of qos 0 messages that are queued if the channel is not writable
     public static final AtomicInteger NOT_WRITABLE_QUEUE_SIZE = new AtomicInteger(1000);
 
     // The limit of unacknowledged messages that hivemq will handle, regardless of the client receive maximum
-    public static int MAX_INFLIGHT_WINDOW_SIZE = 50;
+    public static int MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 50;
 
-
-    //The maximum allowed size of the passed value for the ConnectionAttributeStore in bytes
-    public static final int CONNECTION_ATTRIBUTE_STORE_MAX_VALUE_SIZE = 10240; //10Kb
+    //The maximum allowed size of the passed value for the ConnectionAttributeStore
+    public static final int CONNECTION_ATTRIBUTE_STORE_MAX_VALUE_SIZE_BYTES = 10240; //10Kb
 
     // The configuration for xodus persistence environment jmx
     public static final boolean XODUS_PERSISTENCE_ENVIRONMENT_JMX = false;
     // The configuration for xodus persistence environment garbage collection type
     public static final GCType XODUS_PERSISTENCE_ENVIRONMENT_GC_TYPE = GCType.DELETE;
-    // The configuration for xodus persistence environment garbage collection deletion delay in ms
-    public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_DELETION_DELAY = 60000;
-    // The configuration for xodus persistence environment garbage collection run period in ms
-    public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_RUN_PERIOD = 30000;
+    // The configuration for xodus persistence environment garbage collection deletion delay
+    public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_DELETION_DELAY_MSEC = 60000;
+    // The configuration for xodus persistence environment garbage collection run period
+    public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_RUN_PERIOD_MSEC = 30000;
     // The configuration for xodus persistence environment garbage collection files interval
     public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_FILES_INTERVAL = 1;
     // The configuration for xodus persistence environment garbage collection min age
     public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_MIN_AGE = 2;
-    // The configuration for xodus persistence environment sync period in ms
-    public static final int XODUS_PERSISTENCE_ENVIRONMENT_SYNC_PERIOD = 1000;
+    // The configuration for xodus persistence environment sync period
+    public static final int XODUS_PERSISTENCE_ENVIRONMENT_SYNC_PERIOD_MSEC = 1000;
     // The configuration for xodus persistence environment durable writes
-    public static final boolean XODUS_PERSISTENCE_ENVIRONMENT_DURABLE_WRITES = false;
-    // The the memory limit used by the xodus environments in percentage of the JVM heap (Xmx).
-    public static final int XODUS_PERSISTENCE_LOG_MEMORY_PERCENTAGE = 25;
+    public static final boolean XODUS_PERSISTENCE_ENVIRONMENT_DURABLE_WRITES_ENABLED = false;
+    // The memory limit used by the xodus environments in percentage of the JVM heap (Xmx).
+    public static final int XODUS_PERSISTENCE_LOG_MEMORY_HEAP_PERCENTAGE = 25;
 
 
     // The amount of publishes that are polled per batch
     public static int PUBLISH_POLL_BATCH_SIZE = 50;
 
-    // The amount of bytes that are polled per batch
-    public static final int PUBLISH_POLL_BATCH_MEMORY = 1024 * 1024 * 5; // 5Mb
+    // The amount of bytes that are polled per batch (one publish min)
+    public static final int PUBLISH_POLL_BATCH_SIZE_BYTES = 1024 * 1024 * 5; // 5Mb
 
     // The amount of qos > 0 retained messages that are queued
     public static final AtomicInteger RETAINED_MESSAGE_QUEUE_SIZE = new AtomicInteger(100_000);
@@ -141,32 +137,32 @@ public class InternalConfigurations {
     //The memory that is used for rocksdb block-cache as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
     public static final int RETAINED_MESSAGE_BLOCK_CACHE_SIZE_PORTION = 64;
 
-    //The block size used by rocksdb for the retained message persistence in bytes
-    public static final int RETAINED_MESSAGE_BLOCK_SIZE = 32 * 1024;
+    //The block size used by rocksdb for the retained message persistence
+    public static final int RETAINED_MESSAGE_BLOCK_SIZE_BYTES = 32 * 1024;
 
     /* ************************
      *   Payload Persistence  *
      **************************/
 
-    // The time that entries are cached in memory, in the payload persistence in milliseconds.
-    public static final AtomicLong PAYLOAD_CACHE_DURATION = new AtomicLong(10000);
-    // The maximum amount of entries that are cached in memory, in the payload persistence.
+    // The time that entries are cached in memory by the payload persistence.
+    public static final AtomicLong PAYLOAD_CACHE_DURATION_MSEC = new AtomicLong(10000);
+    // The maximum amount of entries that are cached in memory by the payload persistence.
     public static final AtomicInteger PAYLOAD_CACHE_SIZE = new AtomicInteger(10000);
     // The maximum amount of threads that can access the cache at the same time.
-    public static final AtomicInteger PAYLOAD_CACHE_CONCURRENCY_LEVEL = new AtomicInteger(16);
-    // The schedule in which the cleanup for payloads that are not referenced anymore are executed.
-    public static final AtomicInteger PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE = new AtomicInteger(250);
-    // The amount of time that a payload is preserved after the last reference was removed. In case the same payload is published again.
-    public static final AtomicLong PAYLOAD_PERSISTENCE_CLEANUP_DELAY = new AtomicLong(2000);
+    public static final AtomicInteger PAYLOAD_CACHE_CONCURRENCY_LEVEL_THREADS = new AtomicInteger(16);
+    // An interval of time between two consecutively executed payload cleanups for payloads that are not referenced anymore.
+    public static final AtomicInteger PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE_MSEC = new AtomicInteger(250);
+    // The amount of time that a payload is preserved after the last reference was removed in case the same payload is published again.
+    public static final AtomicLong PAYLOAD_PERSISTENCE_CLEANUP_DELAY_MSEC = new AtomicLong(2000);
     // The amount of threads in the cleanup job thread pool.
     public static final AtomicInteger PAYLOAD_PERSISTENCE_CLEANUP_THREADS = new AtomicInteger(AVAILABLE_PROCESSORS_TIMES_TWO);
     // The bucket count for the payload persistence.
     public static final AtomicInteger PAYLOAD_PERSISTENCE_BUCKET_COUNT = new AtomicInteger(64);
 
-    //The configuration if rocks db is used instead of xodus for payload persistence.
+    //The type of storage underlying the payload persistence (for example, rocks db or xodus).
     public static final AtomicReference<PersistenceType> PAYLOAD_PERSISTENCE_TYPE = new AtomicReference<>(PersistenceType.FILE_NATIVE);
 
-    // In case we tried to decrement a reference count that was already zero, a stacktrace will be logged to warn, if this flag is true (default is debug)
+    // If this flag is true, then on an attempt to decrement a reference counter that was already zero, a stacktrace will be logged to warn (by default logged to debug)
     public static final boolean LOG_REFERENCE_COUNTING_STACKTRACE_AS_WARNING = false;
 
 
@@ -174,37 +170,23 @@ public class InternalConfigurations {
      *     Misc     *
      *******************/
 
-    /**
-     * The concurrency level of the shared subscription cache
-     */
     public static final AtomicInteger SHARED_SUBSCRIPTION_CACHE_CONCURRENCY_LEVEL = new AtomicInteger(AVAILABLE_PROCESSORS);
-    /**
-     * The concurrency level of the shared subscriber service cache
-     */
+
     public static final AtomicInteger SHARED_SUBSCRIBER_CACHE_CONCURRENCY_LEVEL = new AtomicInteger(AVAILABLE_PROCESSORS);
 
-    public static final AtomicInteger CLEANUP_JOB_SCHEDULE = new AtomicInteger(4);
+    public static final AtomicInteger INTERVAL_BETWEEN_CLEANUP_JOBS_SEC = new AtomicInteger(4);
 
     public static final AtomicBoolean MQTT_ALLOW_DOLLAR_TOPICS = new AtomicBoolean(false);
 
     public static final AtomicInteger MQTT_EVENT_EXECUTOR_THREAD_COUNT = new AtomicInteger(AVAILABLE_PROCESSORS_TIMES_TWO);
 
-    /**
-     * The amount of clean up job tasks that are processed at the same time, in each schedule interval
-     */
-    public static final AtomicBoolean ACKNOWLEDGE_AFTER_PERSIST = new AtomicBoolean(true);
+    public static final AtomicBoolean ACKNOWLEDGE_INCOMING_PUBLISH_AFTER_PERSISTING_ENABLED = new AtomicBoolean(true);
 
     public static final boolean XODUS_LOG_CACHE_USE_NIO = false;
 
-    /**
-     * The live time of a entry in the shared subscription cache in milliseconds
-     */
-    public static final long SHARED_SUBSCRIPTION_CACHE_DURATION = 1000;
+    public static final long SHARED_SUBSCRIPTION_CACHE_TIME_TO_LIVE_MSEC = 1000;
 
-    /**
-     * The maximum of entries in the shared subscription cache
-     */
-    public static final int SHARED_SUBSCRIPTION_CACHE_SIZE = 10000;
+    public static final int SHARED_SUBSCRIPTION_CACHE_MAX_SIZE_SUBSCRIPTIONS = 10000;
 
     //The memory that is used for rocksdb memtable as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
     public static final AtomicInteger PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION = new AtomicInteger(32);
@@ -212,79 +194,56 @@ public class InternalConfigurations {
     //The memory that is used for rocksdb block-cache as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
     public static final AtomicInteger PAYLOAD_PERSISTENCE_BLOCK_CACHE_SIZE_PORTION = new AtomicInteger(64);
 
-    //The block size used by rocksdb for the retained message persistence in bytes
-    public static final int PAYLOAD_PERSISTENCE_BLOCK_SIZE = 32 * 1024;
+    //The block size used by rocksdb for the retained message persistence
+    public static final int PAYLOAD_PERSISTENCE_BLOCK_SIZE_BYTES = 32 * 1024; // 32 KB
 
-    // The period with which stats are written to the LOG file in seconds. Periodic writes are disabled when set to '0'.
-    public static final int ROCKSDB_STATS_PERSIST_PERIOD = 0;
+    // The period with which stats are written to the LOG file. Periodic writes are disabled when set to '0'.
+    public static final int ROCKSDB_STATS_PERSIST_PERIOD_SEC = 0;
 
-    // The maximum size of each LOG file in bytes
-    public static final int ROCKSDB_MAX_LOG_FILE_SIZE = 1024 * 500; // 500KB
+    // The maximum size of each LOG file
+    public static final int ROCKSDB_MAX_LOG_FILE_SIZE_BYTES = 1024 * 500; // 500KB
 
     // The maximum amount of LOG files per RocksDB (bucket)
-    public static final int ROCKSDB_LOG_FILE_NUMBER = 2;
+    public static final int ROCKSDB_LOG_FILES_COUNT = 2;
 
     // The maximum size stats history buffer that is used to dump stats to the LOG file
-    public static final int ROCKSDB_STATS_HISTORY_BUFFER_SIZE = 64 * 1024; // 64KB
+    public static final int OCKSDB_STATS_HISTORY_BUFFER_SIZE_BYTES = 64 * 1024; // 64KB
 
-    /**
-     * The maximum number of publishes until a flush is triggered on the Netty pipeline.
-     */
-    public static final AtomicInteger MAX_PUBLISHES_BEFORE_FLUSH = new AtomicInteger(128);
+    public static final AtomicInteger COUNT_OF_PUBLISHES_WRITTEN_TO_CHANNEL_TO_TRIGGER_FLUSH = new AtomicInteger(128);
 
 
-    /**
-     * The live time of a entry in the shared subscriber cache in milliseconds
-     */
-    public static final long SHARED_SUBSCRIBER_CACHE_DURATION = 1000;
+    public static final long SHARED_SUBSCRIBER_CACHE_TIME_TO_LIVE_MSEC = 1000;
 
-    /**
-     * The maximum of a entries in the shared subscriber cache
-     */
-    public static final int SHARED_SUBSCRIBER_CACHE_SIZE = 10000;
+    public static final int SHARED_SUBSCRIBER_CACHE_MAX_SIZE_SUBSCRIBERS = 10000;
 
     public static final int CLEANUP_JOB_PARALLELISM = 1;
 
     // set to true to close all client connections at netty-event-loop shutdown
     public static final boolean NETTY_SHUTDOWN_LEGACY = false;
-    public static final int NETTY_SHUTDOWN_PARTITION_SIZE = 100;
+    public static final int NETTY_COUNT_OF_CONNECTIONS_IN_SHUTDOWN_PARTITION = 100;
 
     public static final double MQTT_CONNECTION_KEEP_ALIVE_FACTOR = 1.5;
 
     public static final long DISCONNECT_KEEP_ALIVE_BATCH = 100;
 
-    public static final double CONNECT_THROTTLING_INFLIGHT_TO_QUEUE_RATIO = 2.0;
-    public static final double CONNECT_THROTTLING_FEEDBACK_TO_TIME_BETWEEN_RATIO = 2.0;
-    public static final double CONNECT_THROTTLING_TIMEOUT_FACTOR = 2.0;
+    public static final int EVENT_LOOP_GROUP_SHUTDOWN_TIMEOUT_SEC = 60;
+    public static final int CONNECTION_PERSISTENCE_SHUTDOWN_TIMEOUT_SEC = 180;
 
-    public static final int EVENT_LOOP_GROUP_SHUTDOWN_TIMEOUT = 60;
-    public static final int CHANNEL_PERSISTENCE_SHUTDOWN_TIMEOUT = 180;
-
-    public static final boolean DROP_MESSAGES_QOS_0 = true;
+    public static final boolean DROP_MESSAGES_QOS_0_ENABLED = true;
 
 
-    public static final int WILL_DELAY_CHECK_SCHEDULE = 1;
+    public static final int WILL_DELAY_CHECK_INTERVAL_SEC = 1;
 
 
-    public static final int LISTENER_SOCKET_RECEIVE_BUFFER_SIZE = -1;
-    public static final int LISTENER_SOCKET_SEND_BUFFER_SIZE = -1;
-    public static final int LISTENER_CLIENT_WRITE_BUFFER_HIGH_THRESHOLD = 65536; // 64Kb
-    public static final int LISTENER_CLIENT_WRITE_BUFFER_LOW_THRESHOLD = 32768;  // 32Kb
+    public static final int LISTENER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES = -1;
+    public static final int LISTENER_SOCKET_SEND_BUFFER_SIZE_BYTES = -1;
+    public static final int LISTENER_CLIENT_WRITE_BUFFER_HIGH_THRESHOLD_BYTES = 65536; // 64Kb
+    public static final int LISTENER_CLIENT_WRITE_BUFFER_LOW_THRESHOLD_BYTES = 32768;  // 32Kb
 
-    /**
-     * the outgoing bandwidth throttling config in bytes per second.
-     */
-    public static final int OUTGOING_BANDWIDTH_THROTTLING_DEFAULT = 0; // unlimited
+    public static final int OUTGOING_BANDWIDTH_THROTTLING_DEFAULT_BYTES_PER_SEC = 0; // unlimited
 
-    /**
-     * publishes are removed after the message expiry even if they are already in-flight.
-     */
-    public static boolean EXPIRE_INFLIGHT_MESSAGES = false;
-
-    /**
-     * pubrels are removed after the message expiry.
-     */
-    public static boolean EXPIRE_INFLIGHT_PUBRELS = false;
+    public static boolean EXPIRE_INFLIGHT_MESSAGES_ENABLED = false;
+    public static boolean EXPIRE_INFLIGHT_PUBRELS_ENABLED = false;
 
 
     /* *****************

--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -49,17 +49,25 @@ public class InternalConfigurations {
      *  Persistences *
      *****************/
 
-    // The "persistence shutdown grace period" represents the time span,
-    // in which single writer tasks are still processed after the persistence shutdown hook was called.
+    /**
+     * The "persistence shutdown grace period" represents the time span,
+     * in which single writer tasks are still processed after the persistence shutdown hook was called.
+     */
     public static final AtomicInteger PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC = new AtomicInteger(2000);
 
-    //timeout to wait for persistence shutdown to finish on HiveMQ shutdown
+    /**
+     * timeout to wait for persistence shutdown to finish on HiveMQ shutdown
+     */
     public static final AtomicInteger PERSISTENCE_SHUTDOWN_TIMEOUT_SEC = new AtomicInteger(300);
 
-    //timeout to wait for persistence startup executors shutdown to finish on HiveMQ shutdown
+    /**
+     * timeout to wait for persistence startup executors shutdown to finish on HiveMQ shutdown
+     */
     public static final AtomicInteger PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT_SEC = new AtomicInteger(300);
 
-    //the factor to multiply core size with to calculate thread count for initializing persistences
+    /**
+     * the factor to multiply core size with to calculate thread count for initializing persistences
+     */
     public static final AtomicInteger PERSISTENCE_STARTUP_THREAD_POOL_SIZE = new AtomicInteger(AVAILABLE_PROCESSORS_TIMES_FOUR);
 
     public static final AtomicInteger PERSISTENCE_BUCKET_COUNT = new AtomicInteger(64);
@@ -70,110 +78,201 @@ public class InternalConfigurations {
     public static final AtomicInteger PERSISTENCE_CLOSE_RETRIES = new AtomicInteger(500);
     public static final AtomicInteger PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC = new AtomicInteger(100);
 
-    //max amount of subscriptions to pull from the peristence for extension iterate chunk
+    /**
+     * max amount of subscriptions to pull from the peristence for extension iterate chunk
+     */
     public static final int PERSISTENCE_SUBSCRIPTIONS_MAX_CHUNK_SIZE = 2000;
 
-    //max amount of clients to pull from the peristence for extension iterate chunk
+    /**
+     * max amount of clients to pull from the peristence for extension iterate chunk
+     */
     public static final int PERSISTENCE_CLIENT_SESSIONS_MAX_CHUNK_SIZE = 2000;
 
-    //max amount of memory for retained messages to pull from the peristence for extension iterate chunk
+    /**
+     * max amount of memory for retained messages to pull from the peristence for extension iterate chunk
+     */
     public static final int PERSISTENCE_RETAINED_MESSAGES_MAX_CHUNK_MEMORY_BYTES = 10485760; //10 MByte
 
-    //The threshold at which the topic tree starts to map entries instead of storing them in an array
+    /**
+     * The threshold at which the topic tree starts to map entries instead of storing them in an array
+     */
     public static final AtomicInteger TOPIC_TREE_MAP_CREATION_THRESHOLD = new AtomicInteger(16);
-    // The configuration for qos 0 memory hard limit divisor, must be greater than 0.
+
+    /**
+     * The configuration for qos 0 memory hard limit divisor, must be greater than 0.
+     */
     public static final AtomicInteger QOS_0_MEMORY_HARD_LIMIT_DIVISOR = new AtomicInteger(4);
 
-    // The configuration for qos 0 memory limit per client, must be greater than 0.
+    /**
+     * The configuration for qos 0 memory limit per client, must be greater than 0.
+     */
     public static final AtomicInteger QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES = new AtomicInteger(1024 * 1024 * 5);
 
-    // The configuration for shared sub caching of publish without packet-id
+    /**
+     * The configuration for shared sub caching of publish without packet-id
+     */
     public static final AtomicInteger SHARED_SUBSCRIPTION_WITHOUT_PACKET_ID_CACHE_MAX_SIZE_ENTRIES = new AtomicInteger(10000);
 
-    // The amount of qos 0 messages that are queued if the channel is not writable
+    /**
+     * The amount of qos 0 messages that are queued if the channel is not writable
+     */
     public static final AtomicInteger NOT_WRITABLE_QUEUE_SIZE = new AtomicInteger(1000);
 
-    // The limit of unacknowledged messages that hivemq will handle, regardless of the client receive maximum
+    /**
+     * The limit of unacknowledged messages that hivemq will handle, regardless of the client receive maximum
+     */
     public static int MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 50;
 
-    //The maximum allowed size of the passed value for the ConnectionAttributeStore
+    /**
+     * The maximum allowed size of the passed value for the ConnectionAttributeStore
+     */
     public static final int CONNECTION_ATTRIBUTE_STORE_MAX_VALUE_SIZE_BYTES = 10240; //10Kb
 
-    // The configuration for xodus persistence environment jmx
+    /**
+     * The configuration for xodus persistence environment jmx
+     */
     public static final boolean XODUS_PERSISTENCE_ENVIRONMENT_JMX = false;
-    // The configuration for xodus persistence environment garbage collection type
+
+    /**
+     * The configuration for xodus persistence environment garbage collection type
+     */
     public static final GCType XODUS_PERSISTENCE_ENVIRONMENT_GC_TYPE = GCType.DELETE;
-    // The configuration for xodus persistence environment garbage collection deletion delay
+
+    /**
+     * The configuration for xodus persistence environment garbage collection deletion delay
+     */
     public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_DELETION_DELAY_MSEC = 60000;
-    // The configuration for xodus persistence environment garbage collection run period
+
+    /**
+     * The configuration for xodus persistence environment garbage collection run period
+     */
     public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_RUN_PERIOD_MSEC = 30000;
-    // The configuration for xodus persistence environment garbage collection files interval
+
+    /**
+     * The configuration for xodus persistence environment garbage collection files interval
+     */
     public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_FILES_INTERVAL = 1;
-    // The configuration for xodus persistence environment garbage collection min age
+
+    /**
+     * The configuration for xodus persistence environment garbage collection min age
+     */
     public static final int XODUS_PERSISTENCE_ENVIRONMENT_GC_MIN_AGE = 2;
-    // The configuration for xodus persistence environment sync period
+
+    /**
+     * The configuration for xodus persistence environment sync period
+     */
     public static final int XODUS_PERSISTENCE_ENVIRONMENT_SYNC_PERIOD_MSEC = 1000;
-    // The configuration for xodus persistence environment durable writes
+
+    /**
+     * The configuration for xodus persistence environment durable writes
+     */
     public static final boolean XODUS_PERSISTENCE_ENVIRONMENT_DURABLE_WRITES_ENABLED = false;
-    // The memory limit used by the xodus environments in percentage of the JVM heap (Xmx).
+
+    /**
+     * The memory limit used by the xodus environments in percentage of the JVM heap (Xmx).
+     */
     public static final int XODUS_PERSISTENCE_LOG_MEMORY_HEAP_PERCENTAGE = 25;
 
 
-    // The amount of publishes that are polled per batch
+    /**
+     * The amount of publishes that are polled per batch
+     */
     public static int PUBLISH_POLL_BATCH_SIZE = 50;
 
-    // The amount of bytes that are polled per batch (one publish min)
+    /**
+     * The amount of bytes that are polled per batch (one publish min)
+     */
     public static final int PUBLISH_POLL_BATCH_SIZE_BYTES = 1024 * 1024 * 5; // 5Mb
 
-    // The amount of qos > 0 retained messages that are queued
+    /**
+     * The amount of qos > 0 retained messages that are queued
+     */
     public static final AtomicInteger RETAINED_MESSAGE_QUEUE_SIZE = new AtomicInteger(100_000);
 
-    //The configuration if rocks db is used instead of xodus for retained messages.
+    /**
+     * The configuration if rocks db is used instead of xodus for retained messages.
+     */
     public static final AtomicReference<PersistenceType> RETAINED_MESSAGE_PERSISTENCE_TYPE = new AtomicReference<>(PersistenceType.FILE_NATIVE);
 
-    //The memory that is used for rocksdb memtable as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+    /**
+     * The memory that is used for rocksdb memtable as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+     */
     public static final int RETAINED_MESSAGE_MEMTABLE_SIZE_PORTION = 32;
 
-    //The memory that is used for rocksdb block-cache as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+    /**
+     * The memory that is used for rocksdb block-cache as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+     */
     public static final int RETAINED_MESSAGE_BLOCK_CACHE_SIZE_PORTION = 64;
 
-    //The block size used by rocksdb for the retained message persistence
+    /**
+     * The block size used by rocksdb for the retained message persistence
+     */
     public static final int RETAINED_MESSAGE_BLOCK_SIZE_BYTES = 32 * 1024;
 
     /* ************************
      *   Payload Persistence  *
      **************************/
 
-    // The time that entries are cached in memory by the payload persistence.
+    /**
+     * The time that entries are cached in memory by the payload persistence.
+     */
     public static final AtomicLong PAYLOAD_CACHE_DURATION_MSEC = new AtomicLong(10000);
-    // The maximum amount of entries that are cached in memory by the payload persistence.
+
+    /**
+     * The maximum amount of entries that are cached in memory by the payload persistence.
+     */
     public static final AtomicInteger PAYLOAD_CACHE_SIZE = new AtomicInteger(10000);
-    // The maximum amount of threads that can access the cache at the same time.
+
+    /**
+     * The maximum amount of threads that can access the cache at the same time.
+     */
     public static final AtomicInteger PAYLOAD_CACHE_CONCURRENCY_LEVEL_THREADS = new AtomicInteger(16);
-    // An interval of time between two consecutively executed payload cleanups for payloads that are not referenced anymore.
+
+    /**
+     * An interval of time between two consecutively executed payload cleanups for payloads that are not referenced anymore.
+     */
     public static final AtomicInteger PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE_MSEC = new AtomicInteger(250);
-    // The amount of time that a payload is preserved after the last reference was removed in case the same payload is published again.
+
+    /**
+     * The amount of time that a payload is preserved after the last reference was removed in case the same payload is published again.
+     */
     public static final AtomicLong PAYLOAD_PERSISTENCE_CLEANUP_DELAY_MSEC = new AtomicLong(2000);
-    // The amount of threads in the cleanup job thread pool.
+
+    /**
+     * The amount of threads in the cleanup job thread pool.
+     */
     public static final AtomicInteger PAYLOAD_PERSISTENCE_CLEANUP_THREADS = new AtomicInteger(AVAILABLE_PROCESSORS_TIMES_TWO);
-    // The bucket count for the payload persistence.
+
+    /**
+     * The bucket count for the payload persistence.
+     */
     public static final AtomicInteger PAYLOAD_PERSISTENCE_BUCKET_COUNT = new AtomicInteger(64);
 
     public static final AtomicBoolean PUBLISH_PAYLOAD_FORCE_FLUSH_ENABLED = new AtomicBoolean(true);
 
-    //The type of storage underlying the payload persistence (for example, rocks db or xodus).
+    /**
+     * The type of storage underlying the payload persistence (for example, rocks db or xodus).
+     */
     public static final AtomicReference<PersistenceType> PAYLOAD_PERSISTENCE_TYPE = new AtomicReference<>(PersistenceType.FILE_NATIVE);
 
-    //The memory that is used for rocksdb memtable as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+    /**
+     * The memory that is used for rocksdb memtable as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+     */
     public static final AtomicInteger PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION = new AtomicInteger(32);
 
-    //The memory that is used for rocksdb block-cache as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+    /**
+     * The memory that is used for rocksdb block-cache as a portion of the RAM for the retained message persistence. (size = RAM/configValue)
+     */
     public static final AtomicInteger PAYLOAD_PERSISTENCE_BLOCK_CACHE_SIZE_PORTION = new AtomicInteger(64);
 
-    //The block size used by rocksdb for the retained message persistence
+    /**
+     * The block size used by rocksdb for the retained message persistence
+     */
     public static final int PAYLOAD_PERSISTENCE_BLOCK_SIZE_BYTES = 32 * 1024; // 32 KB
 
-    // If this flag is true, then on an attempt to decrement a reference counter that was already zero, a stacktrace will be logged to warn (by default logged to debug)
+    /**
+     * If this flag is true, then on an attempt to decrement a reference counter that was already zero, a stacktrace will be logged to warn (by default logged to debug)
+     */
     public static final boolean LOG_REFERENCE_COUNTING_STACKTRACE_AS_WARNING = false;
 
     /* *****************
@@ -189,10 +288,14 @@ public class InternalConfigurations {
      *      Metrics     *
      *******************/
 
-    //Toggles for system metrics via OSHI
+    /**
+     * Toggles for system metrics via OSHI
+     */
     public static final boolean SYSTEM_METRICS_ENABLED = true;
 
-    // register metrics for jmx reporting on startup if enabled
+    /**
+     * register metrics for jmx reporting on startup if enabled
+     */
     public static final AtomicBoolean JMX_REPORTER_ENABLED = new AtomicBoolean(true);
 
     /* *****************
@@ -265,16 +368,24 @@ public class InternalConfigurations {
 
     public static final int SHARED_SUBSCRIPTION_CACHE_MAX_SIZE_SUBSCRIPTIONS = 10000;
 
-    // The period with which stats are written to the LOG file. Periodic writes are disabled when set to '0'.
+    /**
+     * The period with which stats are written to the LOG file. Periodic writes are disabled when set to '0'.
+     */
     public static final int ROCKSDB_STATS_PERSIST_PERIOD_SEC = 0;
 
-    // The maximum size of each LOG file
+    /**
+     * The maximum size of each LOG file
+     */
     public static final int ROCKSDB_MAX_LOG_FILE_SIZE_BYTES = 1024 * 500; // 500KB
 
-    // The maximum amount of LOG files per RocksDB (bucket)
+    /**
+     * The maximum amount of LOG files per RocksDB (bucket)
+     */
     public static final int ROCKSDB_LOG_FILES_COUNT = 2;
 
-    // The maximum size stats history buffer that is used to dump stats to the LOG file
+    /**
+     * The maximum size stats history buffer that is used to dump stats to the LOG file
+     */
     public static final int OCKSDB_STATS_HISTORY_BUFFER_SIZE_BYTES = 64 * 1024; // 64KB
 
     public static final AtomicInteger COUNT_OF_PUBLISHES_WRITTEN_TO_CHANNEL_TO_TRIGGER_FLUSH = new AtomicInteger(128);
@@ -285,7 +396,9 @@ public class InternalConfigurations {
 
     public static final int CLEANUP_JOB_PARALLELISM = 1;
 
-    // set to true to close all client connections at netty-event-loop shutdown
+    /**
+     * set to true to close all client connections at netty-event-loop shutdown
+     */
     public static final boolean NETTY_SHUTDOWN_LEGACY = false;
     public static final int NETTY_COUNT_OF_CONNECTIONS_IN_SHUTDOWN_PARTITION = 100;
 

--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -176,78 +176,6 @@ public class InternalConfigurations {
     // If this flag is true, then on an attempt to decrement a reference counter that was already zero, a stacktrace will be logged to warn (by default logged to debug)
     public static final boolean LOG_REFERENCE_COUNTING_STACKTRACE_AS_WARNING = false;
 
-
-    /* *****************
-     *     Misc     *
-     *******************/
-
-    public static final AtomicInteger SHARED_SUBSCRIPTION_CACHE_CONCURRENCY_LEVEL = new AtomicInteger(AVAILABLE_PROCESSORS);
-
-    public static final AtomicInteger SHARED_SUBSCRIBER_CACHE_CONCURRENCY_LEVEL = new AtomicInteger(AVAILABLE_PROCESSORS);
-
-    public static final AtomicInteger INTERVAL_BETWEEN_CLEANUP_JOBS_SEC = new AtomicInteger(4);
-
-    public static final AtomicBoolean MQTT_ALLOW_DOLLAR_TOPICS = new AtomicBoolean(false);
-
-    public static final AtomicInteger MQTT_EVENT_EXECUTOR_THREAD_COUNT = new AtomicInteger(AVAILABLE_PROCESSORS_TIMES_TWO);
-
-    public static final AtomicBoolean ACKNOWLEDGE_INCOMING_PUBLISH_AFTER_PERSISTING_ENABLED = new AtomicBoolean(true);
-
-    public static final boolean XODUS_LOG_CACHE_USE_NIO = false;
-
-    public static final long SHARED_SUBSCRIPTION_CACHE_TIME_TO_LIVE_MSEC = 1000;
-
-    public static final int SHARED_SUBSCRIPTION_CACHE_MAX_SIZE_SUBSCRIPTIONS = 10000;
-
-    // The period with which stats are written to the LOG file. Periodic writes are disabled when set to '0'.
-    public static final int ROCKSDB_STATS_PERSIST_PERIOD_SEC = 0;
-
-    // The maximum size of each LOG file
-    public static final int ROCKSDB_MAX_LOG_FILE_SIZE_BYTES = 1024 * 500; // 500KB
-
-    // The maximum amount of LOG files per RocksDB (bucket)
-    public static final int ROCKSDB_LOG_FILES_COUNT = 2;
-
-    // The maximum size stats history buffer that is used to dump stats to the LOG file
-    public static final int OCKSDB_STATS_HISTORY_BUFFER_SIZE_BYTES = 64 * 1024; // 64KB
-
-    public static final AtomicInteger COUNT_OF_PUBLISHES_WRITTEN_TO_CHANNEL_TO_TRIGGER_FLUSH = new AtomicInteger(128);
-
-
-    public static final long SHARED_SUBSCRIBER_CACHE_TIME_TO_LIVE_MSEC = 1000;
-
-    public static final int SHARED_SUBSCRIBER_CACHE_MAX_SIZE_SUBSCRIBERS = 10000;
-
-    public static final int CLEANUP_JOB_PARALLELISM = 1;
-
-    // set to true to close all client connections at netty-event-loop shutdown
-    public static final boolean NETTY_SHUTDOWN_LEGACY = false;
-    public static final int NETTY_COUNT_OF_CONNECTIONS_IN_SHUTDOWN_PARTITION = 100;
-
-    public static final double MQTT_CONNECTION_KEEP_ALIVE_FACTOR = 1.5;
-
-    public static final long DISCONNECT_KEEP_ALIVE_BATCH = 100;
-
-    public static final int EVENT_LOOP_GROUP_SHUTDOWN_TIMEOUT_SEC = 60;
-    public static final int CONNECTION_PERSISTENCE_SHUTDOWN_TIMEOUT_SEC = 180;
-
-    public static final boolean DROP_MESSAGES_QOS_0_ENABLED = true;
-
-
-    public static final int WILL_DELAY_CHECK_INTERVAL_SEC = 1;
-
-
-    public static final int LISTENER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES = -1;
-    public static final int LISTENER_SOCKET_SEND_BUFFER_SIZE_BYTES = -1;
-    public static final int LISTENER_CLIENT_WRITE_BUFFER_HIGH_THRESHOLD_BYTES = 65536; // 64Kb
-    public static final int LISTENER_CLIENT_WRITE_BUFFER_LOW_THRESHOLD_BYTES = 32768;  // 32Kb
-
-    public static final int OUTGOING_BANDWIDTH_THROTTLING_DEFAULT_BYTES_PER_SEC = 0; // unlimited
-
-    public static boolean EXPIRE_INFLIGHT_MESSAGES_ENABLED = false;
-    public static boolean EXPIRE_INFLIGHT_PUBRELS_ENABLED = false;
-
-
     /* *****************
      *      SSL       *
      *******************/
@@ -290,7 +218,6 @@ public class InternalConfigurations {
 
     public static final int USAGE_STATISTICS_SEND_INTERVAL_MINUTES = 1440; //24h
 
-
     /* ***********************
      *    Extension System   *
      *************************/
@@ -316,4 +243,70 @@ public class InternalConfigurations {
 
     public static final AtomicInteger AUTH_PROCESS_TIMEOUT_SEC = new AtomicInteger(30);
 
+    /* *****************
+     *     Misc     *
+     *******************/
+
+    public static final AtomicInteger SHARED_SUBSCRIPTION_CACHE_CONCURRENCY_LEVEL = new AtomicInteger(AVAILABLE_PROCESSORS);
+
+    public static final AtomicInteger SHARED_SUBSCRIBER_CACHE_CONCURRENCY_LEVEL = new AtomicInteger(AVAILABLE_PROCESSORS);
+
+    public static final AtomicInteger INTERVAL_BETWEEN_CLEANUP_JOBS_SEC = new AtomicInteger(4);
+
+    public static final AtomicBoolean MQTT_ALLOW_DOLLAR_TOPICS = new AtomicBoolean(false);
+
+    public static final AtomicInteger MQTT_EVENT_EXECUTOR_THREAD_COUNT = new AtomicInteger(AVAILABLE_PROCESSORS_TIMES_TWO);
+
+    public static final AtomicBoolean ACKNOWLEDGE_INCOMING_PUBLISH_AFTER_PERSISTING_ENABLED = new AtomicBoolean(true);
+
+    public static final boolean XODUS_LOG_CACHE_USE_NIO = false;
+
+    public static final long SHARED_SUBSCRIPTION_CACHE_TIME_TO_LIVE_MSEC = 1000;
+
+    public static final int SHARED_SUBSCRIPTION_CACHE_MAX_SIZE_SUBSCRIPTIONS = 10000;
+
+    // The period with which stats are written to the LOG file. Periodic writes are disabled when set to '0'.
+    public static final int ROCKSDB_STATS_PERSIST_PERIOD_SEC = 0;
+
+    // The maximum size of each LOG file
+    public static final int ROCKSDB_MAX_LOG_FILE_SIZE_BYTES = 1024 * 500; // 500KB
+
+    // The maximum amount of LOG files per RocksDB (bucket)
+    public static final int ROCKSDB_LOG_FILES_COUNT = 2;
+
+    // The maximum size stats history buffer that is used to dump stats to the LOG file
+    public static final int OCKSDB_STATS_HISTORY_BUFFER_SIZE_BYTES = 64 * 1024; // 64KB
+
+    public static final AtomicInteger COUNT_OF_PUBLISHES_WRITTEN_TO_CHANNEL_TO_TRIGGER_FLUSH = new AtomicInteger(128);
+
+    public static final long SHARED_SUBSCRIBER_CACHE_TIME_TO_LIVE_MSEC = 1000;
+
+    public static final int SHARED_SUBSCRIBER_CACHE_MAX_SIZE_SUBSCRIBERS = 10000;
+
+    public static final int CLEANUP_JOB_PARALLELISM = 1;
+
+    // set to true to close all client connections at netty-event-loop shutdown
+    public static final boolean NETTY_SHUTDOWN_LEGACY = false;
+    public static final int NETTY_COUNT_OF_CONNECTIONS_IN_SHUTDOWN_PARTITION = 100;
+
+    public static final double MQTT_CONNECTION_KEEP_ALIVE_FACTOR = 1.5;
+
+    public static final long DISCONNECT_KEEP_ALIVE_BATCH = 100;
+
+    public static final int EVENT_LOOP_GROUP_SHUTDOWN_TIMEOUT_SEC = 60;
+    public static final int CONNECTION_PERSISTENCE_SHUTDOWN_TIMEOUT_SEC = 180;
+
+    public static final boolean DROP_MESSAGES_QOS_0_ENABLED = true;
+
+    public static final int WILL_DELAY_CHECK_INTERVAL_SEC = 1;
+
+    public static final int LISTENER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES = -1;
+    public static final int LISTENER_SOCKET_SEND_BUFFER_SIZE_BYTES = -1;
+    public static final int LISTENER_CLIENT_WRITE_BUFFER_HIGH_THRESHOLD_BYTES = 65536; // 64Kb
+    public static final int LISTENER_CLIENT_WRITE_BUFFER_LOW_THRESHOLD_BYTES = 32768;  // 32Kb
+
+    public static final int OUTGOING_BANDWIDTH_THROTTLING_DEFAULT_BYTES_PER_SEC = 0; // unlimited
+
+    public static boolean EXPIRE_INFLIGHT_MESSAGES_ENABLED = false;
+    public static boolean EXPIRE_INFLIGHT_PUBRELS_ENABLED = false;
 }

--- a/src/main/java/com/hivemq/extensions/client/parameter/ConnectionAttributes.java
+++ b/src/main/java/com/hivemq/extensions/client/parameter/ConnectionAttributes.java
@@ -73,7 +73,7 @@ public class ConnectionAttributes {
             return connectionAttributes;
         }
 
-        final int maxValueSizeBytes = InternalConfigurations.CONNECTION_ATTRIBUTE_STORE_MAX_VALUE_SIZE;
+        final int maxValueSizeBytes = InternalConfigurations.CONNECTION_ATTRIBUTE_STORE_MAX_VALUE_SIZE_BYTES;
 
         final ClientConnection clientConnection = channel.attr(ChannelAttributes.CLIENT_CONNECTION).get();
         return clientConnection.setConnectionAttributesIfAbsent(new ConnectionAttributes(maxValueSizeBytes));

--- a/src/main/java/com/hivemq/extensions/executor/PluginTaskExecutorServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/executor/PluginTaskExecutorServiceImpl.java
@@ -27,7 +27,7 @@ import javax.inject.Singleton;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.hivemq.configuration.service.InternalConfigurations.PLUGIN_TASK_QUEUE_EXECUTOR_COUNT;
+import static com.hivemq.configuration.service.InternalConfigurations.EXTENSION_TASK_QUEUE_EXECUTOR_THREADS_COUNT;
 
 /**
  * @author Christoph Schäbel
@@ -44,7 +44,7 @@ public class PluginTaskExecutorServiceImpl implements PluginTaskExecutorService 
             final @NotNull Provider<PluginTaskExecutor> taskExecutorProvider,
             final @NotNull ShutdownHooks shutdownHooks) {
 
-        taskExecutorCount = PLUGIN_TASK_QUEUE_EXECUTOR_COUNT.get();
+        taskExecutorCount = EXTENSION_TASK_QUEUE_EXECUTOR_THREADS_COUNT.get();
 
         taskExecutors = new PluginTaskExecutor[taskExecutorCount];
 

--- a/src/main/java/com/hivemq/extensions/handler/PluginAuthenticatorServiceImpl.java
+++ b/src/main/java/com/hivemq/extensions/handler/PluginAuthenticatorServiceImpl.java
@@ -115,7 +115,7 @@ public class PluginAuthenticatorServiceImpl implements PluginAuthenticatorServic
         this.authSender = authSender;
         this.priorityComparator = new ExtensionPriorityComparator(extensions);
         this.serverInformation = serverInformation;
-        this.timeout = InternalConfigurations.AUTH_PROCESS_TIMEOUT.get();
+        this.timeout = InternalConfigurations.AUTH_PROCESS_TIMEOUT_SEC.get();
         this.validateUTF8 = configurationService.securityConfiguration().validateUTF8();
     }
 

--- a/src/main/java/com/hivemq/extensions/services/PluginServiceRateLimitService.java
+++ b/src/main/java/com/hivemq/extensions/services/PluginServiceRateLimitService.java
@@ -21,7 +21,7 @@ import com.hivemq.extension.sdk.api.services.exception.RateLimitExceededExceptio
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hivemq.configuration.service.InternalConfigurations.PLUGIN_SERVICE_RATE_LIMIT;
+import static com.hivemq.configuration.service.InternalConfigurations.EXTENSION_SERVICE_CALL_RATE_LIMIT_PER_SEC;
 
 /**
  * @author Lukas Brandl
@@ -39,7 +39,7 @@ public class PluginServiceRateLimitService {
     private final int rateLimit;
 
     public PluginServiceRateLimitService() {
-        rateLimit = PLUGIN_SERVICE_RATE_LIMIT.get();
+        rateLimit = EXTENSION_SERVICE_CALL_RATE_LIMIT_PER_SEC.get();
     }
 
     static {

--- a/src/main/java/com/hivemq/extensions/services/executor/GlobalManagedExtensionExecutorService.java
+++ b/src/main/java/com/hivemq/extensions/services/executor/GlobalManagedExtensionExecutorService.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.*;
 
-import static com.hivemq.configuration.service.InternalConfigurations.MANAGED_PLUGIN_EXECUTOR_SHUTDOWN_TIMEOUT;
+import static com.hivemq.configuration.service.InternalConfigurations.MANAGED_EXTENSION_EXECUTOR_SHUTDOWN_TIMEOUT_SEC;
 
 /**
  * @author Florian Limpöck
@@ -57,8 +57,8 @@ public class GlobalManagedExtensionExecutorService implements ScheduledExecutorS
 
         final ThreadFactory threadFactory = ThreadFactoryUtil.create("managed-extension-executor-%d");
 
-        final int corePoolSize = InternalConfigurations.MANAGED_PLUGIN_THREAD_POOL_SIZE.get();
-        final int keepAlive = InternalConfigurations.MANAGED_PLUGIN_THREAD_POOL_KEEP_ALIVE_SECONDS.get();
+        final int corePoolSize = InternalConfigurations.MANAGED_EXTENSION_THREAD_POOL_THREADS_COUNT.get();
+        final int keepAlive = InternalConfigurations.MANAGED_EXTENSION_THREAD_POOL_KEEP_ALIVE_SEC.get();
 
         scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(corePoolSize, threadFactory);
         log.debug("Set extension executor thread pool size to {}", corePoolSize);
@@ -71,7 +71,7 @@ public class GlobalManagedExtensionExecutorService implements ScheduledExecutorS
         //for instrumentation (metrics)
         scheduledExecutorService = scheduledThreadPoolExecutor;
 
-        shutdownHooks.add(new ManagedPluginExecutorShutdownHook(this, MANAGED_PLUGIN_EXECUTOR_SHUTDOWN_TIMEOUT.get()));
+        shutdownHooks.add(new ManagedPluginExecutorShutdownHook(this, MANAGED_EXTENSION_EXECUTOR_SHUTDOWN_TIMEOUT_SEC.get()));
     }
 
     public int getCorePoolSize() {

--- a/src/main/java/com/hivemq/limitation/TopicAliasLimiterImpl.java
+++ b/src/main/java/com/hivemq/limitation/TopicAliasLimiterImpl.java
@@ -37,8 +37,8 @@ public class TopicAliasLimiterImpl implements TopicAliasLimiter {
     public TopicAliasLimiterImpl() {
         this.memoryUsage = new AtomicLong(0);
         this.topicAliasesTotal = new AtomicLong(0);
-        this.memorySoftLimit = InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_SOFT_LIMIT.get();
-        this.memoryHardLimit = InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT.get();
+        this.memorySoftLimit = InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_SOFT_LIMIT_BYTES.get();
+        this.memoryHardLimit = InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT_BYTES.get();
     }
 
     @Override

--- a/src/main/java/com/hivemq/migration/persistence/legacy/PublishPayloadRocksDBLocalPersistence_4_4.java
+++ b/src/main/java/com/hivemq/migration/persistence/legacy/PublishPayloadRocksDBLocalPersistence_4_4.java
@@ -57,7 +57,7 @@ public class PublishPayloadRocksDBLocalPersistence_4_4 extends RocksDBLocalPersi
                 InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.get(),
                 InternalConfigurations.PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION.get(),
                 InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_CACHE_SIZE_PORTION.get(),
-                InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_SIZE,
+                InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_SIZE_BYTES,
                 false);
     }
 

--- a/src/main/java/com/hivemq/migration/persistence/legacy/RetainedMessageRocksDBLocalPersistence_4_4.java
+++ b/src/main/java/com/hivemq/migration/persistence/legacy/RetainedMessageRocksDBLocalPersistence_4_4.java
@@ -66,7 +66,7 @@ public class RetainedMessageRocksDBLocalPersistence_4_4 extends RocksDBLocalPers
                 InternalConfigurations.PERSISTENCE_BUCKET_COUNT.get(),
                 InternalConfigurations.RETAINED_MESSAGE_MEMTABLE_SIZE_PORTION,
                 InternalConfigurations.RETAINED_MESSAGE_BLOCK_CACHE_SIZE_PORTION,
-                InternalConfigurations.RETAINED_MESSAGE_BLOCK_SIZE,
+                InternalConfigurations.RETAINED_MESSAGE_BLOCK_SIZE_BYTES,
                 false);
 
         this.payloadPersistence = payloadPersistence;

--- a/src/main/java/com/hivemq/mqtt/handler/connack/MqttConnackerImpl.java
+++ b/src/main/java/com/hivemq/mqtt/handler/connack/MqttConnackerImpl.java
@@ -59,8 +59,8 @@ public class MqttConnackerImpl implements MqttConnacker {
     @Inject
     public MqttConnackerImpl(final @NotNull EventLog eventLog) {
         this.eventLog = eventLog;
-        connackWithReasonCode = InternalConfigurations.CONNACK_WITH_REASON_CODE.get();
-        connackWithReasonString = InternalConfigurations.CONNACK_WITH_REASON_STRING.get();
+        connackWithReasonCode = InternalConfigurations.CONNACK_WITH_REASON_CODE_ENABLED.get();
+        connackWithReasonString = InternalConfigurations.CONNACK_WITH_REASON_STRING_ENABLED.get();
     }
 
     @Override

--- a/src/main/java/com/hivemq/mqtt/handler/disconnect/DisconnectHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/disconnect/DisconnectHandler.java
@@ -72,7 +72,7 @@ public class DisconnectHandler extends SimpleChannelInboundHandler<DISCONNECT> {
         this.topicAliasLimiter = topicAliasLimiter;
         this.clientSessionPersistence = clientSessionPersistence;
         this.connectionPersistence = connectionPersistence;
-        logClientReasonString = InternalConfigurations.LOG_CLIENT_REASON_STRING_ON_DISCONNECT;
+        logClientReasonString = InternalConfigurations.LOG_CLIENT_REASON_STRING_ON_DISCONNECT_ENABLED;
     }
 
     @Override

--- a/src/main/java/com/hivemq/mqtt/handler/disconnect/MqttServerDisconnectorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/handler/disconnect/MqttServerDisconnectorImpl.java
@@ -55,8 +55,8 @@ public class MqttServerDisconnectorImpl implements MqttServerDisconnector {
     @Inject
     public MqttServerDisconnectorImpl(final @NotNull EventLog eventLog) {
         this.eventLog = eventLog;
-        disconnectWithReasonCode = InternalConfigurations.DISCONNECT_WITH_REASON_CODE.get();
-        disconnectWithReasonString = InternalConfigurations.DISCONNECT_WITH_REASON_STRING.get();
+        disconnectWithReasonCode = InternalConfigurations.DISCONNECT_WITH_REASON_CODE_ENABLED.get();
+        disconnectWithReasonString = InternalConfigurations.DISCONNECT_WITH_REASON_STRING_ENABLED.get();
     }
 
     @Override

--- a/src/main/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandler.java
@@ -52,7 +52,7 @@ public class MessageExpiryHandler extends ChannelOutboundHandlerAdapter {
         if (msg instanceof PUBLISH) {
             final PUBLISH publish = (PUBLISH) msg;
             checkAndSetPublishExpiry(publish);
-            final boolean expireInflight = InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES;
+            final boolean expireInflight = InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES_ENABLED;
             final boolean isInflight = (publish.getQoS() == QoS.EXACTLY_ONCE) && publish.isDuplicateDelivery();
             final boolean drop = (publish.getMessageExpiryInterval() == 0) && (!isInflight || expireInflight);
             if (drop) {
@@ -62,7 +62,7 @@ public class MessageExpiryHandler extends ChannelOutboundHandlerAdapter {
         } else if (msg instanceof PUBREL) {
             final PUBREL pubrel = (PUBREL) msg;
             checkAndSetPubrelExpiry(pubrel);
-            final boolean expireInflight = InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS;
+            final boolean expireInflight = InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED;
             final boolean drop = (pubrel.getExpiryInterval() != null) && (pubrel.getExpiryInterval() == 0) && expireInflight;
             if (drop) {
                 ctx.fireUserEventTriggered(new PubrelDroppedEvent(pubrel));

--- a/src/main/java/com/hivemq/mqtt/handler/publish/PublishFlowHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/publish/PublishFlowHandler.java
@@ -45,7 +45,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hivemq.configuration.service.InternalConfigurations.DROP_MESSAGES_QOS_0;
+import static com.hivemq.configuration.service.InternalConfigurations.DROP_MESSAGES_QOS_0_ENABLED;
 import static com.hivemq.mqtt.message.connect.Mqtt5CONNECT.SESSION_EXPIRE_ON_DISCONNECT;
 
 /**
@@ -134,7 +134,7 @@ public class PublishFlowHandler extends ChannelDuplexHandler {
             return;
         }
 
-        if (DROP_MESSAGES_QOS_0) {
+        if (DROP_MESSAGES_QOS_0_ENABLED) {
             final boolean messageDropped = dropOutgoingPublishesHandler.checkChannelNotWritable(ctx, msg, promise);
             if (messageDropped) {
                 return;

--- a/src/main/java/com/hivemq/mqtt/handler/publish/PublishFlushHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/publish/PublishFlushHandler.java
@@ -41,7 +41,7 @@ public class PublishFlushHandler extends ChannelInboundHandlerAdapter implements
 
     public PublishFlushHandler(final @NotNull MetricsHolder metricsHolder) {
         channelNotWritable = metricsHolder.getChannelNotWritableCounter();
-        maxWritesBeforeFlush = InternalConfigurations.MAX_PUBLISHES_BEFORE_FLUSH.get();
+        maxWritesBeforeFlush = InternalConfigurations.COUNT_OF_PUBLISHES_WRITTEN_TO_CHANNEL_TO_TRIGGER_FLUSH.get();
     }
 
     @Override

--- a/src/main/java/com/hivemq/mqtt/services/InternalPublishServiceImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/InternalPublishServiceImpl.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-import static com.hivemq.configuration.service.InternalConfigurations.ACKNOWLEDGE_AFTER_PERSIST;
+import static com.hivemq.configuration.service.InternalConfigurations.ACKNOWLEDGE_INCOMING_PUBLISH_AFTER_PERSISTING_ENABLED;
 
 /**
  * @author Christoph Schäbel
@@ -67,7 +67,7 @@ public class InternalPublishServiceImpl implements InternalPublishService {
         this.retainedMessagePersistence = retainedMessagePersistence;
         this.topicTree = topicTree;
         this.publishDistributor = publishDistributor;
-        this.acknowledgeAfterPersist = ACKNOWLEDGE_AFTER_PERSIST.get();
+        this.acknowledgeAfterPersist = ACKNOWLEDGE_INCOMING_PUBLISH_AFTER_PERSISTING_ENABLED.get();
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/mqtt/services/PublishPollServiceImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishPollServiceImpl.java
@@ -61,7 +61,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.hivemq.configuration.service.InternalConfigurations.PUBLISH_POLL_BATCH_MEMORY;
+import static com.hivemq.configuration.service.InternalConfigurations.PUBLISH_POLL_BATCH_SIZE_BYTES;
 
 @LazySingleton
 public class PublishPollServiceImpl implements PublishPollService {
@@ -148,7 +148,7 @@ public class PublishPollServiceImpl implements PublishPollService {
             return;
         }
 
-        final ListenableFuture<ImmutableList<PUBLISH>> future = clientQueuePersistence.readNew(client, false, messageIds, PUBLISH_POLL_BATCH_MEMORY);
+        final ListenableFuture<ImmutableList<PUBLISH>> future = clientQueuePersistence.readNew(client, false, messageIds, PUBLISH_POLL_BATCH_SIZE_BYTES);
 
         Futures.addCallback(future, new FutureCallback<>() {
             @Override
@@ -197,7 +197,7 @@ public class PublishPollServiceImpl implements PublishPollService {
 
     @Override
     public void pollInflightMessages(final @NotNull String client, final @NotNull Channel channel) {
-        final ListenableFuture<ImmutableList<MessageWithID>> future = clientQueuePersistence.readInflight(client, PUBLISH_POLL_BATCH_MEMORY, pollMessageLimit(channel));
+        final ListenableFuture<ImmutableList<MessageWithID>> future = clientQueuePersistence.readInflight(client, PUBLISH_POLL_BATCH_SIZE_BYTES, pollMessageLimit(channel));
         Futures.addCallback(future, new FutureCallback<>() {
             @Override
             public void onSuccess(final ImmutableList<MessageWithID> messages) {
@@ -300,7 +300,7 @@ public class PublishPollServiceImpl implements PublishPollService {
             return;
         }
 
-        final ListenableFuture<ImmutableList<PUBLISH>> future = clientQueuePersistence.readShared(sharedSubscription, pollMessageLimit(channel), PUBLISH_POLL_BATCH_MEMORY);
+        final ListenableFuture<ImmutableList<PUBLISH>> future = clientQueuePersistence.readShared(sharedSubscription, pollMessageLimit(channel), PUBLISH_POLL_BATCH_SIZE_BYTES);
 
         Futures.addCallback(future, new FutureCallback<>() {
             @Override

--- a/src/main/java/com/hivemq/persistence/CleanUpService.java
+++ b/src/main/java/com/hivemq/persistence/CleanUpService.java
@@ -95,7 +95,7 @@ public class CleanUpService {
         this.retainedMessagePersistence = retainedMessagePersistence;
         this.clientQueuePersistence = clientQueuePersistence;
         this.persistenceBucketCount = PERSISTENCE_BUCKET_COUNT.get();
-        this.cleanUpJobSchedule = CLEANUP_JOB_SCHEDULE.get();
+        this.cleanUpJobSchedule = INTERVAL_BETWEEN_CLEANUP_JOBS_SEC.get();
     }
 
     @PostConstruct

--- a/src/main/java/com/hivemq/persistence/InMemoryProducerQueues.java
+++ b/src/main/java/com/hivemq/persistence/InMemoryProducerQueues.java
@@ -25,8 +25,6 @@ import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
 import com.hivemq.util.ThreadFactoryUtil;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -70,7 +68,7 @@ public class InMemoryProducerQueues implements ProducerQueues {
         this.persistenceBucketCount = persistenceBucketCount;
         this.amountOfQueues = amountOfQueues;
         bucketsPerQueue = persistenceBucketCount / amountOfQueues;
-        shutdownGracePeriod = InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD.get();
+        shutdownGracePeriod = InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC.get();
 
         final ImmutableList.Builder<AtomicLong> counterBuilder = ImmutableList.builder();
 

--- a/src/main/java/com/hivemq/persistence/PersistenceShutdownHook.java
+++ b/src/main/java/com/hivemq/persistence/PersistenceShutdownHook.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_SHUTDOWN_TIMEOUT;
+import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_SHUTDOWN_TIMEOUT_SEC;
 
 /**
  * @author Lukas Brandl
@@ -105,7 +105,7 @@ public class PersistenceShutdownHook implements HiveMQShutdownHook {
         //We have to use a direct executor service here because the usual persistence executor might already be shut down
         final ListenableFuture<Void> combinedFuture = FutureUtils.voidFutureFromList(builder.build());
 
-        final int shutdownTimeout = PERSISTENCE_SHUTDOWN_TIMEOUT.get();
+        final int shutdownTimeout = PERSISTENCE_SHUTDOWN_TIMEOUT_SEC.get();
 
         try {
             payloadPersistenceExecutor.awaitTermination(shutdownTimeout, TimeUnit.SECONDS);

--- a/src/main/java/com/hivemq/persistence/PersistenceStartup.java
+++ b/src/main/java/com/hivemq/persistence/PersistenceStartup.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT;
+import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT_SEC;
 import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_STARTUP_THREAD_POOL_SIZE;
 
 /**
@@ -91,10 +91,10 @@ public class PersistenceStartup implements HiveMQShutdownHook {
         environmentCreateExecutor.shutdown();
 
         try {
-            if (!persistenceStartExecutor.awaitTermination(PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT.get(), TimeUnit.SECONDS)) {
+            if (!persistenceStartExecutor.awaitTermination(PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT_SEC.get(), TimeUnit.SECONDS)) {
                 persistenceStartExecutor.shutdownNow();
             }
-            if (!environmentCreateExecutor.awaitTermination(PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT.get(), TimeUnit.SECONDS)) {
+            if (!environmentCreateExecutor.awaitTermination(PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT_SEC.get(), TimeUnit.SECONDS)) {
                 environmentCreateExecutor.shutdownNow();
             }
         } catch (final InterruptedException e) {

--- a/src/main/java/com/hivemq/persistence/SingleWriterServiceImpl.java
+++ b/src/main/java/com/hivemq/persistence/SingleWriterServiceImpl.java
@@ -30,11 +30,10 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.util.SplittableRandom;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hivemq.configuration.service.InternalConfigurations.SINGLE_WRITER_CHECK_SCHEDULE;
+import static com.hivemq.configuration.service.InternalConfigurations.SINGLE_WRITER_INTERVAL_TO_CHECK_PENDING_TASKS_AND_SCHEDULE_MSEC;
 
 /**
  * @author Lukas Brandl
@@ -79,7 +78,7 @@ public class SingleWriterServiceImpl implements SingleWriterService {
         persistenceBucketCount = InternalConfigurations.PERSISTENCE_BUCKET_COUNT.get();
         threadPoolSize = InternalConfigurations.SINGLE_WRITER_THREAD_POOL_SIZE.get();
         creditsPerExecution = InternalConfigurations.SINGLE_WRITER_CREDITS_PER_EXECUTION.get();
-        shutdownGracePeriod = InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD.get();
+        shutdownGracePeriod = InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC.get();
 
         final ThreadFactory threadFactory = ThreadFactoryUtil.create("single-writer-%d");
         singleWriterExecutor = Executors.newFixedThreadPool(threadPoolSize, threadFactory);
@@ -119,7 +118,7 @@ public class SingleWriterServiceImpl implements SingleWriterService {
             } catch (final Exception e) {
                 log.error("Exception in single writer check task ", e);
             }
-        }, SINGLE_WRITER_CHECK_SCHEDULE.get(), SINGLE_WRITER_CHECK_SCHEDULE.get(), TimeUnit.MILLISECONDS);
+        }, SINGLE_WRITER_INTERVAL_TO_CHECK_PENDING_TASKS_AND_SCHEDULE_MSEC.get(), SINGLE_WRITER_INTERVAL_TO_CHECK_PENDING_TASKS_AND_SCHEDULE_MSEC.get(), TimeUnit.MILLISECONDS);
     }
 
     @VisibleForTesting

--- a/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistence.java
@@ -123,7 +123,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
         super(environmentUtil, localPersistenceFileUtil, persistenceStartup,
                 InternalConfigurations.PERSISTENCE_BUCKET_COUNT.get(), true);
         retainedMessageMax = InternalConfigurations.RETAINED_MESSAGE_QUEUE_SIZE.get();
-        qos0ClientMemoryLimit = InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.get();
+        qos0ClientMemoryLimit = InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.get();
 
         this.serializer = new ClientQueuePersistenceSerializer(payloadPersistence);
         this.messageDroppedService = messageDroppedService;
@@ -134,7 +134,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
         this.qos0MemoryLimit = getQos0MemoryLimit();
         this.clientQos0MemoryMap = new ConcurrentHashMap<>();
         this.sharedSubLastPacketWithoutIdCache = CacheBuilder.newBuilder()
-                .maximumSize(InternalConfigurations.SHARED_SUBSCRIPTION_WITHOUT_PACKET_ID_CACHE_MAX_SIZE.get())
+                .maximumSize(InternalConfigurations.SHARED_SUBSCRIPTION_WITHOUT_PACKET_ID_CACHE_MAX_SIZE_ENTRIES.get())
                 .expireAfterAccess(60, TimeUnit.SECONDS)
                 .build();
     }
@@ -1031,7 +1031,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
                     final MessageWithID message = serializer.deserializeValue(serializedValue);
                     if (message instanceof PUBREL) {
                         final PUBREL pubrel = (PUBREL) message;
-                        if (!InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS) {
+                        if (!InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED) {
                             return true;
                         }
                         if (pubrel.getExpiryInterval() == null || pubrel.getPublishTimestamp() == null) {
@@ -1048,7 +1048,7 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
 
                     } else if (message instanceof PUBLISH) {
                         final PUBLISH publish = (PUBLISH) message;
-                        final boolean expireInflight = InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES;
+                        final boolean expireInflight = InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES_ENABLED;
                         final boolean isInflight = publish.getQoS() == QoS.EXACTLY_ONCE && publish.getPacketIdentifier() > 0;
                         final boolean drop = PublishUtil.checkExpiry(publish) && (!isInflight || expireInflight);
                         if (drop) {

--- a/src/main/java/com/hivemq/persistence/clientsession/PendingWillMessages.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/PendingWillMessages.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.hivemq.configuration.service.InternalConfigurations.WILL_DELAY_CHECK_SCHEDULE;
+import static com.hivemq.configuration.service.InternalConfigurations.WILL_DELAY_CHECK_INTERVAL_SEC;
 
 /**
  * @author Lukas Brandl
@@ -71,7 +71,7 @@ public class PendingWillMessages {
         this.clientSessionPersistence = clientSessionPersistence;
         this.clientSessionLocalPersistence = clientSessionLocalPersistence;
         this.metricsHolder = metricsHolder;
-        executorService.scheduleAtFixedRate(new CheckWillsTask(), WILL_DELAY_CHECK_SCHEDULE, WILL_DELAY_CHECK_SCHEDULE, TimeUnit.SECONDS);
+        executorService.scheduleAtFixedRate(new CheckWillsTask(), WILL_DELAY_CHECK_INTERVAL_SEC, WILL_DELAY_CHECK_INTERVAL_SEC, TimeUnit.SECONDS);
     }
 
     public void addWill(final @NotNull String clientId, final @NotNull ClientSession session) {

--- a/src/main/java/com/hivemq/persistence/clientsession/SharedSubscriptionServiceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/SharedSubscriptionServiceImpl.java
@@ -28,7 +28,6 @@ import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -77,16 +76,16 @@ public class SharedSubscriptionServiceImpl implements SharedSubscriptionService 
     void postConstruct() {
 
         sharedSubscriberCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(SHARED_SUBSCRIBER_CACHE_DURATION, TimeUnit.MILLISECONDS)
+                .expireAfterWrite(SHARED_SUBSCRIBER_CACHE_TIME_TO_LIVE_MSEC, TimeUnit.MILLISECONDS)
                 .concurrencyLevel(SHARED_SUBSCRIBER_CACHE_CONCURRENCY_LEVEL.get())
-                .maximumSize(SHARED_SUBSCRIBER_CACHE_SIZE)
+                .maximumSize(SHARED_SUBSCRIBER_CACHE_MAX_SIZE_SUBSCRIBERS)
                 .recordStats()
                 .build();
 
         sharedSubscriptionCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(SHARED_SUBSCRIPTION_CACHE_DURATION, TimeUnit.MILLISECONDS)
+                .expireAfterWrite(SHARED_SUBSCRIPTION_CACHE_TIME_TO_LIVE_MSEC, TimeUnit.MILLISECONDS)
                 .concurrencyLevel(SHARED_SUBSCRIPTION_CACHE_CONCURRENCY_LEVEL.get())
-                .maximumSize(SHARED_SUBSCRIPTION_CACHE_SIZE)
+                .maximumSize(SHARED_SUBSCRIPTION_CACHE_MAX_SIZE_SUBSCRIPTIONS)
                 .recordStats()
                 .build();
     }

--- a/src/main/java/com/hivemq/persistence/connection/ConnectionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/connection/ConnectionPersistenceImpl.java
@@ -54,7 +54,7 @@ public class ConnectionPersistenceImpl implements ConnectionPersistence {
     @Inject
     public ConnectionPersistenceImpl() {
         shutdownLegacy = InternalConfigurations.NETTY_SHUTDOWN_LEGACY;
-        shutdownPartitionSize = InternalConfigurations.NETTY_SHUTDOWN_PARTITION_SIZE;
+        shutdownPartitionSize = InternalConfigurations.NETTY_COUNT_OF_CONNECTIONS_IN_SHUTDOWN_PARTITION;
         interrupted = new AtomicBoolean(false);
         clientConnectionMap = new ConcurrentHashMap<>();
         serverChannelMap = new ConcurrentHashMap<>();

--- a/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -101,7 +101,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         this.messageDroppedService = messageDroppedService;
 
         qos0MemoryLimit = getQos0MemoryLimit();
-        qos0ClientMemoryLimit = InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.get();
+        qos0ClientMemoryLimit = InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.get();
         retainedMessageMax = InternalConfigurations.RETAINED_MESSAGE_QUEUE_SIZE.get();
 
         qos0MessagesMemory = new AtomicLong();
@@ -820,7 +820,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             final MessageWithID messageWithID = qos12iterator.next();
             if (messageWithID instanceof PubrelWithRetained) {
                 final PubrelWithRetained pubrel = (PubrelWithRetained) messageWithID;
-                if (!InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS) {
+                if (!InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED) {
                     continue;
                 }
                 if (pubrel.getExpiryInterval() == null || pubrel.getPublishTimestamp() == null) {
@@ -837,7 +837,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
             } else if (messageWithID instanceof PublishWithRetained) {
                 final PublishWithRetained publish = (PublishWithRetained) messageWithID;
-                final boolean expireInflight = InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES;
+                final boolean expireInflight = InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES_ENABLED;
                 final boolean isInflight = publish.getQoS() == QoS.EXACTLY_ONCE && publish.getPacketIdentifier() > 0;
                 final boolean drop = PublishUtil.checkExpiry(publish) && (!isInflight || expireInflight);
                 if (drop) {

--- a/src/main/java/com/hivemq/persistence/local/rocksdb/RocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/rocksdb/RocksDBLocalPersistence.java
@@ -109,11 +109,11 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
             options.setTableFormatConfig(tableConfig);
             options.setWriteBufferSize(memtableSize);
 
-            options.setStatsPersistPeriodSec(InternalConfigurations.ROCKSDB_STATS_PERSIST_PERIOD);
-            options.setStatsDumpPeriodSec(InternalConfigurations.ROCKSDB_STATS_PERSIST_PERIOD);
-            options.setMaxLogFileSize(InternalConfigurations.ROCKSDB_MAX_LOG_FILE_SIZE);
-            options.setKeepLogFileNum(InternalConfigurations.ROCKSDB_LOG_FILE_NUMBER);
-            options.setStatsHistoryBufferSize(InternalConfigurations.ROCKSDB_STATS_HISTORY_BUFFER_SIZE);
+            options.setStatsPersistPeriodSec(InternalConfigurations.ROCKSDB_STATS_PERSIST_PERIOD_SEC);
+            options.setStatsDumpPeriodSec(InternalConfigurations.ROCKSDB_STATS_PERSIST_PERIOD_SEC);
+            options.setMaxLogFileSize(InternalConfigurations.ROCKSDB_MAX_LOG_FILE_SIZE_BYTES);
+            options.setKeepLogFileNum(InternalConfigurations.ROCKSDB_LOG_FILES_COUNT);
+            options.setStatsHistoryBufferSize(InternalConfigurations.OCKSDB_STATS_HISTORY_BUFFER_SIZE_BYTES);
 
             for (int i = 0; i < bucketCount; i++) {
                 final File persistenceFile = new File(persistenceFolder, name + "_" + i);
@@ -149,11 +149,11 @@ public abstract class RocksDBLocalPersistence implements LocalPersistence, FileP
             options.setTableFormatConfig(tableConfig);
             options.setWriteBufferSize(memtableSize);
 
-            options.setStatsPersistPeriodSec(InternalConfigurations.ROCKSDB_STATS_PERSIST_PERIOD);
-            options.setStatsDumpPeriodSec(InternalConfigurations.ROCKSDB_STATS_PERSIST_PERIOD);
-            options.setMaxLogFileSize(InternalConfigurations.ROCKSDB_MAX_LOG_FILE_SIZE);
-            options.setKeepLogFileNum(InternalConfigurations.ROCKSDB_LOG_FILE_NUMBER);
-            options.setStatsHistoryBufferSize(InternalConfigurations.ROCKSDB_STATS_HISTORY_BUFFER_SIZE);
+            options.setStatsPersistPeriodSec(InternalConfigurations.ROCKSDB_STATS_PERSIST_PERIOD_SEC);
+            options.setStatsDumpPeriodSec(InternalConfigurations.ROCKSDB_STATS_PERSIST_PERIOD_SEC);
+            options.setMaxLogFileSize(InternalConfigurations.ROCKSDB_MAX_LOG_FILE_SIZE_BYTES);
+            options.setKeepLogFileNum(InternalConfigurations.ROCKSDB_LOG_FILES_COUNT);
+            options.setStatsHistoryBufferSize(InternalConfigurations.OCKSDB_STATS_HISTORY_BUFFER_SIZE_BYTES);
 
             final File persistenceFolder = localPersistenceFileUtil.getVersionedLocalPersistenceFolder(name, version);
             final CountDownLatch counter = new CountDownLatch(bucketCount);

--- a/src/main/java/com/hivemq/persistence/local/xodus/EnvironmentUtil.java
+++ b/src/main/java/com/hivemq/persistence/local/xodus/EnvironmentUtil.java
@@ -53,12 +53,12 @@ public class EnvironmentUtil {
 
         return createEnvironmentConfig(
                 XODUS_PERSISTENCE_ENVIRONMENT_GC_MIN_AGE,
-                XODUS_PERSISTENCE_ENVIRONMENT_GC_DELETION_DELAY,
+                XODUS_PERSISTENCE_ENVIRONMENT_GC_DELETION_DELAY_MSEC,
                 XODUS_PERSISTENCE_ENVIRONMENT_GC_FILES_INTERVAL,
-                XODUS_PERSISTENCE_ENVIRONMENT_GC_RUN_PERIOD,
+                XODUS_PERSISTENCE_ENVIRONMENT_GC_RUN_PERIOD_MSEC,
                 XODUS_PERSISTENCE_ENVIRONMENT_GC_TYPE,
-                XODUS_PERSISTENCE_ENVIRONMENT_SYNC_PERIOD,
-                XODUS_PERSISTENCE_ENVIRONMENT_DURABLE_WRITES,
+                XODUS_PERSISTENCE_ENVIRONMENT_SYNC_PERIOD_MSEC,
+                XODUS_PERSISTENCE_ENVIRONMENT_DURABLE_WRITES_ENABLED,
                 XODUS_PERSISTENCE_ENVIRONMENT_JMX,
                 name
         );
@@ -128,7 +128,7 @@ public class EnvironmentUtil {
         final PersistenceType retainedMessagePersistenceType = InternalConfigurations.RETAINED_MESSAGE_PERSISTENCE_TYPE.get();
         // Use the default cache size if only xodus persistences are used.
         if (payloadPersistenceType != PersistenceType.FILE && retainedMessagePersistenceType != PersistenceType.FILE) {
-            final int logCacheMemory = InternalConfigurations.XODUS_PERSISTENCE_LOG_MEMORY_PERCENTAGE;
+            final int logCacheMemory = InternalConfigurations.XODUS_PERSISTENCE_LOG_MEMORY_HEAP_PERCENTAGE;
             log.trace("Setting log cache memory percentage for persistence {} to {}", name, logCacheMemory);
             environmentConfig.setMemoryUsagePercentage(logCacheMemory);
         }

--- a/src/main/java/com/hivemq/persistence/local/xodus/RetainedMessageRocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/xodus/RetainedMessageRocksDBLocalPersistence.java
@@ -72,7 +72,7 @@ public class RetainedMessageRocksDBLocalPersistence extends RocksDBLocalPersiste
                 InternalConfigurations.PERSISTENCE_BUCKET_COUNT.get(),
                 InternalConfigurations.RETAINED_MESSAGE_MEMTABLE_SIZE_PORTION,
                 InternalConfigurations.RETAINED_MESSAGE_BLOCK_CACHE_SIZE_PORTION,
-                InternalConfigurations.RETAINED_MESSAGE_BLOCK_SIZE,
+                InternalConfigurations.RETAINED_MESSAGE_BLOCK_SIZE_BYTES,
                 InternalConfigurations.RETAINED_MESSAGE_PERSISTENCE_TYPE.get() == PersistenceType.FILE_NATIVE);
 
         this.payloadPersistence = payloadPersistence;

--- a/src/main/java/com/hivemq/persistence/local/xodus/XodusLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/xodus/XodusLocalPersistence.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_CLOSE_RETRIES;
-import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL;
+import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC;
 
 public abstract class XodusLocalPersistence implements LocalPersistence, FilePersistence {
 
@@ -67,7 +67,7 @@ public abstract class XodusLocalPersistence implements LocalPersistence, FilePer
         this.enabled = enabled;
 
         this.closeRetries = PERSISTENCE_CLOSE_RETRIES.get();
-        this.closeRetryInterval = PERSISTENCE_CLOSE_RETRY_INTERVAL.get();
+        this.closeRetryInterval = PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.get();
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImpl.java
@@ -72,11 +72,11 @@ public class PublishPayloadPersistenceImpl implements PublishPayloadPersistence 
         this.scheduledExecutorService = scheduledExecutorService;
 
         payloadCache = CacheBuilder.newBuilder()
-                .expireAfterAccess(InternalConfigurations.PAYLOAD_CACHE_DURATION.get(), TimeUnit.MILLISECONDS)
+                .expireAfterAccess(InternalConfigurations.PAYLOAD_CACHE_DURATION_MSEC.get(), TimeUnit.MILLISECONDS)
                 .maximumSize(InternalConfigurations.PAYLOAD_CACHE_SIZE.get())
-                .concurrencyLevel(InternalConfigurations.PAYLOAD_CACHE_CONCURRENCY_LEVEL.get())
+                .concurrencyLevel(InternalConfigurations.PAYLOAD_CACHE_CONCURRENCY_LEVEL_THREADS.get())
                 .build();
-        removeSchedule = InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE.get();
+        removeSchedule = InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE_MSEC.get();
         int bucketLockCount = InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.get();
         bucketLock = new BucketLock(bucketLockCount);
         payloadReferenceCounterRegistry = new PayloadReferenceCounterRegistryImpl(bucketLock);
@@ -85,7 +85,7 @@ public class PublishPayloadPersistenceImpl implements PublishPayloadPersistence 
     // The payload persistence has to be initialized after the other persistence bootstraps are finished.
     @Override
     public void init() {
-        final long removeDelay = InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_DELAY.get();
+        final long removeDelay = InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_DELAY_MSEC.get();
         final int cleanupThreadCount = InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_THREADS.get();
         final long taskSchedule = removeSchedule * cleanupThreadCount;
         for (int i = 0; i < cleanupThreadCount; i++) {

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistence.java
@@ -74,7 +74,7 @@ public class PublishPayloadRocksDBLocalPersistence extends RocksDBLocalPersisten
                 InternalConfigurations.PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION.get() /
                 InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.get();
         this.rocksdbToMemTableSize = new long[InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.get()];
-        this.forceFlush = InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH.get();
+        this.forceFlush = InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH_ENABLED.get();
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistence.java
@@ -68,7 +68,7 @@ public class PublishPayloadRocksDBLocalPersistence extends RocksDBLocalPersisten
                 InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.get(),
                 InternalConfigurations.PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION.get(),
                 InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_CACHE_SIZE_PORTION.get(),
-                InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_SIZE,
+                InternalConfigurations.PAYLOAD_PERSISTENCE_BLOCK_SIZE_BYTES,
                 InternalConfigurations.PAYLOAD_PERSISTENCE_TYPE.get() == PersistenceType.FILE_NATIVE);
         this.memtableSize = PhysicalMemoryUtil.physicalMemory() /
                 InternalConfigurations.PAYLOAD_PERSISTENCE_MEMTABLE_SIZE_PORTION.get() /

--- a/src/main/java/com/hivemq/persistence/retained/RetainedMessagePersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/retained/RetainedMessagePersistenceImpl.java
@@ -24,7 +24,6 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extensions.iteration.ChunkCursor;
 import com.hivemq.extensions.iteration.Chunker;
 import com.hivemq.extensions.iteration.MultipleChunkResult;
-import com.hivemq.extensions.services.publish.RetainedPublishImpl;
 import com.hivemq.mqtt.topic.TopicMatcher;
 import com.hivemq.persistence.AbstractPersistence;
 import com.hivemq.persistence.ProducerQueues;
@@ -183,7 +182,7 @@ public class RetainedMessagePersistenceImpl extends AbstractPersistence implemen
     @Override
     public @NotNull ListenableFuture<MultipleChunkResult<Map<String, @NotNull RetainedMessage>>> getAllLocalRetainedMessagesChunk(
             @NotNull ChunkCursor cursor) {
-        return chunker.getAllLocalChunk(cursor, InternalConfigurations.PERSISTENCE_RETAINED_MESSAGES_MAX_CHUNK_MEMORY,
+        return chunker.getAllLocalChunk(cursor, InternalConfigurations.PERSISTENCE_RETAINED_MESSAGES_MAX_CHUNK_MEMORY_BYTES,
                 // Chunker.SingleWriterCall interface
                 (bucket, lastKey, maxResults) ->
                         // actual single writer call

--- a/src/main/java/com/hivemq/security/ssl/SslContextStore.java
+++ b/src/main/java/com/hivemq/security/ssl/SslContextStore.java
@@ -45,7 +45,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.hivemq.configuration.service.InternalConfigurations.SSL_RELOAD_ENABLED;
-import static com.hivemq.configuration.service.InternalConfigurations.SSL_RELOAD_INTERVAL;
+import static com.hivemq.configuration.service.InternalConfigurations.SSL_RELOAD_INTERVAL_SEC;
 
 /**
  * @author Christoph Schäbel
@@ -88,7 +88,7 @@ public class SslContextStore {
             executorService.schedule(new SslContextFirstTimeRunnable(tls,
                             sslContextMap,
                             checksumMap,
-                            SSL_RELOAD_INTERVAL,
+                            SSL_RELOAD_INTERVAL_SEC,
                             executorService,
                             sslUtil),
                     0,
@@ -106,7 +106,7 @@ public class SslContextStore {
             new SslContextFirstTimeRunnable(tls,
                     sslContextMap,
                     checksumMap,
-                    SSL_RELOAD_INTERVAL,
+                    SSL_RELOAD_INTERVAL_SEC,
                     executorService,
                     sslUtil).run();
         }

--- a/src/main/java/com/hivemq/statistics/UsageStatistics.java
+++ b/src/main/java/com/hivemq/statistics/UsageStatistics.java
@@ -124,7 +124,7 @@ public class UsageStatistics {
             } finally {
                 //reschedule
                 scheduledExecutorService.schedule(new SendStatisticsTask(statisticsSender, statisticsCollector,
-                        scheduledExecutorService, "runtime"), InternalConfigurations.STATISTICS_SEND_EVERY_MINUTES, TimeUnit.MINUTES);
+                        scheduledExecutorService, "runtime"), InternalConfigurations.USAGE_STATISTICS_SEND_INTERVAL_MINUTES, TimeUnit.MINUTES);
             }
         }
     }

--- a/src/main/java/com/hivemq/throttling/ioc/GlobalTrafficShapingProvider.java
+++ b/src/main/java/com/hivemq/throttling/ioc/GlobalTrafficShapingProvider.java
@@ -66,7 +66,7 @@ public class GlobalTrafficShapingProvider implements Provider<GlobalTrafficShapi
         final long incomingLimit = restrictionsConfigurationService.incomingLimit();
         log.debug("Throttling incoming traffic to {} B/s", incomingLimit);
 
-        final long outgoinglimit = InternalConfigurations.OUTGOING_BANDWIDTH_THROTTLING_DEFAULT;
+        final long outgoinglimit = InternalConfigurations.OUTGOING_BANDWIDTH_THROTTLING_DEFAULT_BYTES_PER_SEC;
         log.debug("Throttling outgoing traffic to {} B/s", outgoinglimit);
 
         return new GlobalTrafficShapingHandler(scheduledExecutorService, outgoinglimit, incomingLimit, 1000L);

--- a/src/main/java/com/hivemq/util/ChannelUtils.java
+++ b/src/main/java/com/hivemq/util/ChannelUtils.java
@@ -94,7 +94,7 @@ public final class ChannelUtils {
 
     public static int maxInflightWindow(@NotNull final Channel channel) {
         final Integer clientReceiveMaximum = channel.attr(ChannelAttributes.CLIENT_CONNECTION).get().getClientReceiveMaximum();
-        final int max = InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE;
+        final int max = InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES;
         if (clientReceiveMaximum == null) {
             return max;
         }

--- a/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
@@ -166,7 +166,7 @@ public class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
 
 
         final FullConfigurationService fullConfig = new TestConfigurationBootstrap().getFullConfigurationService();
-        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT.set(47);
+        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT_BYTES.set(47);
 
         channel = new EmbeddedChannel(TestMqttDecoder.create(fullConfig));
         clientConnection = new ClientConnection(channel, null);
@@ -197,7 +197,7 @@ public class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
 
 
         final FullConfigurationService fullConfig = new TestConfigurationBootstrap().getFullConfigurationService();
-        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT.set(100);
+        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT_BYTES.set(100);
 
         channel = new EmbeddedChannel(TestMqttDecoder.create(fullConfig));
         clientConnection = new ClientConnection(channel, null);
@@ -1163,7 +1163,7 @@ public class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
 
     @Test
     public void decode_noTopicAliasFound_returnsNull() {
-        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT.set(1024 * 1024 * 200);
+        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT_BYTES.set(1024 * 1024 * 200);
         channel = new EmbeddedChannel(TestMqttDecoder.create());
         clientConnection = new ClientConnection(channel, null);
         channel.attr(ChannelAttributes.CLIENT_CONNECTION).set(clientConnection);

--- a/src/test/java/com/hivemq/extensions/executor/PluginTaskExecutorServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/executor/PluginTaskExecutorServiceImplTest.java
@@ -58,7 +58,7 @@ public class PluginTaskExecutorServiceImplTest {
     public void before() {
         MockitoAnnotations.initMocks(this);
 
-        InternalConfigurations.PLUGIN_TASK_QUEUE_EXECUTOR_COUNT.set(2);
+        InternalConfigurations.EXTENSION_TASK_QUEUE_EXECUTOR_THREADS_COUNT.set(2);
 
         executorService =
                 new PluginTaskExecutorServiceImpl(new ExecutorProvider(Lists.newArrayList(executor1, executor2)),

--- a/src/test/java/com/hivemq/extensions/services/PluginServiceRateLimitServiceTest.java
+++ b/src/test/java/com/hivemq/extensions/services/PluginServiceRateLimitServiceTest.java
@@ -44,7 +44,7 @@ public class PluginServiceRateLimitServiceTest {
 
     @Test
     public void test_limit() {
-        InternalConfigurations.PLUGIN_SERVICE_RATE_LIMIT.set(10);
+        InternalConfigurations.EXTENSION_SERVICE_CALL_RATE_LIMIT_PER_SEC.set(10);
 
         pluginServiceRateLimitService = new PluginServiceRateLimitService();
 
@@ -61,7 +61,7 @@ public class PluginServiceRateLimitServiceTest {
 
     @Test
     public void test_limit_not_exceeded() {
-        InternalConfigurations.PLUGIN_SERVICE_RATE_LIMIT.set(2);
+        InternalConfigurations.EXTENSION_SERVICE_CALL_RATE_LIMIT_PER_SEC.set(2);
 
         pluginServiceRateLimitService = new PluginServiceRateLimitService();
 

--- a/src/test/java/com/hivemq/extensions/services/executor/GlobalManagedExtensionExecutorServiceTest.java
+++ b/src/test/java/com/hivemq/extensions/services/executor/GlobalManagedExtensionExecutorServiceTest.java
@@ -35,8 +35,8 @@ public class GlobalManagedExtensionExecutorServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        InternalConfigurations.MANAGED_PLUGIN_THREAD_POOL_KEEP_ALIVE_SECONDS.set(60);
-        InternalConfigurations.MANAGED_PLUGIN_THREAD_POOL_SIZE.set(4);
+        InternalConfigurations.MANAGED_EXTENSION_THREAD_POOL_KEEP_ALIVE_SEC.set(60);
+        InternalConfigurations.MANAGED_EXTENSION_THREAD_POOL_THREADS_COUNT.set(4);
 
         managedPluginExecutorService = new GlobalManagedExtensionExecutorService(shutdownHooks);
     }

--- a/src/test/java/com/hivemq/extensions/services/executor/ManagedExecutorServicePerExtensionTest.java
+++ b/src/test/java/com/hivemq/extensions/services/executor/ManagedExecutorServicePerExtensionTest.java
@@ -56,8 +56,8 @@ public class ManagedExecutorServicePerExtensionTest {
 
     @Before
     public void setUp() throws Exception {
-        InternalConfigurations.MANAGED_PLUGIN_THREAD_POOL_KEEP_ALIVE_SECONDS.set(60);
-        InternalConfigurations.MANAGED_PLUGIN_THREAD_POOL_SIZE.set(4);
+        InternalConfigurations.MANAGED_EXTENSION_THREAD_POOL_KEEP_ALIVE_SEC.set(60);
+        InternalConfigurations.MANAGED_EXTENSION_THREAD_POOL_THREADS_COUNT.set(4);
 
         when(hiveMQExtensions.getExtensionForClassloader(classLoader)).thenReturn(extension);
 

--- a/src/test/java/com/hivemq/limitation/TopicAliasLimiterImplTest.java
+++ b/src/test/java/com/hivemq/limitation/TopicAliasLimiterImplTest.java
@@ -36,8 +36,8 @@ public class TopicAliasLimiterImplTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_SOFT_LIMIT.set(50);
-        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT.set(200);
+        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_SOFT_LIMIT_BYTES.set(50);
+        InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT_BYTES.set(200);
 
         topicAliasLimiter = new TopicAliasLimiterImpl();
     }

--- a/src/test/java/com/hivemq/mqtt/handler/connack/MqttConnackerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connack/MqttConnackerTest.java
@@ -70,8 +70,8 @@ public class MqttConnackerTest {
     @After
     public void tearDown() throws Exception {
         LogbackCapturingAppender.Factory.cleanUp();
-        InternalConfigurations.CONNACK_WITH_REASON_CODE.set(true);
-        InternalConfigurations.CONNACK_WITH_REASON_STRING.set(true);
+        InternalConfigurations.CONNACK_WITH_REASON_CODE_ENABLED.set(true);
+        InternalConfigurations.CONNACK_WITH_REASON_STRING_ENABLED.set(true);
     }
 
     @Test(expected = NullPointerException.class)
@@ -266,7 +266,7 @@ public class MqttConnackerTest {
 
     @Test(timeout = 20000)
     public void test_connackError_mqtt_3_1_without_reason_code() {
-        InternalConfigurations.CONNACK_WITH_REASON_CODE.set(false);
+        InternalConfigurations.CONNACK_WITH_REASON_CODE_ENABLED.set(false);
         mqttConnacker = new MqttConnackerImpl(eventLog);
         final ClientConnection clientConnection = new ClientConnection(channel, null);
         channel.attr(ChannelAttributes.CLIENT_CONNECTION).set(clientConnection);
@@ -384,7 +384,7 @@ public class MqttConnackerTest {
 
     @Test(timeout = 20000)
     public void test_connackError_mqtt_5_without_reason_string() throws InterruptedException {
-        InternalConfigurations.CONNACK_WITH_REASON_STRING.set(false);
+        InternalConfigurations.CONNACK_WITH_REASON_STRING_ENABLED.set(false);
         mqttConnacker = new MqttConnackerImpl(eventLog);
         final ClientConnection clientConnection = new ClientConnection(channel, null);
         channel.attr(ChannelAttributes.CLIENT_CONNECTION).set(clientConnection);
@@ -403,7 +403,7 @@ public class MqttConnackerTest {
 
     @Test(timeout = 20000)
     public void test_connackError_mqtt_5_without_reason_code() {
-        InternalConfigurations.CONNACK_WITH_REASON_CODE.set(false);
+        InternalConfigurations.CONNACK_WITH_REASON_CODE_ENABLED.set(false);
         mqttConnacker = new MqttConnackerImpl(eventLog);
         final ClientConnection clientConnection = new ClientConnection(channel, null);
         channel.attr(ChannelAttributes.CLIENT_CONNECTION).set(clientConnection);

--- a/src/test/java/com/hivemq/mqtt/handler/disconnect/MqttServerDisconnectorTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/disconnect/MqttServerDisconnectorTest.java
@@ -58,8 +58,8 @@ public class MqttServerDisconnectorTest {
 
     @After
     public void tearDown() throws Exception {
-        InternalConfigurations.DISCONNECT_WITH_REASON_CODE.set(true);
-        InternalConfigurations.DISCONNECT_WITH_REASON_STRING.set(true);
+        InternalConfigurations.DISCONNECT_WITH_REASON_CODE_ENABLED.set(true);
+        InternalConfigurations.DISCONNECT_WITH_REASON_STRING_ENABLED.set(true);
     }
 
     @Test
@@ -105,8 +105,8 @@ public class MqttServerDisconnectorTest {
     @Test
     public void test_disconnect_channel_without_reason_code_and_reason_string() throws InterruptedException {
 
-        InternalConfigurations.DISCONNECT_WITH_REASON_CODE.set(false);
-        InternalConfigurations.DISCONNECT_WITH_REASON_STRING.set(false);
+        InternalConfigurations.DISCONNECT_WITH_REASON_CODE_ENABLED.set(false);
+        InternalConfigurations.DISCONNECT_WITH_REASON_STRING_ENABLED.set(false);
 
         mqttServerDisconnector = new MqttServerDisconnectorImpl(eventLog);
 
@@ -166,7 +166,7 @@ public class MqttServerDisconnectorTest {
     @Test
     public void test_disconnect_channel_with_reason_code_and_reason_string_not_wanted() throws InterruptedException {
 
-        InternalConfigurations.DISCONNECT_WITH_REASON_STRING.set(false);
+        InternalConfigurations.DISCONNECT_WITH_REASON_STRING_ENABLED.set(false);
 
         mqttServerDisconnector = new MqttServerDisconnectorImpl(eventLog);
 

--- a/src/test/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandlerTest.java
@@ -172,7 +172,7 @@ public class MessageExpiryHandlerTest {
 
     @Test
     public void test_message_expired_qos_2_dup() throws Exception {
-        InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES = true;
+        InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES_ENABLED = true;
         final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic", QoS.EXACTLY_ONCE);
         publish.setMessageExpiryInterval(1);
         publish.setDuplicateDelivery(true);
@@ -197,7 +197,7 @@ public class MessageExpiryHandlerTest {
 
     @Test
     public void test_pubrel_expired() throws InterruptedException {
-        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS = true;
+        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED = true;
 
         final PUBREL pubrel = new PUBREL(1);
         pubrel.setExpiryInterval(0L);
@@ -221,7 +221,7 @@ public class MessageExpiryHandlerTest {
 
     @Test
     public void test_pubrel_dont_expired() throws InterruptedException {
-        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS = false;
+        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED = false;
         final PUBREL pubrel = new PUBREL(1);
         pubrel.setExpiryInterval(0L);
         pubrel.setPublishTimestamp(System.currentTimeMillis());

--- a/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlowHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlowHandlerTest.java
@@ -81,7 +81,7 @@ public class PublishFlowHandlerTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE = 5;
+        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 5;
         when(pool.takeNextId()).thenReturn(100);
         orderedTopicService = new OrderedTopicService();
         channel = new EmbeddedChannel(new PublishFlowHandler(publishPollService,
@@ -95,7 +95,7 @@ public class PublishFlowHandlerTest {
 
     @After
     public void tearDown() throws Exception {
-        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE = 50;
+        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 50;
     }
 
     @Test
@@ -520,7 +520,7 @@ public class PublishFlowHandlerTest {
     @Test(timeout = 5000)
     public void test_qos1_release_next_message_on_dropped() throws Exception {
 
-        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE = 1;
+        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 1;
 
         final PUBLISH publish = createPublish("topic", 1, QoS.AT_LEAST_ONCE);
         final PUBLISH publish2 = createPublish("topic", 2, QoS.AT_LEAST_ONCE);
@@ -629,7 +629,7 @@ public class PublishFlowHandlerTest {
 
     @Test(timeout = 4_000)
     public void test_remove_messages() throws Exception {
-        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE = 1;
+        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 1;
 
         final PUBLISH publish1 = createPublish("topic", 1, QoS.AT_LEAST_ONCE);
         final PUBLISH publish2 = createPublish("topic", 2, QoS.AT_LEAST_ONCE);
@@ -667,7 +667,7 @@ public class PublishFlowHandlerTest {
     @Test(timeout = 5000)
     public void test_qos2_release_next_message_on_next_pubcomp() throws Exception {
 
-        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE = 1;
+        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 1;
 
         final PUBLISH publish = createPublish("topic", 1, QoS.EXACTLY_ONCE);
         final PUBLISH publish2 = createPublish("topic", 2, QoS.EXACTLY_ONCE);
@@ -695,7 +695,7 @@ public class PublishFlowHandlerTest {
     @Test(timeout = 5000)
     public void test_qos2_release_next_message_on_failed_pubrec() throws Exception {
 
-        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE = 1;
+        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 1;
 
         final PUBLISH publish = createPublish("topic", 1, QoS.EXACTLY_ONCE);
         final PUBLISH publish2 = createPublish("topic", 2, QoS.EXACTLY_ONCE);
@@ -764,7 +764,7 @@ public class PublishFlowHandlerTest {
     public void test_max_inflight_window() throws Exception {
 
         channel.attr(ChannelAttributes.CLIENT_CONNECTION).get().setClientReceiveMaximum(50);
-        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE = 3;
+        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 3;
 
 
         final PUBLISH publish = createPublish("topic", 1, QoS.EXACTLY_ONCE);

--- a/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlushHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlushHandlerTest.java
@@ -110,7 +110,7 @@ public class PublishFlushHandlerTest {
     public void whenMaxPublishesBeforeFlushIsOne_thenFlushIsTriggeredAfterEachPublish() {
         when(channel.isWritable()).thenReturn(true);
         when(channel.isActive()).thenReturn(true);
-        InternalConfigurations.MAX_PUBLISHES_BEFORE_FLUSH.set(1);
+        InternalConfigurations.COUNT_OF_PUBLISHES_WRITTEN_TO_CHANNEL_TO_TRIGGER_FLUSH.set(1);
         publishFlushHandler = new PublishFlushHandler(metricsHolder);
         publishFlushHandler.handlerAdded(channelHandlerContext);
         final PUBLISH publish = new PUBLISHFactory.Mqtt3Builder().withTopic("topic").withHivemqId("hivemqId").withQoS(QoS.AT_LEAST_ONCE).withOnwardQos(QoS.AT_LEAST_ONCE).withPayload(new byte[100]).build();

--- a/src/test/java/com/hivemq/mqtt/services/PublishPollServiceImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/services/PublishPollServiceImplTest.java
@@ -136,7 +136,7 @@ public class PublishPollServiceImplTest {
         when(channel.writeAndFlush(any())).thenReturn(channelFuture);
 
         InternalConfigurations.PUBLISH_POLL_BATCH_SIZE = 50;
-        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE = 50;
+        InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 50;
 
         singleWriterService = TestSingleWriterFactory.defaultSingleWriter();
 

--- a/src/test/java/com/hivemq/persistence/InMemorySingleWriterServiceTest.java
+++ b/src/test/java/com/hivemq/persistence/InMemorySingleWriterServiceTest.java
@@ -37,7 +37,7 @@ public class InMemorySingleWriterServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD.set(200);
+        InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC.set(200);
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(64);
         singleWriterServiceImpl = new InMemorySingleWriter();
     }

--- a/src/test/java/com/hivemq/persistence/PersistenceShutdownHookTest.java
+++ b/src/test/java/com/hivemq/persistence/PersistenceShutdownHookTest.java
@@ -98,7 +98,7 @@ public class PersistenceShutdownHookTest {
         final SettableFuture<Void> voidSettableFuture = SettableFuture.create();
         when(retainedMessagePersistence.closeDB()).thenReturn(voidSettableFuture);
 
-        InternalConfigurations.PERSISTENCE_SHUTDOWN_TIMEOUT.set(1);
+        InternalConfigurations.PERSISTENCE_SHUTDOWN_TIMEOUT_SEC.set(1);
 
         final long start = System.currentTimeMillis();
         persistenceShutdownHook.run();

--- a/src/test/java/com/hivemq/persistence/PersistenceStartupTest.java
+++ b/src/test/java/com/hivemq/persistence/PersistenceStartupTest.java
@@ -74,7 +74,7 @@ public class PersistenceStartupTest {
     @Test
     public void test_shut_down_interrupts_environment_creation_at_timeout() throws InterruptedException {
 
-        InternalConfigurations.PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT.set(0);
+        InternalConfigurations.PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT_SEC.set(0);
 
         persistenceStartup = new PersistenceStartup();
 
@@ -102,7 +102,7 @@ public class PersistenceStartupTest {
     @Test
     public void test_shut_down_interrupts_start_at_timeout() throws InterruptedException {
 
-        InternalConfigurations.PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT.set(0);
+        InternalConfigurations.PERSISTENCE_STARTUP_SHUTDOWN_TIMEOUT_SEC.set(0);
 
         persistenceStartup = new PersistenceStartup();
 

--- a/src/test/java/com/hivemq/persistence/SingleWriterServiceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/SingleWriterServiceImplTest.java
@@ -40,7 +40,7 @@ public class SingleWriterServiceImplTest {
     public void setUp() throws Exception {
         InternalConfigurations.SINGLE_WRITER_THREAD_POOL_SIZE.set(4);
         InternalConfigurations.SINGLE_WRITER_CREDITS_PER_EXECUTION.set(200);
-        InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD.set(200);
+        InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC.set(200);
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(64);
 
         singleWriterServiceImpl = new SingleWriterServiceImpl();

--- a/src/test/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistenceTest.java
@@ -87,12 +87,12 @@ public class ClientQueueXodusLocalPersistenceTest {
 
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(bucketCount);
         InternalConfigurations.PERSISTENCE_CLOSE_RETRIES.set(3);
-        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL.set(5);
+        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.set(5);
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString()))
                 .thenReturn(temporaryFolder.newFolder());
 
         InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.set(10000);
-        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.set(1024);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024);
         InternalConfigurations.RETAINED_MESSAGE_QUEUE_SIZE.set(5);
 
         persistenceStartup = new PersistenceStartup();
@@ -1016,7 +1016,7 @@ public class ClientQueueXodusLocalPersistenceTest {
     @Test
     public void test_read_byte_limit_respected_qos0() {
 
-        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.set(1024 * 100);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024 * 100);
 
         persistence.stop();
         persistence = new ClientQueueXodusLocalPersistence(
@@ -1049,7 +1049,7 @@ public class ClientQueueXodusLocalPersistenceTest {
     @Test
     public void test_read_byte_limit_respected_qos1() {
 
-        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.set(1024 * 100);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024 * 100);
 
         persistence.stop();
         persistence = new ClientQueueXodusLocalPersistence(
@@ -1093,7 +1093,7 @@ public class ClientQueueXodusLocalPersistenceTest {
     @Test
     public void test_read_byte_limit_respected_qos0_and_qos1() {
 
-        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.set(1024 * 100);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024 * 100);
 
         persistence.stop();
         persistence = new ClientQueueXodusLocalPersistence(

--- a/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
@@ -79,7 +79,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
 
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(bucketCount);
         InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.set(10000);
-        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.set(1024);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024);
         InternalConfigurations.RETAINED_MESSAGE_QUEUE_SIZE.set(5);
 
         metricRegistry = new MetricRegistry();
@@ -90,7 +90,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
 
     @After
     public void tearDown() throws Exception {
-        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS = false;
+        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED = false;
     }
 
     @Test
@@ -704,7 +704,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
     @Test
     public void test_clean_up_expired_pubrels_configured() throws InterruptedException {
 
-        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS = true;
+        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED = true;
 
         metricRegistry = new MetricRegistry();
         persistence = new ClientQueueMemoryLocalPersistence(
@@ -1062,7 +1062,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
     @Test
     public void test_read_byte_limit_respected_qos0() {
 
-        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.set(1024 * 100);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024 * 100);
 
         metricRegistry = new MetricRegistry();
         persistence = new ClientQueueMemoryLocalPersistence(
@@ -1095,7 +1095,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
     @Test
     public void test_read_byte_limit_respected_qos1() {
 
-        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.set(1024 * 100);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024 * 100);
 
         metricRegistry = new MetricRegistry();
         persistence = new ClientQueueMemoryLocalPersistence(
@@ -1138,7 +1138,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
     @Test
     public void test_read_byte_limit_respected_qos0_and_qos1() {
 
-        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT.set(1024 * 100);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024 * 100);
 
         metricRegistry = new MetricRegistry();
         persistence = new ClientQueueMemoryLocalPersistence(

--- a/src/test/java/com/hivemq/persistence/local/memory/ClientSessionMemoryLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/memory/ClientSessionMemoryLocalPersistenceTest.java
@@ -81,7 +81,7 @@ public class ClientSessionMemoryLocalPersistenceTest {
         MockitoAnnotations.initMocks(this);
 
         InternalConfigurations.PERSISTENCE_CLOSE_RETRIES.set(3);
-        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL.set(5);
+        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.set(5);
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(BUCKET_COUNT);
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString())).thenReturn(
                 temporaryFolder.newFolder());

--- a/src/test/java/com/hivemq/persistence/local/xodus/RetainedMessageRocksDBLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/RetainedMessageRocksDBLocalPersistenceTest.java
@@ -69,7 +69,7 @@ public class RetainedMessageRocksDBLocalPersistenceTest {
         closeableMock = MockitoAnnotations.openMocks(this);
 
         InternalConfigurations.PERSISTENCE_CLOSE_RETRIES.set(3);
-        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL.set(5);
+        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.set(5);
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(BUCKETSIZE);
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString())).thenReturn(
                 temporaryFolder.newFolder());

--- a/src/test/java/com/hivemq/persistence/local/xodus/RetainedMessageXodusLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/RetainedMessageXodusLocalPersistenceTest.java
@@ -71,7 +71,7 @@ public class RetainedMessageXodusLocalPersistenceTest {
         closeableMock = MockitoAnnotations.openMocks(this);
 
         InternalConfigurations.PERSISTENCE_CLOSE_RETRIES.set(3);
-        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL.set(5);
+        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.set(5);
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(BUCKETSIZE);
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString())).thenReturn(
                 temporaryFolder.newFolder());

--- a/src/test/java/com/hivemq/persistence/local/xodus/clientsession/ClientSessionSubscriptionXodusLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/clientsession/ClientSessionSubscriptionXodusLocalPersistenceTest.java
@@ -74,7 +74,7 @@ public class ClientSessionSubscriptionXodusLocalPersistenceTest {
         closeableMock = MockitoAnnotations.openMocks(this);
 
         InternalConfigurations.PERSISTENCE_CLOSE_RETRIES.set(3);
-        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL.set(5);
+        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.set(5);
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(bucketCount);
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString())).thenReturn(temporaryFolder.newFolder());
 

--- a/src/test/java/com/hivemq/persistence/local/xodus/clientsession/ClientSessionXodusLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/clientsession/ClientSessionXodusLocalPersistenceTest.java
@@ -74,7 +74,7 @@ public class ClientSessionXodusLocalPersistenceTest {
         final LocalPersistenceFileUtil localPersistenceFileUtil = mock(LocalPersistenceFileUtil.class);
 
         InternalConfigurations.PERSISTENCE_CLOSE_RETRIES.set(3);
-        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL.set(5);
+        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.set(5);
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(BUCKET_COUNT);
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString())).thenReturn(temporaryFolder.newFolder());
 

--- a/src/test/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/payload/PublishPayloadPersistenceImplTest.java
@@ -52,10 +52,10 @@ public class PublishPayloadPersistenceImplTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        InternalConfigurations.PAYLOAD_CACHE_DURATION.set(1000L);
+        InternalConfigurations.PAYLOAD_CACHE_DURATION_MSEC.set(1000L);
         InternalConfigurations.PAYLOAD_CACHE_SIZE.set(1000);
-        InternalConfigurations.PAYLOAD_CACHE_CONCURRENCY_LEVEL.set(1);
-        InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE.set(10000);
+        InternalConfigurations.PAYLOAD_CACHE_CONCURRENCY_LEVEL_THREADS.set(1);
+        InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE_MSEC.set(10000);
         InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.set(64);
 
         persistence = new PublishPayloadPersistenceImpl(localPersistence, scheduledExecutorService);
@@ -186,7 +186,7 @@ public class PublishPayloadPersistenceImplTest {
     @Test
     public void init_persistence() throws Exception {
 
-        InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE.set(250);
+        InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_SCHEDULE_MSEC.set(250);
         InternalConfigurations.PAYLOAD_PERSISTENCE_CLEANUP_THREADS.set(4);
 
         persistence = new PublishPayloadPersistenceImpl(localPersistence, scheduledExecutorService);

--- a/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/payload/PublishPayloadRocksDBLocalPersistenceTest.java
@@ -67,7 +67,7 @@ public class PublishPayloadRocksDBLocalPersistenceTest {
     public void cleanUp() throws InterruptedException {
         LogbackCapturingAppender.Factory.cleanUp();
         InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.set(64);
-        InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH.set(true);
+        InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH_ENABLED.set(true);
         persistence.closeDB();
         persistenceStartup.finish();
     }
@@ -199,7 +199,7 @@ public class PublishPayloadRocksDBLocalPersistenceTest {
         persistenceStartup.finish();
         persistence.closeDB();
         persistenceStartup = new PersistenceStartup();
-        InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH.set(false);
+        InternalConfigurations.PUBLISH_PAYLOAD_FORCE_FLUSH_ENABLED.set(false);
         persistence = new PublishPayloadRocksDBLocalPersistence(localPersistenceFileUtil, persistenceStartup);
         persistence.start();
 

--- a/src/test/java/com/hivemq/persistence/payload/PublishPayloadXodusLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/payload/PublishPayloadXodusLocalPersistenceTest.java
@@ -52,7 +52,7 @@ public class PublishPayloadXodusLocalPersistenceTest {
     public void before() throws Exception {
         localPersistenceFileUtil = mock(LocalPersistenceFileUtil.class);
         InternalConfigurations.PERSISTENCE_CLOSE_RETRIES.set(3);
-        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL.set(5);
+        InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.set(5);
         InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.set(8);
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString())).thenReturn(
                 temporaryFolder.newFolder());

--- a/src/test/java/util/TestSingleWriterFactory.java
+++ b/src/test/java/util/TestSingleWriterFactory.java
@@ -30,8 +30,8 @@ public class TestSingleWriterFactory {
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(64);
         InternalConfigurations.SINGLE_WRITER_THREAD_POOL_SIZE.set(1);
         InternalConfigurations.SINGLE_WRITER_CREDITS_PER_EXECUTION.set(100);
-        InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD.set(1000);
-        InternalConfigurations.SINGLE_WRITER_CHECK_SCHEDULE.set(100);
+        InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC.set(1000);
+        InternalConfigurations.SINGLE_WRITER_INTERVAL_TO_CHECK_PENDING_TASKS_AND_SCHEDULE_MSEC.set(100);
 
         final SingleWriterServiceImpl singleWriterServiceImpl = new SingleWriterServiceImpl();
         for (int i = 0; i < singleWriterServiceImpl.callbackExecutors.length; i++) {


### PR DESCRIPTION
**Motivation**

Make looking up units faster, without going to the configs file.

**Changes**

Added units as suffixes to the configs names, renamed some configs to reflect their role more accurately, removed the redundant comments, and consolidated some configs in the file.