### PR TITLE
Reduce BucketLock contention by RemoveEntryTask

### DIFF
--- a/src/main/java/com/hivemq/persistence/payload/RemovablePayload.java
+++ b/src/main/java/com/hivemq/persistence/payload/RemovablePayload.java
@@ -16,6 +16,9 @@
 package com.hivemq.persistence.payload;
 
 import com.hivemq.extension.sdk.api.annotations.Immutable;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Lukas Brandl
@@ -26,9 +29,12 @@ public class RemovablePayload {
     private final long id;
     private final long timestamp;
 
+    final AtomicBoolean inProgress;
+
     public RemovablePayload(final long id, final long timestamp) {
         this.id = id;
         this.timestamp = timestamp;
+        this.inProgress = new AtomicBoolean();
     }
 
     public long getId() {

--- a/src/main/java/com/hivemq/persistence/payload/RemoveEntryTask.java
+++ b/src/main/java/com/hivemq/persistence/payload/RemoveEntryTask.java
@@ -60,7 +60,9 @@ public class RemoveEntryTask implements Runnable {
             RemovablePayload removablePayload = removablePayloads.poll();
             final long startTime = System.currentTimeMillis();
             while (removablePayload != null) {
-                if (System.currentTimeMillis() - removablePayload.getTimestamp() > removeDelay) {
+                if (System.currentTimeMillis() - removablePayload.getTimestamp() > removeDelay
+                // TODO: Replace inProgress guard to avoid BucketLock contention with an overhauled structure. #11000
+                && removablePayload.inProgress.compareAndSet(false, true)) {
                     final long payloadId = removablePayload.getId();
                     bucketLock.accessBucketByPaloadId(removablePayload.getId(), () -> {
                         final int referenceCount = payloadReferenceCounterRegistry.get(payloadId);

--- a/src/main/java/com/hivemq/persistence/payload/RemoveEntryTask.java
+++ b/src/main/java/com/hivemq/persistence/payload/RemoveEntryTask.java
@@ -61,7 +61,6 @@ public class RemoveEntryTask implements Runnable {
             final long startTime = System.currentTimeMillis();
             while (removablePayload != null) {
                 if (System.currentTimeMillis() - removablePayload.getTimestamp() > removeDelay
-                // TODO: Replace inProgress guard to avoid BucketLock contention with an overhauled structure. #11000
                 && removablePayload.inProgress.compareAndSet(false, true)) {
                     final long payloadId = removablePayload.getId();
                     bucketLock.accessBucketByPaloadId(removablePayload.getId(), () -> {


### PR DESCRIPTION
[hivemq.kanbanize.com/ctrl_board/42/cards/11291/details](https://hivemq.kanbanize.com/ctrl_board/42/cards/11291/details/)

Added a guard so that concurrently running RemoveEntryTasks don't try to process entries of the shared removablePayloads queue.

Since this is more of a workaround, the structure should be improved in the scope of the ticket [hivemq.kanbanize.com/ctrl_board/42/cards/11000/details](https://hivemq.kanbanize.com/ctrl_board/42/cards/11000/details/).