### PR TITLE
Fix race where a QoS 0 payload gets deleted concurrently during polling

### DIFF
--- a/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -23,7 +23,6 @@ import com.hivemq.bootstrap.ClientConnectionContext;
 import com.hivemq.configuration.service.MqttConfigurationService;
 import com.hivemq.mqtt.message.MessageWithID;
 import com.hivemq.mqtt.message.QoS;
-import com.hivemq.mqtt.message.dropping.MessageDroppedService;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.services.PublishPollService;
@@ -78,9 +77,6 @@ public class ClientQueuePersistenceImplTest {
     ClientSessionLocalPersistence clientSessionLocalPersistence;
 
     @Mock
-    MessageDroppedService messageDroppedService;
-
-    @Mock
     LocalTopicTree topicTree;
 
     @Mock
@@ -104,7 +100,6 @@ public class ClientQueuePersistenceImplTest {
                 singleWriterService,
                 mqttConfigurationService,
                 clientSessionLocalPersistence,
-                messageDroppedService,
                 topicTree,
                 connectionPersistence,
                 publishPollService);
@@ -127,7 +122,6 @@ public class ClientQueuePersistenceImplTest {
                 eq(QueuedMessagesStrategy.DISCARD),
                 anyBoolean(),
                 anyInt());
-        verify(messageDroppedService, never()).queueFull("client", "topic", 1);
     }
 
     @Test(timeout = 5000)
@@ -299,7 +293,6 @@ public class ClientQueuePersistenceImplTest {
                 anyInt());
         verify(clientSessionLocalPersistence,
                 never()).getSession("client"); // Get session because new publishes are available
-        verify(messageDroppedService, never()).queueFull("client", "topic", 1);
     }
 
     @Test(timeout = 5000)
@@ -316,7 +309,6 @@ public class ClientQueuePersistenceImplTest {
                 anyBoolean(),
                 anyInt());
         verify(clientSessionLocalPersistence).getSession("client"); // Get session because new publishes are available
-        verify(messageDroppedService, never()).queueFull("client", "topic", 1);
     }
 
     private PUBLISH createPublish(final int packetId, final QoS qos, final String topic) {

--- a/src/test/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistenceTest.java
@@ -94,6 +94,9 @@ public class ClientQueueXodusLocalPersistenceTest {
     public void setUp() throws Exception {
         closeableMock = MockitoAnnotations.openMocks(this);
 
+        // Return a non-null payload to ensure a PUBLISH isn't dropped during its lookup due to a missing payload.
+        when(payloadPersistence.get(anyLong())).thenReturn(new byte[0]);
+
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(bucketCount);
         InternalConfigurations.PERSISTENCE_CLOSE_RETRIES.set(3);
         InternalConfigurations.PERSISTENCE_CLOSE_RETRY_INTERVAL_MSEC.set(5);
@@ -1255,6 +1258,7 @@ public class ClientQueueXodusLocalPersistenceTest {
     @Test
     public void test_read_byte_limit_respected_qos1() {
 
+        when(payloadPersistence.get(anyLong())).thenReturn(null);
         InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024 * 100);
 
         persistence.stop();
@@ -1300,6 +1304,7 @@ public class ClientQueueXodusLocalPersistenceTest {
     @Test
     public void test_read_byte_limit_respected_qos0_and_qos1() {
 
+        when(payloadPersistence.get(anyLong())).thenReturn(null);
         InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(1024 * 100);
 
         persistence.stop();


### PR DESCRIPTION
[hivemq.kanbanize.com/ctrl_board/42/cards/2123/details](https://hivemq.kanbanize.com/ctrl_board/42/cards/2123/details/)

Previously, the payload reference counter was decremented
immediately after polling the QoS 0 PUBLISH from its queue,
but before assigning the payload to the PUBLISH again.

This introduced a race condition with the payload cleanup
which was then permitted to delete the payload concurrently.

Therefore, assign the payload during lookup to fix the race.

Additionally, drop messages without payload immediately
during iteration; don't schedule another single writer task.