### PR TITLE
update openjdk link in run.bat/run.sh

### DIFF
--- a/src/distribution/bin/run.bat
+++ b/src/distribution/bin/run.bat
@@ -117,7 +117,7 @@ fsutil dirty query %systemdrive% >nul
 exit /b
 
 :NOJAVA
-  echo You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptium.net/?variant=openjdk11 and try again.
+  echo You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptium.net/?variant=openjdk and try again.
 
 :EXIT
   pause

--- a/src/distribution/bin/run.sh
+++ b/src/distribution/bin/run.sh
@@ -106,6 +106,6 @@ if hash java 2>/dev/null; then
     fi
 
 else
-    echoerr "ERROR! You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptium.net/?variant=openjdk11 and try again."
+    echoerr "ERROR! You do not have the Java Runtime Environment installed, please install Java JRE from https://adoptium.net/?variant=openjdk and try again."
     exit 1
 fi


### PR DESCRIPTION
link to openjdk in run.bat/run.sh pointed to jdk11 which made HiveMQ fail to start up in windows11/64bit. changing the link to point to the latest stable release get's HiveMQ working

**Motivation**

Resolves #421

**Changes**
run.bat/run.sh
    https://adoptium.net/?variant=openjdk11 -> https://adoptium.net/?variant=openjdk