### PR TITLE
Fix SIGSEGV during shutdown with enabled diagnostics mode

### DIFF
--- a/src/main/java/com/hivemq/bootstrap/ioc/GuiceBootstrap.java
+++ b/src/main/java/com/hivemq/bootstrap/ioc/GuiceBootstrap.java
@@ -24,6 +24,7 @@ import com.google.inject.Stage;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingletonModule;
 import com.hivemq.bootstrap.netty.ioc.NettyModule;
 import com.hivemq.configuration.HivemqId;
+import com.hivemq.configuration.SystemProperties;
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.ioc.ConfigurationModule;
 import com.hivemq.configuration.service.FullConfigurationService;
@@ -61,7 +62,7 @@ public class GuiceBootstrap {
             final @NotNull Injector persistenceInjector,
             final @NotNull LifecycleModule lifecycleModule) {
 
-        if (!Boolean.parseBoolean(System.getProperty("diagnosticMode"))) {
+        if (!Boolean.parseBoolean(System.getProperty(SystemProperties.DIAGNOSTIC_MODE))) {
             log.trace("Turning Guice stack traces off");
             System.setProperty("guice_include_stack_traces", "OFF");
         }

--- a/src/main/java/com/hivemq/configuration/SystemProperties.java
+++ b/src/main/java/com/hivemq/configuration/SystemProperties.java
@@ -29,4 +29,6 @@ public class SystemProperties {
     public static final String DATA_FOLDER = "hivemq.data.folder";
 
     public static final String EXTENSIONS_FOLDER = "hivemq.extensions.folder";
+
+    public static final String DIAGNOSTIC_MODE = "diagnosticMode";
 }

--- a/src/main/java/com/hivemq/diagnostic/DiagnosticMode.java
+++ b/src/main/java/com/hivemq/diagnostic/DiagnosticMode.java
@@ -17,11 +17,18 @@ package com.hivemq.diagnostic;
 
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import com.hivemq.common.shutdown.HiveMQShutdownHook;
+import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.diagnostic.data.DiagnosticData;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
+import com.hivemq.util.ThreadFactoryUtil;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
@@ -32,29 +39,55 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @Singleton
 public class DiagnosticMode {
 
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(DiagnosticMode.class);
+    private static final Logger log = LoggerFactory.getLogger(DiagnosticMode.class);
+
+    private static final String THREAD_NAME_FORMAT = "diagnostic-mode-%d";
+
     public static final String FILE_NAME_METRIC_LOG = "metric.log";
     public static final String FILE_NAME_TRACE_LOG = "tracelog.log";
     public static final String FILE_NAME_DIAGNOSTICS_FILE = "diagnostics.txt";
     public static final String FILE_NAME_DIAGNOSTICS_FOLDER = "diagnostics";
     public static final String FILE_NAME_MIGRATION_LOG = "migration.log";
-    private final DiagnosticData diagnosticData;
-    private final SystemInformation systemInformation;
-    private final MetricRegistry metricRegistry;
-    private ConsoleReporter metricReporter;
+
+    private final @NotNull DiagnosticData diagnosticData;
+    private final @NotNull SystemInformation systemInformation;
+    private final @NotNull MetricRegistry metricRegistry;
+    private final @NotNull ShutdownHooks shutdownHooks;
+    private final @NotNull ScheduledExecutorService executor;
+
+    private @Nullable ConsoleReporter metricReporter;
 
     @Inject
-    DiagnosticMode(final DiagnosticData diagnosticData,
-                   final SystemInformation systemInformation,
-                   final MetricRegistry metricRegistry) {
+    DiagnosticMode(final @NotNull DiagnosticData diagnosticData,
+            final @NotNull SystemInformation systemInformation,
+            final @NotNull MetricRegistry metricRegistry,
+            final @NotNull ShutdownHooks shutdownHooks) {
+        this(diagnosticData, systemInformation, metricRegistry, shutdownHooks, Executors.newSingleThreadScheduledExecutor(ThreadFactoryUtil.create(THREAD_NAME_FORMAT)));
+    }
+
+    /**
+     * @param executor This instance adopts ownership of the passed executor.
+     *                 Used only for testing purposes, as the otherwise internally created executor of ConsoleReporter
+     *                 can't be accessed.
+     */
+    @VisibleForTesting
+    DiagnosticMode(final @NotNull DiagnosticData diagnosticData,
+            final @NotNull SystemInformation systemInformation,
+            final @NotNull MetricRegistry metricRegistry,
+            final @NotNull ShutdownHooks shutdownHooks,
+            final @NotNull ScheduledExecutorService executor) {
         this.diagnosticData = diagnosticData;
         this.systemInformation = systemInformation;
         this.metricRegistry = metricRegistry;
+        this.shutdownHooks = shutdownHooks;
+        this.executor = executor;
     }
 
     @PostConstruct
@@ -72,30 +105,50 @@ public class DiagnosticMode {
         }
     }
 
-    public void stop() {
-        if (metricReporter != null) {
-            metricReporter.stop();
-        }
-    }
-
     private void startLoggingMetrics(final File diagnosticFolder) {
         final File metricLog = new File(diagnosticFolder, FILE_NAME_METRIC_LOG);
 
         try {
             final PrintStream logStream = new PrintStream(metricLog, Charset.defaultCharset().name());
             metricReporter = ConsoleReporter.forRegistry(metricRegistry)
+                    .scheduleOn(executor)
+                    // Shut this executor down on stop. We can configure this here because we own it.
+                    .shutdownExecutorOnStop(true)
                     .convertRatesTo(TimeUnit.SECONDS)
                     .convertDurationsTo(TimeUnit.MILLISECONDS)
                     .outputTo(logStream)
                     .build();
             metricReporter.start(1, TimeUnit.SECONDS);
 
+            shutdownHooks.add(new HiveMQShutdownHook() {
+                @Override
+                public @NotNull String name() {
+                    return "HiveMQ Diagnostic Mode Shutdown";
+                }
+
+                @Override
+                public @NotNull Priority priority() {
+                    // DiagnosticMode must not access other JNI components that might be shut down before it by trying to
+                    // retrieve current metrics from them. These components may dispose their internal state outside the JVM
+                    // which might lead to SIGSEGV upon access.
+                    // Since DiagnosticMode itself isn't expected to be accessed by other components, shut it down ASAP for
+                    // simplicity.
+                    // No interference is expected with other shutdown hooks of the same priority.
+                    return Priority.FIRST;
+                }
+
+                @Override
+                public void run() {
+                    metricReporter.stop();
+                }
+            });
+
         } catch (final IOException e) {
             log.error("Not able to create metric.log, for {}", e.getCause());
         }
     }
 
-    private void copyMigrationLog(final Optional<File> diagnosticsFolder) {
+    private void copyMigrationLog(final @NotNull Optional<File> diagnosticsFolder) {
 
         //copy migration log if available
         final File migrationLog = new File(systemInformation.getLogFolder(), FILE_NAME_MIGRATION_LOG);
@@ -109,7 +162,7 @@ public class DiagnosticMode {
         }
     }
 
-    private void createDiagnosticsFile(final File diagnosticsFolder) {
+    private void createDiagnosticsFile(final @NotNull File diagnosticsFolder) {
         final File diagnosticsFile = new File(diagnosticsFolder, FILE_NAME_DIAGNOSTICS_FILE);
 
         try {
@@ -123,7 +176,7 @@ public class DiagnosticMode {
         }
     }
 
-    private Optional<File> createDiagnosticsFolder() {
+    private @NotNull Optional<File> createDiagnosticsFolder() {
         final File hiveMQHomeFolder = systemInformation.getHiveMQHomeFolder();
 
         final File diagnosticsFolder = new File(hiveMQHomeFolder, FILE_NAME_DIAGNOSTICS_FOLDER);
@@ -147,6 +200,5 @@ public class DiagnosticMode {
         }
 
         return Optional.of(diagnosticsFolder);
-
     }
 }

--- a/src/main/java/com/hivemq/diagnostic/DiagnosticModule.java
+++ b/src/main/java/com/hivemq/diagnostic/DiagnosticModule.java
@@ -16,6 +16,7 @@
 package com.hivemq.diagnostic;
 
 import com.google.inject.AbstractModule;
+import com.hivemq.configuration.SystemProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +29,7 @@ public class DiagnosticModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        final boolean diagnosticMode = Boolean.parseBoolean(System.getProperty("diagnosticMode"));
+        final boolean diagnosticMode = Boolean.parseBoolean(System.getProperty(SystemProperties.DIAGNOSTIC_MODE));
         if (diagnosticMode) {
             log.info("Starting with Diagnostic mode");
             bind(DiagnosticMode.class).asEagerSingleton();

--- a/src/test/java/com/hivemq/diagnostic/DiagnosticModuleTest.java
+++ b/src/test/java/com/hivemq/diagnostic/DiagnosticModuleTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.diagnostic;
 
 import com.google.inject.*;
+import com.hivemq.configuration.SystemProperties;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -30,7 +31,7 @@ public class DiagnosticModuleTest {
 
     @Test
     public void test_diagnostic_mode_enabled() throws Exception {
-        System.setProperty("diagnosticMode", "true");
+        System.setProperty(SystemProperties.DIAGNOSTIC_MODE, "true");
         try {
 
             Guice.createInjector(new DiagnosticModule());
@@ -42,7 +43,7 @@ public class DiagnosticModuleTest {
 
     @Test
     public void test_diagnostic_mode_disabled() throws Exception {
-        System.setProperty("diagnosticMode", "false");
+        System.setProperty(SystemProperties.DIAGNOSTIC_MODE, "false");
 
         final Injector injector = Guice.createInjector(new DiagnosticModule());
 


### PR DESCRIPTION
**Motivation**

Avoid crash during shutdown with enabled diagnostics mode.

**Changes**

This was caused by DiagnosticMode's ConsoleReporter which periodically writes metrics to disk and must not access any RocksDB instance after it has been closed already.

Therefore, stop DiagnosticMode first via ShutdownHooks.