### PR TITLE
Reduce used message IDs memory footprint

### DIFF
--- a/src/main/java/com/hivemq/mqtt/message/pool/SequentialMessageIDPoolImpl.java
+++ b/src/main/java/com/hivemq/mqtt/message/pool/SequentialMessageIDPoolImpl.java
@@ -27,12 +27,6 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-/**
- * Implementation note: Benchmarks revealed that the implementation with synchronized
- * methods is fast enough for our use case
- *
- * @author Dominik Obermaier
- */
 @ThreadSafe
 public class SequentialMessageIDPoolImpl implements MessageIDPool {
 


### PR DESCRIPTION
[hivemq.kanbanize.com/ctrl_board/42/cards/10306/details](https://hivemq.kanbanize.com/ctrl_board/42/cards/10306/details/)

Switched from HashSet<Integer> to Eclipse Collections' ShortHashSet
to reduce the memory footprint.

We can use ShortHashSet instead of IntHashSet because the range of
IDs, 1..65535, is unsigned short anyway, and we can shift those
int values into signed short range.**Motivation**