### PR TITLE
[latest] Refactor PublushFlowHanderl, so, now we have two clear distinct paths…

### DIFF
--- a/src/main/java/com/hivemq/persistence/qos/IncomingMessageFlowPersistenceImpl.java
+++ b/src/main/java/com/hivemq/persistence/qos/IncomingMessageFlowPersistenceImpl.java
@@ -32,7 +32,7 @@ public class IncomingMessageFlowPersistenceImpl implements IncomingMessageFlowPe
     private final @NotNull IncomingMessageFlowLocalPersistence localPersistence;
 
     @Inject
-    IncomingMessageFlowPersistenceImpl(final @NotNull IncomingMessageFlowLocalPersistence localPersistence) {
+    public IncomingMessageFlowPersistenceImpl(final @NotNull IncomingMessageFlowLocalPersistence localPersistence) {
         this.localPersistence = localPersistence;
     }
 

--- a/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlowHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlowHandlerTest.java
@@ -847,7 +847,7 @@ public class PublishFlowHandlerTest {
         verify(incomingPublishHandler, times(1)).interceptOrDelegate(any(ChannelHandlerContext.class),
                 eq(publishQoS2),
                 eq(CLIENT_ID));
-        verify(incomingPublishHandler, times(0)).interceptOrDelegate(any(ChannelHandlerContext.class),
+        verify(incomingPublishHandler, never()).interceptOrDelegate(any(ChannelHandlerContext.class),
                 eq(publishQoS2Duplicate),
                 eq(CLIENT_ID));
     }


### PR DESCRIPTION
… for Qos1 and Qos2, Qos1 is using a map while Qos2 is using the IncomingMessageFlowPersistence

Resolves # 
https://hivemq.kanbanize.com/ctrl_board/42/cards/22992/details/

