### PR TITLE
Bugfix for expired inflight PUBREL not getting removed from the queue

### DIFF
--- a/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT;
 import static com.hivemq.persistence.local.xodus.EnvironmentUtil.GCType;
 
 /**
@@ -469,4 +470,5 @@ public class InternalConfigurations {
     public static boolean EXPIRE_INFLIGHT_MESSAGES_ENABLED = false;
     public static boolean EXPIRE_INFLIGHT_PUBRELS_ENABLED = false;
 
+    public static long MAXIMUM_INFLIGHT_PUBREL_EXPIRY = MAX_EXPIRY_INTERVAL_DEFAULT;
 }

--- a/src/main/java/com/hivemq/mqtt/message/pubrel/PUBREL.java
+++ b/src/main/java/com/hivemq/mqtt/message/pubrel/PUBREL.java
@@ -27,6 +27,8 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.reason.Mqtt5PubRelReasonCode;
 import com.hivemq.util.ObjectMemoryEstimation;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * @since 1.4
  */
@@ -111,7 +113,7 @@ public class PUBREL extends MqttMessageWithUserProperties.MqttMessageWithIdAndRe
                 messageExpiryInterval == PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET) {
             return false;
         }
-        final long waitingSeconds = (System.currentTimeMillis() - publishTimestamp) / 1000;
+        final long waitingSeconds = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - publishTimestamp);
         final long actualMessageExpiry = Math.min(messageExpiryInterval, maximalPubRelExpiry);
         final long remainingTime = actualMessageExpiry - waitingSeconds;
         return remainingTime < 1;

--- a/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueXodusLocalPersistence.java
@@ -1042,6 +1042,9 @@ public class ClientQueueXodusLocalPersistence extends XodusLocalPersistence impl
                     final MessageWithID message = serializer.deserializeValue(serializedValue);
                     if (message instanceof PUBREL) {
                         final PUBREL pubrel = (PUBREL) message;
+                        if (!InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED) {
+                            return true;
+                        }
                         if (!pubrel.hasExpired(InternalConfigurations.MAXIMUM_INFLIGHT_PUBREL_EXPIRY)) {
                             return true;
                         }

--- a/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -445,6 +445,10 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         if (packetIdFound) {
             messages.qos1Or2Messages.set(messageIndexInQueue, pubrelWithRetained);
         } else {
+            if (InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED) {
+                pubrelWithRetained.setMessageExpiryInterval(InternalConfigurations.MAXIMUM_INFLIGHT_PUBREL_EXPIRY);
+                pubrelWithRetained.setPublishTimestamp(System.currentTimeMillis());
+            }
             // Ensure unknown PUBRELs are always first in queue
             messages.qos1Or2Messages.addFirst(pubrelWithRetained);
         }
@@ -752,13 +756,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             final MessageWithID messageWithID = qos12iterator.next();
             if (messageWithID instanceof PubrelWithRetained) {
                 final PubrelWithRetained pubrel = (PubrelWithRetained) messageWithID;
-                if (!InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED) {
-                    continue;
-                }
-                if (pubrel.getMessageExpiryInterval() == null || pubrel.getPublishTimestamp() == null) {
-                    continue;
-                }
-                if (!pubrel.hasExpired()) {
+                if (!pubrel.hasExpired(InternalConfigurations.MAXIMUM_INFLIGHT_PUBREL_EXPIRY)) {
                     continue;
                 }
                 if (pubrel.retained) {

--- a/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -756,6 +756,9 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             final MessageWithID messageWithID = qos12iterator.next();
             if (messageWithID instanceof PubrelWithRetained) {
                 final PubrelWithRetained pubrel = (PubrelWithRetained) messageWithID;
+                if (!InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED) {
+                    continue;
+                }
                 if (!pubrel.hasExpired(InternalConfigurations.MAXIMUM_INFLIGHT_PUBREL_EXPIRY)) {
                     continue;
                 }


### PR DESCRIPTION
**Motivation**

Resolves a bug when an expired inflight PUBREL was not removed from the client queue despite its expiry.

**Changes**

- Improved PUBREL expiry identification
- Using defaults for PUBREL timestamp and message expiry interval 
- Added MAXIMUM_INFLIGHT_PUBREL_EXPIRY seconds config


[Ticket](https://hivemq.kanbanize.com/ctrl_board/42/cards/15739/details/)