### PR TITLE
CVE-2023-34462, Netty update to recommended version 4.1.94.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version=2023.4
 #
 hivemq-extension-sdk.version=4.16.0
 # netty
-netty.version=4.1.79.Final
+netty.version=4.1.94.Final
 # logging
 slf4j.version=2.0.7
 logback.version=1.4.7


### PR DESCRIPTION
**Motivation**
Potential CVE [CVE-2023-34462](https://nvd.nist.gov/vuln/detail/CVE-2023-34462), due to the Netty library. See https://mvnrepository.com/artifact/io.netty/netty-handler/4.1.79.Final
Recommendation is to update to version 4.1.94.Final