### PR TITLE
New method to disable LoggingBootstrap via EmbeddedHiveMQBuilder

### DIFF
--- a/src/main/java/com/hivemq/embedded/EmbeddedHiveMQBuilder.java
+++ b/src/main/java/com/hivemq/embedded/EmbeddedHiveMQBuilder.java
@@ -75,6 +75,14 @@ public interface EmbeddedHiveMQBuilder {
     @NotNull EmbeddedHiveMQBuilder withEmbeddedExtension(@Nullable EmbeddedExtension embeddedExtension);
 
     /**
+     * Disables the internal logging bootstrap, for the case any logging is already provided by other frameworks,
+     * such as OSGi or Springboot.
+     *
+     * @return this builder.
+     */
+    @NotNull EmbeddedHiveMQBuilder withoutLoggingBootstrap();
+
+    /**
      * Concludes the EmbeddedHiveMQ build process.
      * <p>
      * Beware that this method sets the

--- a/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQBuilderImpl.java
+++ b/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQBuilderImpl.java
@@ -35,6 +35,7 @@ public class EmbeddedHiveMQBuilderImpl implements EmbeddedHiveMQBuilder {
     private @Nullable Path dataFolder = null;
     private @Nullable Path extensionsFolder = null;
     private @Nullable EmbeddedExtension embeddedExtension = null;
+    private boolean enableLoggingBootstrap = true;
 
     @Override
     public @NotNull EmbeddedHiveMQBuilder withConfigurationFolder(final @Nullable Path configFolder) {
@@ -61,13 +62,19 @@ public class EmbeddedHiveMQBuilderImpl implements EmbeddedHiveMQBuilder {
     }
 
     @Override
+    public EmbeddedHiveMQBuilder withoutLoggingBootstrap() {
+        this.enableLoggingBootstrap = false;
+        return this;
+    }
+
+    @Override
     public @NotNull EmbeddedHiveMQ build() {
         // Shim for the old API
         final File confFile = configFolder == null ? null : configFolder.toFile();
         final File dataFile = dataFolder == null ? null : dataFolder.toFile();
         final File extensionsFile = extensionsFolder == null ? null : extensionsFolder.toFile();
 
-        return new EmbeddedHiveMQImpl(confFile, dataFile, extensionsFile, embeddedExtension);
+        return new EmbeddedHiveMQImpl(confFile, dataFile, extensionsFile, embeddedExtension, enableLoggingBootstrap);
     }
 
 }

--- a/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
+++ b/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
@@ -64,17 +64,21 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
     private @NotNull LinkedList<CompletableFuture<Void>> stopFutures = new LinkedList<>();
     private @Nullable Future<?> shutDownFuture;
 
+    private final boolean enableLoggingBootstrap;
+
     EmbeddedHiveMQImpl(
             final @Nullable File conf, final @Nullable File data, final @Nullable File extensions) {
-        this(conf, data, extensions, null);
+        this(conf, data, extensions, null, true);
     }
 
     EmbeddedHiveMQImpl(
             final @Nullable File conf,
             final @Nullable File data,
             final @Nullable File extensions,
-            final @Nullable EmbeddedExtension embeddedExtension) {
+            final @Nullable EmbeddedExtension embeddedExtension,
+            final boolean enableLoggingBootstrap) {
         this.embeddedExtension = embeddedExtension;
+        this.enableLoggingBootstrap = enableLoggingBootstrap;
 
         log.info("Setting default authentication behavior to ALLOW ALL");
         InternalConfigurations.AUTH_DENY_UNAUTHENTICATED_CONNECTIONS.set(false);
@@ -146,7 +150,7 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
                     systemInformation.init();
                     configurationService = ConfigurationBootstrap.bootstrapConfig(systemInformation);
 
-                    hiveMQServer = new HiveMQServer(systemInformation, metricRegistry, configurationService, false);
+                    hiveMQServer = new HiveMQServer(systemInformation, metricRegistry, configurationService, enableLoggingBootstrap, false);
                     hiveMQServer.bootstrap();
                     hiveMQServer.startInstance(embeddedExtension);
 

--- a/src/test/java/com/hivemq/embedded/internal/EmbeddedHiveMQImplTest.java
+++ b/src/test/java/com/hivemq/embedded/internal/EmbeddedHiveMQImplTest.java
@@ -268,7 +268,8 @@ public class EmbeddedHiveMQImplTest {
         final EmbeddedExtensionImpl extension =
                 new EmbeddedExtensionImpl("id", "name", "123", "luke_skywalker", 0, 1000, embeddedMain);
 
-        final EmbeddedHiveMQImpl embeddedHiveMQ = new EmbeddedHiveMQImpl(conf, data, extensions, extension);
+        final EmbeddedHiveMQImpl embeddedHiveMQ =
+                new EmbeddedHiveMQImpl(conf, data, extensions, extension, true);
         embeddedHiveMQ.start().get();
 
         assertTrue(embeddedMain.running.get());


### PR DESCRIPTION
**Motivation**
Disabling internal *HiveMQServer* *LoggingBootstrap* resolves class loading issues when incorporating the embedded version in frameworks like *OSGi* or *Springboot*.

Resolves issue #439

**Changes**
- EmbeddedHiveMQBuilder.java
- EmbeddedHiveMQBuilderImpl.java
- EmbeddedHiveMQImpl
- HiveMQServer
- EmbeddedHiveMQImplTest