### PR TITLE
NoMessageIdAvailableException is thrown even if there are free ids available in the pool

### DIFF
--- a/src/main/java/com/hivemq/mqtt/message/pool/FreePacketIdRanges.java
+++ b/src/main/java/com/hivemq/mqtt/message/pool/FreePacketIdRanges.java
@@ -106,6 +106,12 @@ public class FreePacketIdRanges {
                     }
                 }
 
+                // Updating the root range to preserve the invariant of root range being non-empty if there are ranges
+                // with free IDs available. We do so by ignoring intervals that consist of a single id.
+                while ((rootRange.start == rootRange.end) && (rootRange.next != null)) {
+                    rootRange = rootRange.next;
+                }
+
                 return; // id found and taken
             }
 

--- a/src/main/java/com/hivemq/mqtt/message/pool/exception/MessageIdUnavailableException.java
+++ b/src/main/java/com/hivemq/mqtt/message/pool/exception/MessageIdUnavailableException.java
@@ -1,0 +1,8 @@
+package com.hivemq.mqtt.message.pool.exception;
+
+public class MessageIdUnavailableException extends Exception {
+
+    public MessageIdUnavailableException(final int unavailableMessageId) {
+        super(String.format("Desired message id %d is unavailable", unavailableMessageId));
+    }
+}

--- a/src/main/java/com/hivemq/mqtt/message/pool/exception/MessageIdUnavailableException.java
+++ b/src/main/java/com/hivemq/mqtt/message/pool/exception/MessageIdUnavailableException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.mqtt.message.pool.exception;
 
 public class MessageIdUnavailableException extends Exception {

--- a/src/test/java/com/hivemq/mqtt/message/pool/FreePacketIdRangesTest.java
+++ b/src/test/java/com/hivemq/mqtt/message/pool/FreePacketIdRangesTest.java
@@ -54,6 +54,19 @@ public class FreePacketIdRangesTest {
         assertTrue(areConsecutiveMessageIds(Lists.partition(integers, FreePacketIdRanges.MAX_ALLOWED_MQTT_PACKET_ID).get(1)));
     }
 
+    @Test
+    public void takeNextId_whenPreviousTakesLeaveEmptyRangesButFreeIdsRemainInOtherRanges_thenNewIdIsReturned()
+            throws NoMessageIdAvailableException {
+        final FreePacketIdRanges messageIDPool = new FreePacketIdRanges();
+        final int firstId = messageIDPool.takeNextId();
+        assertEquals(1, firstId);
+        final int secondId = messageIDPool.takeNextId();
+        assertEquals(2, secondId);
+        messageIDPool.returnId(firstId);
+        messageIDPool.takeIfAvailable(firstId);
+        assertEquals(3, messageIDPool.takeNextId());
+    }
+
     @Test(expected = NoMessageIdAvailableException.class)
     public void takeNextId_whenNoMoreIdsAvailable_thenExceptionIsThrown() throws
             NoMessageIdAvailableException {

--- a/src/test/java/com/hivemq/mqtt/message/pool/FreePacketIdRangesTest.java
+++ b/src/test/java/com/hivemq/mqtt/message/pool/FreePacketIdRangesTest.java
@@ -17,6 +17,7 @@ package com.hivemq.mqtt.message.pool;
 
 import com.google.common.collect.Lists;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.mqtt.message.pool.exception.MessageIdUnavailableException;
 import com.hivemq.mqtt.message.pool.exception.NoMessageIdAvailableException;
 import org.junit.Test;
 
@@ -56,14 +57,14 @@ public class FreePacketIdRangesTest {
 
     @Test
     public void takeNextId_whenPreviousTakesLeaveEmptyRangesButFreeIdsRemainInOtherRanges_thenNewIdIsReturned()
-            throws NoMessageIdAvailableException {
+            throws NoMessageIdAvailableException, MessageIdUnavailableException {
         final FreePacketIdRanges messageIDPool = new FreePacketIdRanges();
         final int firstId = messageIDPool.takeNextId();
         assertEquals(1, firstId);
         final int secondId = messageIDPool.takeNextId();
         assertEquals(2, secondId);
         messageIDPool.returnId(firstId);
-        messageIDPool.takeIfAvailable(firstId);
+        messageIDPool.takeSpecificId(firstId);
         assertEquals(3, messageIDPool.takeNextId());
     }
 
@@ -98,10 +99,11 @@ public class FreePacketIdRangesTest {
     }
 
     @Test
-    public void takeIfAvailable_whenIdIsFree_thenIdWasTaken() throws NoMessageIdAvailableException {
+    public void takeSpecificId_whenIdIsFree_thenIdWasTaken()
+            throws NoMessageIdAvailableException, MessageIdUnavailableException {
 
         final FreePacketIdRanges messageIDPool = new FreePacketIdRanges();
-        messageIDPool.takeIfAvailable(42);
+        messageIDPool.takeSpecificId(42);
         for (int i = 0; i < FreePacketIdRanges.MAX_ALLOWED_MQTT_PACKET_ID - 1; i++) {
             final int id = messageIDPool.takeNextId();
             assertNotEquals(42, id);//since was taken directly
@@ -109,12 +111,17 @@ public class FreePacketIdRangesTest {
     }
 
     @Test
-    public void takeIfAvailable_whenIdIsTakenTwice_thenItRemainsTaken() throws NoMessageIdAvailableException {
+    public void takeSpecificId_whenIdIsTakenTwice_thenItRemainsTaken()
+            throws NoMessageIdAvailableException, MessageIdUnavailableException {
 
         final FreePacketIdRanges messageIDPool = new FreePacketIdRanges();
 
-        messageIDPool.takeIfAvailable(42);
-        messageIDPool.takeIfAvailable(42);
+        messageIDPool.takeSpecificId(42);
+        try {
+            messageIDPool.takeSpecificId(42);
+        } catch (final MessageIdUnavailableException e) {
+            //ignore
+        }
         for (int i = 0; i < FreePacketIdRanges.MAX_ALLOWED_MQTT_PACKET_ID - 1; i++) {
             final int id = messageIDPool.takeNextId();
             assertNotEquals(42, id);//since was taken directly
@@ -122,10 +129,20 @@ public class FreePacketIdRangesTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void takeIfAvailable_whenTryingToTakeInvalidId_thenExceptionIsThrown() throws NoMessageIdAvailableException {
+    public void takeSpecificId_whenTryingToTakeInvalidId_thenExceptionIsThrown()
+            throws IllegalArgumentException, MessageIdUnavailableException {
 
         final FreePacketIdRanges messageIDPool = new FreePacketIdRanges();
-        messageIDPool.takeIfAvailable(FreePacketIdRanges.MAX_ALLOWED_MQTT_PACKET_ID + 1);
+        messageIDPool.takeSpecificId(FreePacketIdRanges.MAX_ALLOWED_MQTT_PACKET_ID + 1);
+    }
+
+    @Test(expected = MessageIdUnavailableException.class)
+    public void takeSpecificId_whenTryingToTakeTakenId_thenExceptionIsThrown()
+            throws IllegalArgumentException, MessageIdUnavailableException {
+
+        final FreePacketIdRanges messageIDPool = new FreePacketIdRanges();
+        messageIDPool.takeSpecificId(42);
+        messageIDPool.takeSpecificId(42);
     }
 
     private static boolean areConsecutiveMessageIds(final @NotNull List<Integer> integerList) {


### PR DESCRIPTION
[Ticket](https://hivemq.kanbanize.com/ctrl_board/42/cards/17404/details/)