### PR TITLE
LocalTopicTree > Avoid iterating over the root wildcards when there is nothing to remove.

### DIFF
--- a/src/main/java/com/hivemq/mqtt/topic/tree/LocalTopicTree.java
+++ b/src/main/java/com/hivemq/mqtt/topic/tree/LocalTopicTree.java
@@ -399,8 +399,10 @@ public class LocalTopicTree {
             }
         }
         final ImmutableList<SubscriberWithQoS> foundSubscriberList = foundSubscribers.build();
-        rootWildcardSubscribers.removeAll(foundSubscriberList);
-        counters.getSubscriptionCounter().dec(foundSubscriberList.size());
+        if (!foundSubscriberList.isEmpty()) {
+            rootWildcardSubscribers.removeAll(foundSubscriberList);
+            counters.getSubscriptionCounter().dec(foundSubscriberList.size());
+        }
         return !foundSubscriberList.isEmpty();
     }
 


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/42/cards/13429/details/