### PR TITLE
Fix not sending will on clean start during re-connect

### DIFF
--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -179,7 +179,7 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
                 // If no clean start is required, a client might be re-connecting to the existing session.
                 // In this case, cancel any pending send of a will.
                 if (cleanStart) {
-                    pendingWillMessages.sendWillIfPending(client);
+                    pendingWillMessages.sendWillIfPending(client, previousClientSession);
                 } else {
                     pendingWillMessages.cancelWillIfPending(client);
                 }

--- a/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImpl.java
@@ -358,7 +358,9 @@ public class ClientSessionPersistenceImpl extends AbstractPersistence implements
 
     @Override
     public @NotNull ListenableFuture<Void> cleanUp(final int bucketIndex) {
-        return singleWriter.submit(bucketIndex, new ClientSessionCleanUpTask(localPersistence, this));
+        return singleWriter.submit(
+                bucketIndex,
+                new ClientSessionCleanUpTask(localPersistence, this, pendingWillMessages));
     }
 
     @Override

--- a/src/test/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/clientsession/ClientSessionPersistenceImplTest.java
@@ -105,7 +105,7 @@ public class ClientSessionPersistenceImplTest {
         when(localPersistence.disconnect(eq("client"), anyLong(), eq(true), anyInt(), eq(10L))).
                 thenReturn(previousSession);
         clientSessionPersistence.clientDisconnected("client", true, 10).get();
-        verify(pendingWillMessages).addWill("client", previousSession);
+        verify(pendingWillMessages).sendOrEnqueueWillIfAvailable("client", previousSession);
     }
 
     @Test
@@ -135,7 +135,7 @@ public class ClientSessionPersistenceImplTest {
         when(connectionPersistence.get("client")).thenReturn(null);
         final Boolean result = clientSessionPersistence.forceDisconnectClient("client", true, ClientSessionPersistenceImpl.DisconnectSource.EXTENSION).get();
         assertFalse(result);
-        verify(pendingWillMessages).cancelWill("client");
+        verify(pendingWillMessages).cancelWillIfPending("client");
     }
 
     @Test
@@ -150,7 +150,7 @@ public class ClientSessionPersistenceImplTest {
         channel.disconnect();
         final Boolean result = future.get();
         assertTrue(result);
-        verify(pendingWillMessages).cancelWill("client");
+        verify(pendingWillMessages).cancelWillIfPending("client");
         verify(mqttServerDisconnector).disconnect(any(Channel.class), anyString(), anyString(), eq(Mqtt5DisconnectReasonCode.ADMINISTRATIVE_ACTION), any());
     }
 
@@ -166,7 +166,7 @@ public class ClientSessionPersistenceImplTest {
         channel.disconnect();
         final Boolean result = future.get();
         assertTrue(result);
-        verify(pendingWillMessages).cancelWill("client");
+        verify(pendingWillMessages).cancelWillIfPending("client");
         verify(mqttServerDisconnector).disconnect(any(Channel.class), anyString(), anyString(), eq(Mqtt5DisconnectReasonCode.SESSION_TAKEN_OVER), eq("reason-string"));
     }
 

--- a/src/test/java/com/hivemq/persistence/clientsession/task/ClientSessionCleanUpTaskTest.java
+++ b/src/test/java/com/hivemq/persistence/clientsession/task/ClientSessionCleanUpTaskTest.java
@@ -15,9 +15,9 @@
  */
 package com.hivemq.persistence.clientsession.task;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.hivemq.persistence.clientsession.ClientSessionPersistenceImpl;
+import com.hivemq.persistence.clientsession.PendingWillMessages;
 import com.hivemq.persistence.local.ClientSessionLocalPersistence;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,7 +25,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -39,18 +38,23 @@ public class ClientSessionCleanUpTaskTest {
     @Mock
     private ClientSessionPersistenceImpl clientSessionPersistence;
 
+    @Mock
+    private PendingWillMessages pendingWillMessages;
+
     private ClientSessionCleanUpTask task;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        task = new ClientSessionCleanUpTask(localPersistence, clientSessionPersistence);
+        task = new ClientSessionCleanUpTask(localPersistence, clientSessionPersistence, pendingWillMessages);
     }
 
     @Test
-    public void test_clean_up_clean_task() throws Exception {
-        Mockito.when(localPersistence.cleanUp(0)).thenReturn(ImmutableSet.of("client"));
+    public void test_clean_up_clean_task() {
+        final String clientId = "client";
+        Mockito.when(localPersistence.cleanUp(0)).thenReturn(ImmutableSet.of(clientId));
         task.doTask(0);
-        verify(clientSessionPersistence, times(1)).cleanClientData("client");
+        verify(pendingWillMessages).sendWillIfPending(clientId);
+        verify(clientSessionPersistence).cleanClientData(clientId);
     }
 }


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/42/cards/9739/details/

If a client re-connects with a clean start, the specification defines that this "ends" and existing sessions.

Whenever a session ends, the specification defines that the ending session's will must be sent, if available and still pending due to a session expiry interval or a will delay interval that has not been reached yet.

This is achieved by sending any still pending will between disconnecting and (re-)connecting.

Also improved method names of PendingWillMessages.