### PR TITLE
Multi-Arch Docker Images with buildx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      #- name: Publish to Maven Central
-      #  env:
-      #    ORG_GRADLE_PROJECT_signKey: ${{ secrets.SIGN_KEY }}
-      #    ORG_GRADLE_PROJECT_signKeyPass: ${{ secrets.SIGN_KEY_PASS }}
-      #    ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-      #    ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-      #  run: ./gradlew publishEmbeddedPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
+      - name: Publish to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_signKey: ${{ secrets.SIGN_KEY }}
+          ORG_GRADLE_PROJECT_signKeyPass: ${{ secrets.SIGN_KEY_PASS }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+        run: ./gradlew publishEmbeddedPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
       - name: Push To Docker Hub
         run: PUSH_IMAGE=true docker/publish.sh
       - name: Attach HiveMQ Zip to GitHub Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
@@ -21,13 +25,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Publish to Maven Central
-        env:
-          ORG_GRADLE_PROJECT_signKey: ${{ secrets.SIGN_KEY }}
-          ORG_GRADLE_PROJECT_signKeyPass: ${{ secrets.SIGN_KEY_PASS }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-        run: ./gradlew publishEmbeddedPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
+      #- name: Publish to Maven Central
+      #  env:
+      #    ORG_GRADLE_PROJECT_signKey: ${{ secrets.SIGN_KEY }}
+      #    ORG_GRADLE_PROJECT_signKeyPass: ${{ secrets.SIGN_KEY_PASS }}
+      #    ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+      #    ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+      #  run: ./gradlew publishEmbeddedPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
       - name: Push To Docker Hub
         run: PUSH_IMAGE=true docker/publish.sh
       - name: Attach HiveMQ Zip to GitHub Release

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Checkout Extension SDK
         run: |
           git clone https://github.com/hivemq/hivemq-extension-sdk.git ../hivemq-extension-sdk

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY hivemq-ce-${HIVEMQ_VERSION}.zip /
 
 RUN unzip /hivemq-ce-${HIVEMQ_VERSION}.zip
 
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre-alpine
 
 ARG HIVEMQ_VERSION=2019.1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY hivemq-ce-${HIVEMQ_VERSION}.zip /
 
 RUN unzip /hivemq-ce-${HIVEMQ_VERSION}.zip
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre
 
 ARG HIVEMQ_VERSION=2019.1
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-IMAGE="suhrmann/hivemq-ce:snapshot"
+IMAGE="hivemq/hivemq-ce:snapshot"
 
 cd "$(dirname $0)/../"
 HIVEMQ_VERSION=$(./gradlew properties | grep ^version: | sed -e "s/version: //")

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-IMAGE="hivemq/hivemq-ce:snapshot"
+IMAGE="suhrmann/hivemq-ce:snapshot"
 
 cd "$(dirname $0)/../"
 HIVEMQ_VERSION=$(./gradlew properties | grep ^version: | sed -e "s/version: //")
@@ -10,10 +10,17 @@ echo "Building Docker image for HiveMQ ${HIVEMQ_VERSION}"
 ./gradlew hivemqZip
 cd docker
 cp ../build/distributions/hivemq-ce-${HIVEMQ_VERSION}.zip .
-docker build --build-arg HIVEMQ_VERSION=${HIVEMQ_VERSION} -f Dockerfile -t ${IMAGE} .
-rm -f hivemq-ce-${HIVEMQ_VERSION}.zip
 
+PUSH=""
 if [[ ${PUSH_IMAGE} == true ]]; then
     echo "Pushing image"
-    docker push ${IMAGE}
+    PUSH="--push"
 fi
+
+PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7  # check support with jre base image!
+docker buildx build ${PUSH} --platform ${PLATFORMS}  \
+    --build-arg HIVEMQ_VERSION=${HIVEMQ_VERSION}  \
+    -f Dockerfile  \
+    -t ${IMAGE} .
+
+rm -f hivemq-ce-${HIVEMQ_VERSION}.zip

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-IMAGE_PREFIX="hivemq/hivemq-ce"
+IMAGE_PREFIX="suhrmann/hivemq-ce"
 LATEST_IMAGE="${IMAGE_PREFIX}:latest"
 
 cd "$(dirname $0)/../"
@@ -11,16 +11,22 @@ echo "Building Docker image for HiveMQ ${HIVEMQ_VERSION}"
 ./gradlew hivemqZip
 cd docker
 cp ../build/distributions/hivemq-ce-${HIVEMQ_VERSION}.zip .
-docker build --build-arg HIVEMQ_VERSION=${HIVEMQ_VERSION} -f Dockerfile -t ${LATEST_IMAGE} .
-rm -f hivemq-ce-${HIVEMQ_VERSION}.zip
 
 echo "Tagging image as ${HIVEMQ_VERSION}"
 VERSIONED_IMAGE="${IMAGE_PREFIX}:${HIVEMQ_VERSION}"
-docker tag ${LATEST_IMAGE} "${VERSIONED_IMAGE}"
 
+PUSH=""
 if [[ ${PUSH_IMAGE} == true ]]; then
+    PUSH="--push"
     echo "Pushing image as ${VERSIONED_IMAGE}"
-    docker push ${VERSIONED_IMAGE}
     echo "Pushing image as ${LATEST_IMAGE}"
-    docker push ${LATEST_IMAGE}
 fi
+
+PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7  # check support with jre base image!
+docker buildx build ${PUSH} --platform ${PLATFORMS}  \
+  --build-arg HIVEMQ_VERSION=${HIVEMQ_VERSION}  \
+  -f Dockerfile  \
+  -t ${LATEST_IMAGE}  \
+  -t ${VERSIONED_IMAGE} .
+
+rm -f hivemq-ce-${HIVEMQ_VERSION}.zip

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-IMAGE_PREFIX="suhrmann/hivemq-ce"
+IMAGE_PREFIX="hivemq/hivemq-ce"
 LATEST_IMAGE="${IMAGE_PREFIX}:latest"
 
 cd "$(dirname $0)/../"


### PR DESCRIPTION
**Motivation**

Resolves #397 

**Changes**
 - Replace deprecated base image `openjdk:11-jre-slim` with `eclipse-temurin:11-jre` - todo: maybe use `eclipse-temurin:11-jre-alpin` as equivalent of the slim image (alpine untested)
 - Github Actions: add steps qemu and buildx
 - build scripts: replace build command with Docker buildx - with archs: ``linux/amd64,linux/arm64,linux/arm/v7`` (could not find darwin/arm images for JRE