### PR TITLE
Replace Deprecated MockitoAnnotations.initMocks

### DIFF
--- a/src/test/java/com/hivemq/bootstrap/BindInformationTest.java
+++ b/src/test/java/com/hivemq/bootstrap/BindInformationTest.java
@@ -17,6 +17,7 @@ package com.hivemq.bootstrap;
 
 import com.hivemq.configuration.service.entity.TcpListener;
 import io.netty.channel.ChannelFuture;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -31,11 +32,17 @@ public class BindInformationTest {
     ChannelFuture future;
 
     private TcpListener listener;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         listener = new TcpListener(1883, "0.0.0.0");
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/HiveMQNettyBootstrapTest.java
+++ b/src/test/java/com/hivemq/bootstrap/HiveMQNettyBootstrapTest.java
@@ -32,6 +32,7 @@ import com.hivemq.persistence.connection.ConnectionPersistence;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -52,6 +53,7 @@ import static util.TlsTestUtil.createDefaultTLS;
 public class HiveMQNettyBootstrapTest {
 
     private HiveMQNettyBootstrap hiveMQNettyBootstrap;
+    private AutoCloseable closeable;
 
     @Mock
     private ShutdownHooks shutdownHooks;
@@ -73,7 +75,7 @@ public class HiveMQNettyBootstrapTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         hiveMQNettyBootstrap = new HiveMQNettyBootstrap(shutdownHooks,
                 listenerConfigurationService,
                 channelInitializerFactoryImpl,
@@ -85,6 +87,11 @@ public class HiveMQNettyBootstrapTest {
 
         when(channelInitializerFactoryImpl.getChannelInitializer(any(Listener.class))).thenReturn(
                 abstractChannelInitializer);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/netty/ChannelDependenciesTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/ChannelDependenciesTest.java
@@ -45,6 +45,7 @@ import com.hivemq.mqtt.handler.unsubscribe.UnsubscribeHandler;
 import com.hivemq.security.ssl.SslParameterHandler;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -145,10 +146,11 @@ public class ChannelDependenciesTest {
     private @NotNull ShutdownHooks shutdownHooks;
 
     private @NotNull ChannelDependencies channelDependencies;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channelDependencies = new ChannelDependencies(noConnectIdleHandler,
                 () -> connectHandler,
@@ -180,6 +182,11 @@ public class ChannelDependenciesTest {
                 interceptorHandler,
                 globalMQTTMessageCounter,
                 shutdownHooks);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/netty/ExceptionHandlerTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/ExceptionHandlerTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.CorruptedFrameException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -57,10 +58,11 @@ public class ExceptionHandlerTest {
     ClientConnection clientConnection;
 
     private ExceptionHandler handler;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         when(ctx.pipeline()).thenReturn(pipeline);
         when(channel.pipeline()).thenReturn(pipeline);
@@ -70,6 +72,11 @@ public class ExceptionHandlerTest {
         when(ctx.channel()).thenReturn(channel);
 
         handler = new ExceptionHandler(mqttServerDisconnector);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/netty/initializer/ChannelGroupHandlerTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/initializer/ChannelGroupHandlerTest.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.group.ChannelGroup;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -44,14 +45,20 @@ public class ChannelGroupHandlerTest {
     ChannelPipeline channelPipeline;
 
     private ChannelGroupHandler channelGroupHandler;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         channelGroupHandler = new ChannelGroupHandler(channelGroup);
 
         when(ctx.channel()).thenReturn(channel);
         when(ctx.pipeline()).thenReturn(channelPipeline);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/netty/initializer/ChannelInitializerFactoryImplTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/initializer/ChannelInitializerFactoryImplTest.java
@@ -30,6 +30,7 @@ import com.hivemq.logging.EventLog;
 import com.hivemq.security.ssl.NonSslHandler;
 import com.hivemq.security.ssl.SslFactory;
 import io.netty.channel.Channel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -69,15 +70,21 @@ public class ChannelInitializerFactoryImplTest {
     private RestrictionsConfigurationService restrictionsConfigurationService;
 
     private ChannelInitializerFactoryImpl channelInitializerFactory;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(channelDependencies.getConfigurationService()).thenReturn(fullConfigurationService);
         when(channelDependencies.getRestrictionsConfigurationService()).thenReturn(restrictionsConfigurationService);
         when(restrictionsConfigurationService.incomingLimit()).thenReturn(0L);
         channelInitializerFactory =
                 new TestChannelInitializerFactory(channelDependencies, sslFactory, nonSslHandlerProvider);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/netty/initializer/TcpChannelInitializerTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/initializer/TcpChannelInitializerTest.java
@@ -24,6 +24,7 @@ import com.hivemq.mqtt.handler.disconnect.MqttServerDisconnectorImpl;
 import com.hivemq.security.ssl.NonSslHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -58,14 +59,13 @@ public class TcpChannelInitializerTest {
     @Mock
     private RestrictionsConfigurationService restrictionsConfigurationService;
 
-
     private ChannelPipeline pipeline;
-
     private TcpChannelInitializer tcpChannelInitializer;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         when(channelDependencies.getConfigurationService()).thenReturn(fullConfigurationService);
         when(channelDependencies.getRestrictionsConfigurationService()).thenReturn(restrictionsConfigurationService);
@@ -78,6 +78,11 @@ public class TcpChannelInitializerTest {
         when(nonSslHandlerProvider.get()).thenReturn(new NonSslHandler(mqttServerDisconnector));
         when(socketChannel.pipeline()).thenReturn(pipeline);
 
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/netty/initializer/TlsTcpChannelInitializerTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/initializer/TlsTcpChannelInitializerTest.java
@@ -34,6 +34,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -90,10 +91,11 @@ public class TlsTcpChannelInitializerTest {
     private ChannelPipeline pipeline;
 
     private TlsTcpChannelInitializer tlstcpChannelInitializer;
+    private AutoCloseable closeable;
 
     @Before
     public void before() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         pipeline = new FakeChannelPipeline();
 
@@ -115,6 +117,11 @@ public class TlsTcpChannelInitializerTest {
 
         tlstcpChannelInitializer = new TlsTcpChannelInitializer(channelDependencies, tlsTcpListener, sslFactory);
 
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/netty/initializer/TlsWebsocketChannelInitializerTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/initializer/TlsWebsocketChannelInitializerTest.java
@@ -34,6 +34,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -95,10 +96,11 @@ public class TlsWebsocketChannelInitializerTest {
     private Tls tls;
 
     private ChannelPipeline pipeline;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         pipeline = new FakeChannelPipeline();
 
@@ -118,6 +120,11 @@ public class TlsWebsocketChannelInitializerTest {
         final MqttServerDisconnector mqttServerDisconnector = new MqttServerDisconnectorImpl(eventLog);
 
         when(channelDependencies.getMqttServerDisconnector()).thenReturn(mqttServerDisconnector);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/bootstrap/netty/initializer/WebsocketChannelInitializerTest.java
+++ b/src/test/java/com/hivemq/bootstrap/netty/initializer/WebsocketChannelInitializerTest.java
@@ -24,6 +24,7 @@ import com.hivemq.mqtt.handler.disconnect.MqttServerDisconnector;
 import com.hivemq.security.ssl.NonSslHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -58,10 +59,11 @@ public class WebsocketChannelInitializerTest {
     private RestrictionsConfigurationService restrictionsConfigurationService;
 
     private ChannelPipeline pipeline;
+    private AutoCloseable closeable;
 
     @Before
     public void before() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         pipeline = new FakeChannelPipeline();
 
@@ -70,6 +72,11 @@ public class WebsocketChannelInitializerTest {
         when(channelDependencies.getConfigurationService()).thenReturn(fullConfigurationService);
         when(channelDependencies.getRestrictionsConfigurationService()).thenReturn(restrictionsConfigurationService);
         when(restrictionsConfigurationService.incomingLimit()).thenReturn(0L);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/MQTTMessageDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/MQTTMessageDecoderTest.java
@@ -26,6 +26,7 @@ import com.hivemq.util.ReasonStrings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -42,15 +43,21 @@ public class MQTTMessageDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
     private @NotNull ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         channel = new EmbeddedChannel(TestMqttDecoder.create());
         clientConnection = new DummyClientConnection(channel, null);
         //setting version to fake "connected" state
         clientConnection.setProtocolVersion(ProtocolVersion.MQTTv5);
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(clientConnection);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     /* ***********************

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderTest.java
@@ -30,6 +30,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -59,17 +60,18 @@ public class Mqtt31ConnectDecoderTest {
     @Mock
     private @NotNull ChannelFuture channelFuture;
 
-    private @NotNull Mqtt31ConnectDecoder decoder;
-    private ClientConnection clientConnection;
-
     @Mock
     private @NotNull MqttConnacker connacker;
+
+    private @NotNull Mqtt31ConnectDecoder decoder;
+    private ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     private static final byte fixedHeader = 0b0001_0000;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(channel.writeAndFlush(any())).thenReturn(channelFuture);
 
         clientConnection = new DummyClientConnection(channel, null);
@@ -82,6 +84,11 @@ public class Mqtt31ConnectDecoderTest {
                 new ClientIds(new HivemqId()),
                 new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderValidationsTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt31ConnectDecoderValidationsTest.java
@@ -30,6 +30,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -63,13 +64,14 @@ public class Mqtt31ConnectDecoderValidationsTest {
 
     private Mqtt31ConnectDecoder decoder;
     private ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     private static final byte fixedHeader = 0b0001_0000;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(fullConfigurationService.mqttConfiguration()).thenReturn(mqttConfigurationService);
         decoder = new Mqtt31ConnectDecoder(connacker,
                 new ClientIds(new HivemqId()),
@@ -79,6 +81,11 @@ public class Mqtt31ConnectDecoderValidationsTest {
         clientConnection = new DummyClientConnection(channel, null);
         when(channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME)).thenReturn(new TestChannelAttribute<>(
                 clientConnection));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3DisconnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3DisconnectDecoderTest.java
@@ -23,6 +23,7 @@ import com.hivemq.mqtt.message.disconnect.DISCONNECT;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -36,14 +37,20 @@ import static org.junit.Assert.assertTrue;
 public class Mqtt3DisconnectDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channel = new EmbeddedChannel(TestMqttDecoder.create());
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(new DummyClientConnection(channel, null));
         ClientConnection.of(channel).setProtocolVersion(ProtocolVersion.MQTTv3_1_1);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3PubackDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3PubackDecoderTest.java
@@ -23,6 +23,7 @@ import com.hivemq.mqtt.message.puback.PUBACK;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -36,14 +37,20 @@ import static org.junit.Assert.assertTrue;
 public class Mqtt3PubackDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channel = new EmbeddedChannel(TestMqttDecoder.create());
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(new DummyClientConnection(channel, null));
         ClientConnection.of(channel).setProtocolVersion(ProtocolVersion.MQTTv3_1_1);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3PubcompDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3PubcompDecoderTest.java
@@ -23,6 +23,7 @@ import com.hivemq.mqtt.message.pubcomp.PUBCOMP;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -37,13 +38,19 @@ public class Mqtt3PubcompDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
     private @NotNull ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         channel = new EmbeddedChannel(TestMqttDecoder.create());
         clientConnection = new DummyClientConnection(channel, null);
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(clientConnection);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3PublishDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3PublishDecoderTest.java
@@ -26,6 +26,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -45,14 +46,20 @@ import static org.junit.Assert.assertTrue;
 public class Mqtt3PublishDecoderTest {
 
     private EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channel = new EmbeddedChannel(TestMqttDecoder.create());
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(new DummyClientConnection(channel, null));
         ClientConnection.of(channel).setProtocolVersion(ProtocolVersion.MQTTv3_1_1);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3PubrecDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3PubrecDecoderTest.java
@@ -23,6 +23,7 @@ import com.hivemq.mqtt.message.pubrec.PUBREC;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -36,11 +37,17 @@ import static org.junit.Assert.assertTrue;
 public class Mqtt3PubrecDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         channel = new EmbeddedChannel(TestMqttDecoder.create());
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3PubrelDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3PubrelDecoderTest.java
@@ -23,6 +23,7 @@ import com.hivemq.mqtt.message.pubrel.PUBREL;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -36,11 +37,17 @@ import static org.junit.Assert.assertTrue;
 public class Mqtt3PubrelDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         channel = new EmbeddedChannel(TestMqttDecoder.create());
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3SubscribeDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3SubscribeDecoderTest.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -39,14 +40,20 @@ import static org.junit.Assert.assertTrue;
 public class Mqtt3SubscribeDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channel = new EmbeddedChannel(TestMqttDecoder.create());
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(new DummyClientConnection(channel, null));
         ClientConnection.of(channel).setProtocolVersion(ProtocolVersion.MQTTv3_1_1);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/Mqtt3UnsubscribeDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/Mqtt3UnsubscribeDecoderTest.java
@@ -23,6 +23,7 @@ import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -38,14 +39,20 @@ import static org.junit.Assert.assertTrue;
 public class Mqtt3UnsubscribeDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channel = new EmbeddedChannel(TestMqttDecoder.create());
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(new DummyClientConnection(channel, null));
         ClientConnection.of(channel).setProtocolVersion(ProtocolVersion.MQTTv3_1_1);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/MqttPingreqDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/MqttPingreqDecoderTest.java
@@ -23,6 +23,7 @@ import com.hivemq.mqtt.message.ProtocolVersion;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -38,12 +39,18 @@ import static org.junit.Assert.assertTrue;
 public class MqttPingreqDecoderTest {
 
     private @NotNull EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channel = new EmbeddedChannel(TestMqttDecoder.create());
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderTest.java
@@ -33,6 +33,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -75,11 +76,12 @@ public class Mqtt311ConnectDecoderTest {
     private static final byte fixedHeader = 0b0001_0000;
     private HivemqId hiveMQId;
     private ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         clientConnection = new DummyClientConnection(channel, null);
         when(channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME)).thenReturn(new TestChannelAttribute<>(
@@ -93,6 +95,11 @@ public class Mqtt311ConnectDecoderTest {
                 new ClientIds(hiveMQId),
                 new TestConfigurationBootstrap().getFullConfigurationService(),
                 hiveMQId);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderValidationsTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt311/Mqtt311ConnectDecoderValidationsTest.java
@@ -28,6 +28,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -56,13 +57,14 @@ public class Mqtt311ConnectDecoderValidationsTest {
     private MqttConnacker connacker;
     private ClientConnection clientConnection;
     private Mqtt311ConnectDecoder decoder;
+    private AutoCloseable closeable;
 
     private static final byte fixedHeader = 0b0001_0000;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         clientConnection = new DummyClientConnection(channel, null);
         when(channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME)).thenReturn(new TestChannelAttribute<>(new DummyClientConnection(
@@ -73,6 +75,11 @@ public class Mqtt311ConnectDecoderValidationsTest {
                 new ClientIds(new HivemqId()),
                 new TestConfigurationBootstrap().getFullConfigurationService(),
                 new HivemqId());
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5DisconnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5DisconnectDecoderTest.java
@@ -29,6 +29,7 @@ import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -55,11 +56,18 @@ public class Mqtt5DisconnectDecoderTest extends AbstractMqtt5DecoderTest {
     @Mock
     private @NotNull SecurityConfigurationService securityConfigurationService;
 
+    private AutoCloseable closeable;
+
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(securityConfigurationService.allowRequestProblemInformation()).thenReturn(true);
         ClientConnection.of(channel).setClientSessionExpiryInterval(100L);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/configuration/ioc/ConfigurationFileProviderTest.java
+++ b/src/test/java/com/hivemq/configuration/ioc/ConfigurationFileProviderTest.java
@@ -61,11 +61,12 @@ public class ConfigurationFileProviderTest {
 
 
     private File confFolder;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         logger.addAppender(mockAppender);
@@ -84,6 +85,11 @@ public class ConfigurationFileProviderTest {
         final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
         logger.detachAppender(mockAppender);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/configuration/reader/AbstractConfigurationTest.java
+++ b/src/test/java/com/hivemq/configuration/reader/AbstractConfigurationTest.java
@@ -30,6 +30,7 @@ import com.hivemq.configuration.service.impl.listener.ListenerConfigurationServi
 import com.hivemq.statistics.UsageStatisticsConfig;
 import com.hivemq.statistics.UsageStatisticsConfigImpl;
 import com.hivemq.util.EnvVarUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -59,9 +60,11 @@ public class AbstractConfigurationTest {
     SystemInformation systemInformation;
     PersistenceConfigurationService persistenceConfigurationService;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         listenerConfigurationService = new ListenerConfigurationServiceImpl();
 
         xmlFile = temporaryFolder.newFile();
@@ -82,6 +85,11 @@ public class AbstractConfigurationTest {
                 new MqttConfigurator(mqttConfigurationService),
                 new ListenerConfigurator(listenerConfigurationService, systemInformation),
                 new PersistenceConfigurator(persistenceConfigurationService));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
 }

--- a/src/test/java/com/hivemq/configuration/reader/ConfigFileReaderTest.java
+++ b/src/test/java/com/hivemq/configuration/reader/ConfigFileReaderTest.java
@@ -29,6 +29,7 @@ import com.hivemq.configuration.service.impl.listener.ListenerConfigurationServi
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.statistics.UsageStatisticsConfig;
 import com.hivemq.util.EnvVarUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -63,10 +64,11 @@ public class ConfigFileReaderTest {
     private ListenerConfigurationService listenerConfigurationService;
 
     ConfigFileReader reader;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         listenerConfigurationService = new ListenerConfigurationServiceImpl();
 
         final ConfigurationFile configurationFile = new ConfigurationFile(null);
@@ -78,6 +80,11 @@ public class ConfigFileReaderTest {
                 new MqttConfigurator(mqttConfigurationService),
                 new ListenerConfigurator(listenerConfigurationService, systemInformation),
                 new PersistenceConfigurator(persistenceConfigurationService));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/configuration/service/impl/SecurityConfigurationServiceImplTest.java
+++ b/src/test/java/com/hivemq/configuration/service/impl/SecurityConfigurationServiceImplTest.java
@@ -26,7 +26,7 @@ import util.LogbackCapturingAppender;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author Waldemar Ruck
@@ -38,10 +38,11 @@ public class SecurityConfigurationServiceImplTest {
             new SecurityConfigurationServiceImpl();
 
     private LogbackCapturingAppender logCapture;
+    private AutoCloseable closeable;
 
     @Before
     public void setup() {
-        initMocks(this);
+        closeable = openMocks(this);
         final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         logCapture = LogbackCapturingAppender.Factory.weaveInto(logger);
     }
@@ -49,6 +50,11 @@ public class SecurityConfigurationServiceImplTest {
     @After
     public void tearDown() throws Exception {
         LogbackCapturingAppender.Factory.cleanUp();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/ExtensionPriorityComparatorTest.java
+++ b/src/test/java/com/hivemq/extensions/ExtensionPriorityComparatorTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.extensions;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -38,12 +39,18 @@ public class ExtensionPriorityComparatorTest {
     private HiveMQExtensions hiveMQExtensions;
 
     private ExtensionPriorityComparator comparator;
+    private AutoCloseable closeable;
 
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         comparator = new ExtensionPriorityComparator(hiveMQExtensions);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/ListenableFutureConverterTest.java
+++ b/src/test/java/com/hivemq/extensions/ListenableFutureConverterTest.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -46,9 +47,16 @@ public class ListenableFutureConverterTest {
     @Mock
     private RetainedMessagePersistence retainedMessagePersistence;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/auth/ReAuthOutputTest.java
+++ b/src/test/java/com/hivemq/extensions/auth/ReAuthOutputTest.java
@@ -23,6 +23,7 @@ import com.hivemq.extensions.packets.general.ModifiableDefaultPermissionsImpl;
 import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 import com.hivemq.util.Bytes;
 import com.hivemq.util.ReasonStrings;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -48,15 +49,21 @@ public class ReAuthOutputTest {
     private PluginOutPutAsyncer asyncer;
 
     private ReAuthOutput authTaskOutput;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         authTaskOutput = new ReAuthOutput(asyncer,
                 true,
                 new ModifiableDefaultPermissionsImpl(),
                 new ModifiableClientSettingsImpl(10, null),
                 30);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/hivemq/extensions/auth/ReAuthTaskTest.java
+++ b/src/test/java/com/hivemq/extensions/auth/ReAuthTaskTest.java
@@ -30,6 +30,7 @@ import com.hivemq.extensions.services.auth.WrappedAuthenticatorProvider;
 import com.hivemq.mqtt.message.auth.AUTH;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.mqtt.message.reason.Mqtt5AuthReasonCode;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,27 +54,29 @@ import static org.mockito.Mockito.when;
 public class ReAuthTaskTest {
 
     public static AtomicBoolean connect;
-
-    @Mock
-    private WrappedAuthenticatorProvider wrappedAuthenticatorProvider;
     public static AtomicBoolean auth;
-
-    private EnhancedAuthenticator enhancedAuthenticator;
     public static AtomicBoolean reAuth;
+    private EnhancedAuthenticator enhancedAuthenticator;
+    private IsolatedExtensionClassloader classloader;
+    private AutoCloseable closeable;
+
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private ReAuthTask authTask;
     @Mock
+    private WrappedAuthenticatorProvider wrappedAuthenticatorProvider;
+
+    @Mock
     private AuthenticatorProviderInput authenticatorProviderInput;
-    private IsolatedExtensionClassloader classloader;
+
     @Mock
     private HiveMQExtensions extensions;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         connect = new AtomicBoolean();
         auth = new AtomicBoolean();
@@ -89,6 +92,11 @@ public class ReAuthTaskTest {
                 authenticatorProviderInput,
                 "extension1",
                 new ClientAuthenticatorsImpl(new ExtensionPriorityComparator(extensions)));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/hivemq/extensions/auth/parameter/PublishAuthorizerOutputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/auth/parameter/PublishAuthorizerOutputImplTest.java
@@ -18,6 +18,7 @@ package com.hivemq.extensions.auth.parameter;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.packets.publish.AckReasonCode;
 import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -40,11 +41,17 @@ public class PublishAuthorizerOutputImplTest {
     private PluginOutPutAsyncer asyncer;
 
     private PublishAuthorizerOutputImpl output;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         output = new PublishAuthorizerOutputImpl(asyncer);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/auth/parameter/SubscriptionAuthorizerInputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/auth/parameter/SubscriptionAuthorizerInputImplTest.java
@@ -27,6 +27,7 @@ import com.hivemq.mqtt.message.mqtt5.Mqtt5RetainHandling;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -45,15 +46,21 @@ public class SubscriptionAuthorizerInputImplTest {
 
     private Channel channel;
     private ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         channel = new EmbeddedChannel();
         clientConnection = new DummyClientConnection(channel, null);
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(clientConnection);
         clientConnection.setProtocolVersion(ProtocolVersion.MQTTv5);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/auth/parameter/SubscriptionAuthorizerOutputImplTest.java
+++ b/src/test/java/com/hivemq/extensions/auth/parameter/SubscriptionAuthorizerOutputImplTest.java
@@ -18,6 +18,7 @@ package com.hivemq.extensions.auth.parameter;
 import com.hivemq.extension.sdk.api.packets.disconnect.DisconnectReasonCode;
 import com.hivemq.extension.sdk.api.packets.subscribe.SubackReasonCode;
 import com.hivemq.extensions.executor.PluginOutPutAsyncer;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -40,11 +41,17 @@ public class SubscriptionAuthorizerOutputImplTest {
     private PluginOutPutAsyncer asyncer;
 
     private SubscriptionAuthorizerOutputImpl output;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         output = new SubscriptionAuthorizerOutputImpl(asyncer);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/executor/PluginOutputAsyncerImplTest.java
+++ b/src/test/java/com/hivemq/extensions/executor/PluginOutputAsyncerImplTest.java
@@ -22,6 +22,7 @@ import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.async.Async;
 import com.hivemq.extension.sdk.api.async.TimeoutFallback;
 import com.hivemq.extensions.executor.task.PluginTaskOutput;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -44,6 +45,7 @@ public class PluginOutputAsyncerImplTest {
 
 
     private PluginOutPutAsyncer asyncer;
+    private AutoCloseable closeable;
 
     @Mock
     private ShutdownHooks shutdownHooks;
@@ -51,9 +53,14 @@ public class PluginOutputAsyncerImplTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         asyncer = new PluginOutputAsyncerImpl(shutdownHooks);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/executor/PluginTaskExecutorServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/executor/PluginTaskExecutorServiceImplTest.java
@@ -35,6 +35,7 @@ import com.hivemq.extensions.executor.task.PluginTaskInput;
 import com.hivemq.extensions.executor.task.PluginTaskOutput;
 import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -56,6 +57,7 @@ import static org.mockito.Mockito.verify;
 public class PluginTaskExecutorServiceImplTest {
 
     private PluginTaskExecutorServiceImpl executorService;
+    private AutoCloseable closeable;
 
     @Mock
     private PluginTaskExecutor executor1;
@@ -68,13 +70,18 @@ public class PluginTaskExecutorServiceImplTest {
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         InternalConfigurations.EXTENSION_TASK_QUEUE_EXECUTOR_THREADS_COUNT.set(2);
 
         executorService =
                 new PluginTaskExecutorServiceImpl(new ExecutorProvider(Lists.newArrayList(executor1, executor2)),
                         mock(ShutdownHooks.class));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/executor/task/PluginTaskExecutorTest.java
+++ b/src/test/java/com/hivemq/extensions/executor/task/PluginTaskExecutorTest.java
@@ -45,15 +45,15 @@ import static org.junit.Assert.assertTrue;
 public class PluginTaskExecutorTest {
 
     private PluginTaskExecutor pluginTaskExecutor;
-
     private List<Integer> executionOrder;
+    private AutoCloseable closeable;
 
     @Mock
     IsolatedExtensionClassloader classloader;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         executionOrder = Collections.synchronizedList(new ArrayList<>());
 
         pluginTaskExecutor = new PluginTaskExecutor(new AtomicLong(0));
@@ -63,6 +63,11 @@ public class PluginTaskExecutorTest {
     @After
     public void after() {
         pluginTaskExecutor.stop();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/hivemq/extensions/iteration/AsyncLocalChunkIteratorTest.java
+++ b/src/test/java/com/hivemq/extensions/iteration/AsyncLocalChunkIteratorTest.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -50,14 +51,20 @@ public class AsyncLocalChunkIteratorTest {
     private TestFetchCallback fetchCallback;
     private TestItemCallback itemCallback;
     private ExecutorService executorService;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         executorService = Executors.newFixedThreadPool(2);
         fetchCallback = new TestFetchCallback(executorService);
         itemCallback = new TestItemCallback();
         asyncIterator = new AsyncLocalChunkIterator<>(fetchCallback, itemCallback, executorService);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
 

--- a/src/test/java/com/hivemq/extensions/services/PluginServiceRateLimitServiceTest.java
+++ b/src/test/java/com/hivemq/extensions/services/PluginServiceRateLimitServiceTest.java
@@ -17,6 +17,7 @@ package com.hivemq.extensions.services;
 
 
 import com.hivemq.configuration.service.InternalConfigurations;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -30,11 +31,17 @@ import static org.junit.Assert.assertTrue;
 public class PluginServiceRateLimitServiceTest {
 
     private PluginServiceRateLimitService pluginServiceRateLimitService;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         pluginServiceRateLimitService = new PluginServiceRateLimitService();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/services/builder/TopicSubscriptionBuilderImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/builder/TopicSubscriptionBuilderImplTest.java
@@ -28,6 +28,7 @@ import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5RetainHandling;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -41,16 +42,21 @@ import static org.junit.Assert.assertTrue;
 public class TopicSubscriptionBuilderImplTest {
 
     private FullConfigurationService fullConfigurationService;
-
     private TopicSubscriptionBuilder topicSubscriptionBuilder;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         fullConfigurationService = new TestConfigurationBootstrap().getFullConfigurationService();
         topicSubscriptionBuilder = new TopicSubscriptionBuilderImpl(fullConfigurationService);
 
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/extensions/services/publish/PublishServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/publish/PublishServiceImplTest.java
@@ -38,6 +38,7 @@ import com.hivemq.mqtt.services.PublishDistributor;
 import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -84,10 +85,11 @@ public class PublishServiceImplTest {
     private final FullConfigurationService fullConfigurationService =
             new TestConfigurationBootstrap().getFullConfigurationService();
     private PublishServiceImpl publishService;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(rateLimitService.rateLimitExceeded()).thenReturn(false);
         managedPluginExecutorService = new GlobalManagedExtensionExecutorService(shutdownHooks);
         managedPluginExecutorService.postConstruct();
@@ -97,6 +99,11 @@ public class PublishServiceImplTest {
                 publishDistributor,
                 hiveMQId,
                 topicTree);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(expected = DoNotImplementException.class)

--- a/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/session/ClientServiceImplTest.java
@@ -42,6 +42,7 @@ import com.hivemq.persistence.clientsession.ClientSession;
 import com.hivemq.persistence.clientsession.ClientSessionPersistence;
 import com.hivemq.persistence.clientsession.ClientSessionWill;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -89,15 +90,21 @@ public class ClientServiceImplTest {
 
     private final String clientId = "clientID";
     private final long sessionExpiry = 123546L;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         clientService = new ClientServiceImpl(pluginServiceRateLimitService,
                 clientSessionPersistence,
                 getManagedExtensionExecutorService(),
                 asyncIteratorFactory);
         when(pluginServiceRateLimitService.rateLimitExceeded()).thenReturn(false);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(expected = RateLimitExceededException.class)

--- a/src/test/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImplTest.java
+++ b/src/test/java/com/hivemq/extensions/services/subscription/SubscriptionStoreImplTest.java
@@ -47,6 +47,7 @@ import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.clientsession.callback.SubscriptionResult;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -86,6 +87,7 @@ import static org.mockito.Mockito.when;
 public class SubscriptionStoreImplTest {
 
     private SubscriptionStore subscriptionStore;
+    private AutoCloseable closeable;
 
     @Mock
     private ClientSessionSubscriptionPersistence clientSessionSubscriptionPersistence;
@@ -102,13 +104,18 @@ public class SubscriptionStoreImplTest {
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         subscriptionStore = new SubscriptionStoreImpl(clientSessionSubscriptionPersistence,
                 rateLimitService,
                 topicTree,
                 getManagedExtensionExecutorService(),
                 asyncIteratorFactory);
         when(rateLimitService.rateLimitExceeded()).thenReturn(false);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(timeout = 10000)

--- a/src/test/java/com/hivemq/limitation/TopicAliasLimiterImplTest.java
+++ b/src/test/java/com/hivemq/limitation/TopicAliasLimiterImplTest.java
@@ -18,6 +18,7 @@ package com.hivemq.limitation;
 
 import com.hivemq.configuration.service.InternalConfigurations;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -31,15 +32,21 @@ import static org.junit.Assert.assertEquals;
 public class TopicAliasLimiterImplTest {
 
     private TopicAliasLimiter topicAliasLimiter;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_SOFT_LIMIT_BYTES.set(50);
         InternalConfigurations.TOPIC_ALIAS_GLOBAL_MEMORY_HARD_LIMIT_BYTES.set(200);
 
         topicAliasLimiter = new TopicAliasLimiterImpl();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/metrics/gauges/OpenConnectionsGaugeTest.java
+++ b/src/test/java/com/hivemq/metrics/gauges/OpenConnectionsGaugeTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.metrics.gauges;
 
 import io.netty.channel.group.ChannelGroup;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -33,11 +34,17 @@ public class OpenConnectionsGaugeTest {
     ChannelGroup channelGroup;
 
     private OpenConnectionsGauge gauge;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         gauge = new OpenConnectionsGauge(channelGroup);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/metrics/gauges/RetainedMessagesGaugeTest.java
+++ b/src/test/java/com/hivemq/metrics/gauges/RetainedMessagesGaugeTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.metrics.gauges;
 
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -33,12 +34,18 @@ public class RetainedMessagesGaugeTest {
     RetainedMessagePersistence retainedMessagePersistence;
 
     private RetainedMessagesGauge retainedMessagesGauge;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         retainedMessagesGauge = new RetainedMessagesGauge(retainedMessagePersistence);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/metrics/gauges/SessionsGaugeTest.java
+++ b/src/test/java/com/hivemq/metrics/gauges/SessionsGaugeTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.metrics.gauges;
 
 import com.hivemq.persistence.local.ClientSessionLocalPersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -33,12 +34,18 @@ public class SessionsGaugeTest {
     ClientSessionLocalPersistence sessionPersistence;
 
     private SessionsGauge sessionsGauge;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         sessionsGauge = new SessionsGauge(sessionPersistence);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/metrics/ioc/MetricsModuleTest.java
+++ b/src/test/java/com/hivemq/metrics/ioc/MetricsModuleTest.java
@@ -29,6 +29,7 @@ import com.hivemq.persistence.local.ClientSessionLocalPersistence;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -40,10 +41,11 @@ import static org.mockito.Mockito.when;
 public class MetricsModuleTest {
 
     private Injector injector;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         injector = Guice.createInjector(new AbstractModule() {
             @Override
@@ -64,6 +66,11 @@ public class MetricsModuleTest {
                 install(new MetricsModule(new MetricRegistry(), persistenceInjector));
             }
         });
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/migration/meta/MetaFileServiceTest.java
+++ b/src/test/java/com/hivemq/migration/meta/MetaFileServiceTest.java
@@ -18,6 +18,7 @@ package com.hivemq.migration.meta;
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.util.LocalPersistenceFileUtil;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,13 +46,19 @@ public class MetaFileServiceTest {
     private SystemInformation systemInformation;
 
     private File dataFolder;
+    private AutoCloseable closeable;
 
     @Before
     public void before() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         dataFolder = temporaryFolder.newFolder();
         when(systemInformation.getDataFolder()).thenReturn(dataFolder);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/migration/persistence/PersistenceMigratorTest.java
+++ b/src/test/java/com/hivemq/migration/persistence/PersistenceMigratorTest.java
@@ -22,6 +22,7 @@ import com.hivemq.migration.persistence.payload.PublishPayloadTypeMigration;
 import com.hivemq.migration.persistence.queue.ClientQueuePayloadIDMigration;
 import com.hivemq.migration.persistence.retained.RetainedMessagePayloadIDMigration;
 import com.hivemq.migration.persistence.retained.RetainedMessageTypeMigration;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -44,13 +45,20 @@ public class PersistenceMigratorTest {
     @Mock
     private RetainedMessagePayloadIDMigration retainedMessagePayloadIDMigration;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         persistenceMigrator = new PersistenceMigrator(() -> publishPayloadTypeMigration,
                 () -> retainedMessageTypeMigration,
                 () -> retainedMessagePayloadIDMigration,
                 () -> clientQueuePayloadIDMigration);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/migration/persistence/payload/PublishPayloadTypeMigrationTest.java
+++ b/src/test/java/com/hivemq/migration/persistence/payload/PublishPayloadTypeMigrationTest.java
@@ -68,10 +68,11 @@ public class PublishPayloadTypeMigrationTest {
 
     private File dataFolder;
     private FullConfigurationService configurationService;
+    private AutoCloseable closeable;
 
     @Before
     public void before() throws IOException {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         dataFolder = temporaryFolder.newFolder();
         when(systemInformation.getDataFolder()).thenReturn(dataFolder);
         when(systemInformation.getConfigFolder()).thenReturn(temporaryFolder.newFolder());
@@ -94,6 +95,11 @@ public class PublishPayloadTypeMigrationTest {
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(64);
         InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.set(64);
         FileUtils.forceDelete(dataFolder);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/migration/persistence/retained/RetainedMessageTypeMigrationTest.java
+++ b/src/test/java/com/hivemq/migration/persistence/retained/RetainedMessageTypeMigrationTest.java
@@ -85,12 +85,13 @@ public class RetainedMessageTypeMigrationTest {
 
     private File dataFolder;
     private FullConfigurationService configurationService;
+    private AutoCloseable closeable;
 
     private RetainedMessageTypeMigration.RetainedMessagePersistenceTypeSwitchCallback callback;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         dataFolder = temporaryFolder.newFolder();
         when(systemInformation.getDataFolder()).thenReturn(dataFolder);
         when(systemInformation.getConfigFolder()).thenReturn(temporaryFolder.newFolder());
@@ -119,6 +120,11 @@ public class RetainedMessageTypeMigrationTest {
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(64);
         InternalConfigurations.PAYLOAD_PERSISTENCE_BUCKET_COUNT.set(64);
         FileUtils.forceDelete(dataFolder);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
@@ -28,6 +28,7 @@ import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.mqtt.topic.tree.TopicSubscribers;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -73,11 +74,12 @@ public class InternalPublishServiceImplTest {
     private ExecutorService executorService;
 
     private InternalPublishServiceImpl publishService;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         executorService = MoreExecutors.newDirectExecutorService();
 
@@ -89,6 +91,11 @@ public class InternalPublishServiceImplTest {
                 eq(executorService))).thenReturn(Futures.immediateFuture(null));
 
         publishService = new InternalPublishServiceImpl(retainedMessagePersistence, topicTree, publishDistributor);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(timeout = 20000)

--- a/src/test/java/com/hivemq/mqtt/callback/PublishStatusFutureCallbackTest.java
+++ b/src/test/java/com/hivemq/mqtt/callback/PublishStatusFutureCallbackTest.java
@@ -25,6 +25,7 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.services.PublishPollService;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -54,19 +55,16 @@ public class PublishStatusFutureCallbackTest {
     private FreePacketIdRanges messageIDPool;
 
     private boolean sharedSubscription;
-
     private String queueId;
-
     private PUBLISH publish;
-
     private Channel channel;
-
     private String client;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         sharedSubscription = false;
         queueId = "queueId";
         publish = TestMessageUtil.createMqtt5Publish();
@@ -88,6 +86,11 @@ public class PublishStatusFutureCallbackTest {
                 messageIDPool,
                 channel,
                 client);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/DropOutgoingPublishesHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/DropOutgoingPublishesHandlerTest.java
@@ -30,6 +30,7 @@ import com.hivemq.mqtt.message.publish.PublishWithFuture;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -63,10 +64,11 @@ public class DropOutgoingPublishesHandlerTest {
     Counter counter;
 
     private DropOutgoingPublishesHandler handler;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(ctx.channel()).thenReturn(channel);
         final ClientConnection clientConnection = new DummyClientConnection(channel, null);
         clientConnection.setClientId("clientId");
@@ -74,6 +76,11 @@ public class DropOutgoingPublishesHandlerTest {
                 clientConnection));
         InternalConfigurations.NOT_WRITABLE_QUEUE_SIZE.set(0);
         handler = new DropOutgoingPublishesHandler(messageDroppedService);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/InterceptorHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/InterceptorHandlerTest.java
@@ -44,6 +44,7 @@ import com.hivemq.mqtt.message.unsuback.UNSUBACK;
 import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -89,10 +90,11 @@ public class InterceptorHandlerTest {
     private @NotNull ChannelPromise channelPromise;
 
     private @NotNull InterceptorHandler interceptorHandler;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         interceptorHandler = new InterceptorHandler(connectInboundInterceptorHandler,
                 connackOutboundInterceptorHandler,
                 publishOutboundInterceptorHandler,
@@ -105,6 +107,11 @@ public class InterceptorHandlerTest {
                 unsubackOutboundInterceptorHandler,
                 pingInterceptorHandler,
                 disconnectInterceptorHandler);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/auth/AuthHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/auth/AuthHandlerTest.java
@@ -64,11 +64,12 @@ public class AuthHandlerTest {
     private AuthHandler authHandler;
     private EmbeddedChannel channel;
     private ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channel = new EmbeddedChannel();
         clientConnection = new DummyClientConnection(channel, null);
@@ -81,6 +82,11 @@ public class AuthHandlerTest {
     @After
     public void tearDown() throws Exception {
         verify(mqttAuthSender).logAuth(eq(channel), any(), anyBoolean());
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/auth/AuthInProgressMessageHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/auth/AuthInProgressMessageHandlerTest.java
@@ -31,6 +31,7 @@ import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.message.reason.Mqtt5ConnAckReasonCode;
 import com.hivemq.mqtt.message.reason.Mqtt5DisconnectReasonCode;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -53,11 +54,11 @@ public class AuthInProgressMessageHandlerTest {
 
     private MqttConnacker connacker;
     private EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
-
+        closeable = MockitoAnnotations.openMocks(this);
         connacker = new MqttConnackerImpl(eventLog);
 
         channel = new EmbeddedChannel();
@@ -65,6 +66,11 @@ public class AuthInProgressMessageHandlerTest {
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(clientConnection);
         clientConnection.setProtocolVersion(ProtocolVersion.MQTTv5);
         channel.pipeline().addFirst(new AuthInProgressMessageHandler(connacker));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectHandlerTest.java
@@ -154,11 +154,12 @@ public class ConnectHandlerTest {
     private MqttServerDisconnectorImpl serverDisconnector;
     private @NotNull ClientConnectionContext clientConnectionContext;
     private ConnectionPersistence connectionPersistence;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(clientSessionPersistence.isExistent(anyString())).thenReturn(false);
         when(clientSessionPersistence.clientConnected(anyString(),
                 anyBoolean(),
@@ -205,6 +206,11 @@ public class ConnectHandlerTest {
     @After
     public void tearDown() {
         InternalConfigurations.AUTH_DENY_UNAUTHENTICATED_CONNECTIONS.set(true);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/connect/ConnectionLimiterHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/ConnectionLimiterHandlerTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -66,12 +67,19 @@ public class ConnectionLimiterHandlerTest {
     @Mock
     CONNECT connect;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         when(ctx.channel()).thenReturn(channel);
         when(ctx.pipeline()).thenReturn(pipeline);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/connect/MessageBarrierTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/MessageBarrierTest.java
@@ -31,6 +31,7 @@ import com.hivemq.mqtt.message.subscribe.SUBSCRIBE;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -48,16 +49,22 @@ public class MessageBarrierTest {
 
     private EmbeddedChannel channel;
     private MessageBarrier messageBarrier;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         final MqttServerDisconnector mqttServerDisconnector = new MqttServerDisconnectorImpl(new EventLog());
 
         messageBarrier = new MessageBarrier(mqttServerDisconnector);
         channel = new EmbeddedChannel(new DummyHandler());
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(new DummyClientConnection(channel, null));
         channel.pipeline().addFirst(MQTT_MESSAGE_BARRIER, messageBarrier);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/connect/SubscribeMessageBarrierTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/connect/SubscribeMessageBarrierTest.java
@@ -24,6 +24,7 @@ import com.hivemq.mqtt.message.subscribe.SUBSCRIBE;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -39,13 +40,19 @@ public class SubscribeMessageBarrierTest {
 
     private EmbeddedChannel channel;
     private SubscribeMessageBarrier subscribeMessageBarrier;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         subscribeMessageBarrier = new SubscribeMessageBarrier();
         channel = new EmbeddedChannel();
         channel.pipeline().addFirst(MQTT_SUBSCRIBE_MESSAGE_BARRIER, subscribeMessageBarrier);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/ping/PingRequestHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/ping/PingRequestHandlerTest.java
@@ -20,6 +20,7 @@ import com.hivemq.mqtt.message.PINGREQ;
 import com.hivemq.mqtt.message.PINGRESP;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -37,9 +38,16 @@ public class PingRequestHandlerTest {
     @Mock
     ChannelHandlerContext ctx;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/publish/FlowControlHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/FlowControlHandlerTest.java
@@ -29,6 +29,7 @@ import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.message.pubrec.PUBREC;
 import com.hivemq.mqtt.message.reason.Mqtt5PubRecReasonCode;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -54,13 +55,15 @@ public class FlowControlHandlerTest {
 
     private MqttConfigurationServiceImpl mqttConfigurationService;
 
+    private AutoCloseable closeable;
+
     @Mock
     EventLog eventLog;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         mqttConfigurationService = new MqttConfigurationServiceImpl();
         mqttConfigurationService.setServerReceiveMaximum(10);
@@ -69,6 +72,11 @@ public class FlowControlHandlerTest {
 
         flowControlHandler = new FlowControlHandler(mqttConfigurationService, serverDisconnector);
 
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/publish/IncomingPublishServiceTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/IncomingPublishServiceTest.java
@@ -43,6 +43,7 @@ import com.hivemq.mqtt.services.InternalPublishService;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,11 +84,12 @@ public class IncomingPublishServiceTest {
     private EmbeddedChannel channel;
     private ChannelHandlerContext ctx;
     private IncomingPublishService incomingPublishService;
+    private AutoCloseable closeable;
     private final ClientConnection clientConnection = new DummyClientConnection(channel, null);
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         mqttConfigurationService = Mockito.spy(new MqttConfigurationServiceImpl());
         restrictionsConfigurationService = Mockito.spy(new RestrictionsConfigurationServiceImpl());
@@ -115,6 +117,11 @@ public class IncomingPublishServiceTest {
 
         ClientConnection.of(channel).setClientId("clientid");
         ClientConnection.of(channel).setMaxPacketSizeSend(1000L);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandlerTest.java
@@ -55,12 +55,14 @@ public class MessageExpiryHandlerTest {
     private ChannelHandlerContext ctx;
 
     private EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     LogbackCapturingAppender logCapture;
 
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         final MessageExpiryHandler messageExpiryHandler = new MessageExpiryHandler();
         channel = new EmbeddedChannel();
         final ClientConnection clientConnection = new DummyClientConnection(channel, null);
@@ -75,6 +77,11 @@ public class MessageExpiryHandlerTest {
     @After
     public void tearDown() throws Exception {
         LogbackCapturingAppender.Factory.cleanUp();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlowHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlowHandlerTest.java
@@ -87,10 +87,11 @@ public class PublishFlowHandlerTest {
     private OrderedTopicService orderedTopicService;
 
     private EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 5;
         when(freePacketIdRanges.takeNextId()).thenReturn(100);
         orderedTopicService = new OrderedTopicService();
@@ -108,6 +109,11 @@ public class PublishFlowHandlerTest {
     @After
     public void tearDown() throws Exception {
         InternalConfigurations.MAX_INFLIGHT_WINDOW_SIZE_MESSAGES = 50;
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlushHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlushHandlerTest.java
@@ -29,6 +29,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -45,7 +46,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author Daniel Krüger
@@ -66,9 +67,11 @@ public class PublishFlushHandlerTest {
 
     private @NotNull PublishFlushHandler publishFlushHandler = new PublishFlushHandler(metricsHolder);
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(channelHandlerContext.channel()).thenReturn(channel);
         when(channel.eventLoop()).thenReturn(eventLoop);
@@ -77,6 +80,11 @@ public class PublishFlushHandlerTest {
             return null;
         }).when(eventLoop).execute(any(Runnable.class));
         when(channelHandlerContext.write(any())).thenReturn(mock(ChannelFuture.class));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/publish/PublishWriteFailedListenerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/PublishWriteFailedListenerTest.java
@@ -18,6 +18,7 @@ package com.hivemq.mqtt.handler.publish;
 import com.google.common.util.concurrent.SettableFuture;
 import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.EncoderException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -36,9 +37,16 @@ public class PublishWriteFailedListenerTest {
     @Mock
     ChannelFuture channelFuture;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessageListenerAndScheduleNextTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessageListenerAndScheduleNextTest.java
@@ -23,6 +23,7 @@ import com.hivemq.mqtt.message.pool.exception.NoMessageIdAvailableException;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import io.netty.channel.Channel;
 import io.netty.channel.DefaultEventLoop;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -53,14 +54,20 @@ public class SendRetainedMessageListenerAndScheduleNextTest {
     private Channel channel;
 
     private ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         clientConnection = new DummyClientConnection(channel, null);
         when(channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME)).thenReturn(new TestChannelAttribute<>(
                 clientConnection));
         when(channel.eventLoop()).thenReturn(new DefaultEventLoop(Executors.newSingleThreadExecutor()));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessagesListenerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessagesListenerTest.java
@@ -32,6 +32,7 @@ import com.hivemq.persistence.clientsession.callback.SubscriptionResult;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,10 +64,11 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("NullabilityAnnotations")
 public class SendRetainedMessagesListenerTest {
 
+    private Set<Topic> ignoredTopics;
+    private AutoCloseable closeable;
+
     @Mock
     private RetainedMessagePersistence retainedMessagePersistence;
-
-    private Set<Topic> ignoredTopics;
 
     @Mock
     private ChannelFuture channelFuture;
@@ -79,8 +81,13 @@ public class SendRetainedMessagesListenerTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         ignoredTopics = new LinkedHashSet<>();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/handler/unsubscribe/UnsubscribeHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/unsubscribe/UnsubscribeHandlerTest.java
@@ -29,6 +29,7 @@ import com.hivemq.mqtt.message.unsubscribe.UNSUBSCRIBE;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.clientsession.SharedSubscriptionService;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -59,10 +60,11 @@ public class UnsubscribeHandlerTest {
     private @NotNull UnsubscribeHandler unsubscribeHandler;
     private @NotNull EmbeddedChannel channel;
     private @NotNull ClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         unsubscribeHandler = new UnsubscribeHandler(clientSessionSubscriptionPersistence, sharedSubscriptionService);
         clientConnection = new DummyClientConnection(channel, null);
         channel = new EmbeddedChannel(unsubscribeHandler);
@@ -73,6 +75,11 @@ public class UnsubscribeHandlerTest {
                 any(String.class))).thenReturn(Futures.immediateFuture(null));
         when(clientSessionSubscriptionPersistence.removeSubscriptions(anyString(), any(ImmutableSet.class))).thenReturn(
                 Futures.<Void>immediateFuture(null));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/ioc/MQTTHandlerModuleTest.java
+++ b/src/test/java/com/hivemq/mqtt/ioc/MQTTHandlerModuleTest.java
@@ -22,6 +22,7 @@ import com.hivemq.bootstrap.ioc.lazysingleton.LazySingleton;
 import com.hivemq.bootstrap.ioc.lazysingleton.LazySingletonScope;
 import com.hivemq.mqtt.message.dropping.MessageDroppedService;
 import com.hivemq.mqtt.message.dropping.MessageDroppedServiceImpl;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -37,10 +38,11 @@ import static org.mockito.Mockito.when;
 public class MQTTHandlerModuleTest {
 
     private Injector injector;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         injector = Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
@@ -51,6 +53,11 @@ public class MQTTHandlerModuleTest {
                 bindScope(LazySingleton.class, LazySingletonScope.get());
             }
         });
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/message/dropping/MessageDroppedServiceImplTest.java
+++ b/src/test/java/com/hivemq/mqtt/message/dropping/MessageDroppedServiceImplTest.java
@@ -18,6 +18,7 @@ package com.hivemq.mqtt.message.dropping;
 import com.codahale.metrics.MetricRegistry;
 import com.hivemq.logging.EventLog;
 import com.hivemq.metrics.MetricsHolder;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -39,14 +40,20 @@ public class MessageDroppedServiceImplTest {
     private EventLog eventLog;
 
     private MessageDroppedService messageDroppedService;
+    private AutoCloseable closeable;
 
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         messageDroppedService = new MessageDroppedServiceImpl(new MetricsHolder(new MetricRegistry()), eventLog);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TestRemoveSubscriberFromTopicInTopicTreeImpl.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TestRemoveSubscriberFromTopicInTopicTreeImpl.java
@@ -20,6 +20,7 @@ import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.mqtt.topic.SubscriberWithQoS;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -34,13 +35,19 @@ import static org.junit.Assert.assertThat;
 public class TestRemoveSubscriberFromTopicInTopicTreeImpl {
 
     private LocalTopicTree topicTree;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         TOPIC_TREE_MAP_CREATION_THRESHOLD.set(1);
         topicTree = new LocalTopicTree(new MetricsHolder(new MetricRegistry()));
 
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TopicTreeImplExistingSubscriptionTest.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TopicTreeImplExistingSubscriptionTest.java
@@ -20,6 +20,7 @@ import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.subscribe.Topic;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -33,13 +34,19 @@ import static org.junit.Assert.assertTrue;
 public class TopicTreeImplExistingSubscriptionTest {
 
     private LocalTopicTree topicTree;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         InternalConfigurations.TOPIC_TREE_MAP_CREATION_THRESHOLD.set(1);
         topicTree = new LocalTopicTree(new MetricsHolder(new MetricRegistry()));
 
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/mqtt/topic/tree/TopicTreeStartupTest.java
+++ b/src/test/java/com/hivemq/mqtt/topic/tree/TopicTreeStartupTest.java
@@ -31,6 +31,7 @@ import com.hivemq.persistence.clientsession.ClientSession;
 import com.hivemq.persistence.clientsession.ClientSessionPersistence;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.clientsession.SharedSubscriptionService;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -62,10 +63,11 @@ public class TopicTreeStartupTest {
 
     private LocalTopicTree topicTree;
     private TopicTreeStartup topicTreeStartup;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         topicTree = new LocalTopicTree(new MetricsHolder(new MetricRegistry()));
 
@@ -73,6 +75,11 @@ public class TopicTreeStartupTest {
                 clientSessionPersistence,
                 clientSessionSubscriptionPersistence,
                 sharedSubscriptionService);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/InMemoryProducerQueuesTest.java
+++ b/src/test/java/com/hivemq/persistence/InMemoryProducerQueuesTest.java
@@ -17,6 +17,7 @@ package com.hivemq.persistence;
 
 import com.google.common.collect.ImmutableList;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -36,10 +37,17 @@ public class InMemoryProducerQueuesTest {
     @NotNull
     private InMemoryProducerQueues producerQueues;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         producerQueues = new InMemoryProducerQueues(64, 4);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/PersistenceShutdownHookTest.java
+++ b/src/test/java/com/hivemq/persistence/PersistenceShutdownHookTest.java
@@ -26,6 +26,7 @@ import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.persistence.qos.IncomingMessageFlowPersistence;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -59,10 +60,11 @@ public class PersistenceShutdownHookTest {
     private ClientQueuePersistence clientQueuePersistence;
 
     private PersistenceShutdownHook persistenceShutdownHook;
+    private AutoCloseable closeable;
 
     @Before
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         persistenceShutdownHook = new PersistenceShutdownHook(clientSessionPersistence,
                 clientSessionSubscriptionPersistence,
                 incomingMessageFlowPersistence,
@@ -78,6 +80,11 @@ public class PersistenceShutdownHookTest {
         when(clientSessionSubscriptionPersistence.closeDB()).thenReturn(Futures.immediateFuture(null));
         when(retainedMessagePersistence.closeDB()).thenReturn(Futures.immediateFuture(null));
         when(clientQueuePersistence.closeDB()).thenReturn(Futures.immediateFuture(null));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/ProducerQueuesImplTest.java
+++ b/src/test/java/com/hivemq/persistence/ProducerQueuesImplTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.persistence;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -39,15 +40,22 @@ public class ProducerQueuesImplTest {
 
     @NotNull ProducerQueuesImpl producerQueues;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         when(singleWriterServiceImpl.getPersistenceBucketCount()).thenReturn(64);
         when(singleWriterServiceImpl.getThreadPoolSize()).thenReturn(4);
         when(singleWriterServiceImpl.getGlobalTaskCount()).thenReturn(new AtomicLong());
 
         producerQueues = new ProducerQueuesImpl(singleWriterServiceImpl, 4);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/ScheduledCleanUpServiceTest.java
+++ b/src/test/java/com/hivemq/persistence/ScheduledCleanUpServiceTest.java
@@ -25,6 +25,7 @@ import com.hivemq.persistence.clientsession.ClientSessionPersistence;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
 import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -71,10 +72,11 @@ public class ScheduledCleanUpServiceTest {
     private ClientQueuePersistence clientQueuePersistence;
 
     private ScheduledCleanUpService scheduledCleanUpService;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         scheduledCleanUpService = new ScheduledCleanUpService(scheduledExecutorService,
                 clientSessionPersistence,
                 subscriptionPersistence,
@@ -82,6 +84,11 @@ public class ScheduledCleanUpServiceTest {
                 clientQueuePersistence);
 
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(64);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceSerializerTest.java
+++ b/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceSerializerTest.java
@@ -26,6 +26,7 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.message.pubrel.PUBREL;
 import jetbrains.exodus.ByteIterable;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -44,12 +45,18 @@ import static org.junit.Assert.assertTrue;
 public class ClientQueuePersistenceSerializerTest {
 
     private ClientQueuePersistenceSerializer serializer;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         serializer = new ClientQueuePersistenceSerializer();
         ClientQueuePersistenceSerializer.NEXT_PUBLISH_NUMBER.set(Long.MAX_VALUE / 2);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/clientsession/task/ClientSessionCleanUpTaskTest.java
+++ b/src/test/java/com/hivemq/persistence/clientsession/task/ClientSessionCleanUpTaskTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.hivemq.persistence.clientsession.ClientSessionPersistenceImpl;
 import com.hivemq.persistence.clientsession.PendingWillMessages;
 import com.hivemq.persistence.local.ClientSessionLocalPersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -42,11 +43,17 @@ public class ClientSessionCleanUpTaskTest {
     private PendingWillMessages pendingWillMessages;
 
     private ClientSessionCleanUpTask task;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         task = new ClientSessionCleanUpTask(localPersistence, clientSessionPersistence, pendingWillMessages);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/ioc/LocalPersistenceModuleTest.java
+++ b/src/test/java/com/hivemq/persistence/ioc/LocalPersistenceModuleTest.java
@@ -55,6 +55,7 @@ import com.hivemq.persistence.payload.PublishPayloadRocksDBLocalPersistence;
 import com.hivemq.persistence.payload.PublishPayloadXodusLocalPersistence;
 import com.hivemq.persistence.retained.RetainedMessageLocalPersistence;
 import com.hivemq.throttling.ioc.ThrottlingModule;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -110,9 +111,11 @@ public class LocalPersistenceModuleTest {
     @Mock
     private Injector persistenceInjector;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(metricsHolder.getMetricRegistry()).thenReturn(new MetricRegistry());
 
         when(persistenceInjector.getInstance(PublishPayloadPersistence.class)).thenReturn(Mockito.mock(
@@ -143,6 +146,11 @@ public class LocalPersistenceModuleTest {
                 persistenceConfigurationService);
         when(persistenceConfigurationService.getMode()).thenReturn(PersistenceMode.FILE);
 
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/ioc/PersistenceMigrationModuleTest.java
+++ b/src/test/java/com/hivemq/persistence/ioc/PersistenceMigrationModuleTest.java
@@ -29,6 +29,7 @@ import com.hivemq.persistence.local.memory.RetainedMessageMemoryLocalPersistence
 import com.hivemq.persistence.payload.PublishPayloadNoopPersistenceImpl;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.persistence.retained.RetainedMessageLocalPersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -53,10 +54,17 @@ public class PersistenceMigrationModuleTest {
     @Mock
     private PersistenceConfigurationService persistenceConfigurationService;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(persistenceConfigurationService.getMode()).thenReturn(PersistenceConfigurationService.PersistenceMode.FILE);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/ioc/PersistenceModuleTest.java
+++ b/src/test/java/com/hivemq/persistence/ioc/PersistenceModuleTest.java
@@ -42,6 +42,7 @@ import com.hivemq.persistence.local.xodus.RetainedMessageRocksDBLocalPersistence
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.persistence.payload.PublishPayloadPersistenceImpl;
 import com.hivemq.persistence.payload.PublishPayloadRocksDBLocalPersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -62,9 +63,11 @@ public class PersistenceModuleTest {
     @Mock
     private Injector persistenceInjector;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(persistenceInjector.getInstance(PublishPayloadPersistence.class)).thenReturn(Mockito.mock(
                 PublishPayloadPersistence.class));
 
@@ -83,6 +86,11 @@ public class PersistenceModuleTest {
         when(persistenceInjector.getInstance(PersistenceStartup.class)).thenReturn(Mockito.mock(PersistenceStartup.class));
 
         when(persistenceInjector.getInstance(ShutdownHooks.class)).thenReturn(Mockito.mock(ShutdownHooks.class));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
@@ -74,10 +74,11 @@ public class ClientQueueMemoryLocalPersistenceTest {
 
     private final long byteLimit = 5 * 1024 * 1024;
     private MetricRegistry metricRegistry;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(bucketCount);
         InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.set(10000);
@@ -91,6 +92,11 @@ public class ClientQueueMemoryLocalPersistenceTest {
     @After
     public void tearDown() throws Exception {
         InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED = false;
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/local/memory/ClientSessionSubscriptionMemoryLocalPersistenceTest.java
+++ b/src/test/java/com/hivemq/persistence/local/memory/ClientSessionSubscriptionMemoryLocalPersistenceTest.java
@@ -31,6 +31,7 @@ import com.hivemq.util.LocalPersistenceFileUtil;
 import com.hivemq.util.ObjectMemoryEstimation;
 import net.jodah.concurrentunit.Waiter;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -74,10 +75,11 @@ public class ClientSessionSubscriptionMemoryLocalPersistenceTest {
 
     private final int bucketCount = 4;
     private MetricRegistry metricRegistry;
+    private AutoCloseable closeable;
 
     @Before
     public void before() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         InternalConfigurations.PERSISTENCE_BUCKET_COUNT.set(bucketCount);
         when(localPersistenceFileUtil.getVersionedLocalPersistenceFolder(anyString(), anyString())).thenReturn(
@@ -85,6 +87,11 @@ public class ClientSessionSubscriptionMemoryLocalPersistenceTest {
         metricRegistry = new MetricRegistry();
 
         persistence = new ClientSessionSubscriptionMemoryLocalPersistence(metricRegistry);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/local/xodus/EnvironmentCloserTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/EnvironmentCloserTest.java
@@ -20,6 +20,7 @@ import jetbrains.exodus.ExodusException;
 import jetbrains.exodus.env.Environment;
 import jetbrains.exodus.env.Environments;
 import jetbrains.exodus.env.Transaction;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,11 +47,18 @@ public class EnvironmentCloserTest {
     @Mock
     LocalPersistenceFileUtil localPersistenceFileUtil;
 
+    private  AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         when(localPersistenceFileUtil.getLocalPersistenceFolder()).thenReturn(temporaryFolder.newFolder());
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test(timeout = 10000)

--- a/src/test/java/com/hivemq/persistence/local/xodus/XodusUtilsTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/XodusUtilsTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import jetbrains.exodus.ByteIterable;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -37,9 +38,16 @@ import static org.junit.Assert.assertEquals;
  */
 public class XodusUtilsTest {
 
+    private AutoCloseable closeable;
+
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/local/xodus/bucket/BucketTest.java
+++ b/src/test/java/com/hivemq/persistence/local/xodus/bucket/BucketTest.java
@@ -17,6 +17,7 @@ package com.hivemq.persistence.local.xodus.bucket;
 
 import jetbrains.exodus.env.Environment;
 import jetbrains.exodus.env.Store;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -36,9 +37,16 @@ public class BucketTest {
     @Mock
     Store store;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/qos/IncomingMessageFlowPersistenceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/qos/IncomingMessageFlowPersistenceImplTest.java
@@ -17,6 +17,7 @@ package com.hivemq.persistence.qos;
 
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.persistence.local.IncomingMessageFlowLocalPersistence;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -32,14 +33,20 @@ import static org.mockito.Mockito.verify;
 public class IncomingMessageFlowPersistenceImplTest {
 
     private IncomingMessageFlowPersistenceImpl incomingMessageFlowPersistence;
+    private AutoCloseable closeable;
 
     @Mock
     private IncomingMessageFlowLocalPersistence incomingMessageFlowLocalPersistence;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         incomingMessageFlowPersistence = new IncomingMessageFlowPersistenceImpl(incomingMessageFlowLocalPersistence);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/security/ssl/NonSslHandlerTest.java
+++ b/src/test/java/com/hivemq/security/ssl/NonSslHandlerTest.java
@@ -25,6 +25,7 @@ import com.hivemq.mqtt.handler.disconnect.MqttServerDisconnector;
 import com.hivemq.mqtt.handler.disconnect.MqttServerDisconnectorImpl;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -42,6 +43,8 @@ public class NonSslHandlerTest {
     private @NotNull EmbeddedChannel channel;
 
     private @NotNull MqttServerDisconnector disconnector;
+
+    private AutoCloseable closeable;
 
     private static final byte @NotNull [] VALID_SSL_PACKET = {
             22,
@@ -655,13 +658,18 @@ public class NonSslHandlerTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         final Listener listener = mock(TcpListener.class);
         channel = new EmbeddedChannel();
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME)
                 .set(new UndefinedClientConnection(channel, null, listener));
         disconnector = new MqttServerDisconnectorImpl(new EventLog());
         channel.pipeline().addLast(new NonSslHandler(disconnector));
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/security/ssl/SslClientCertificateHandlerTest.java
+++ b/src/test/java/com/hivemq/security/ssl/SslClientCertificateHandlerTest.java
@@ -30,6 +30,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -58,6 +59,7 @@ public class SslClientCertificateHandlerTest {
 
     private EmbeddedChannel channel;
     private UndefinedClientConnection clientConnection;
+    private AutoCloseable closeable;
 
     @Mock
     private MqttServerDisconnectorImpl mqttServerDisconnector;
@@ -76,7 +78,7 @@ public class SslClientCertificateHandlerTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         when(sslHandler.engine()).thenReturn(sslEngine);
         when(sslEngine.getSession()).thenReturn(sslSession);
@@ -88,6 +90,11 @@ public class SslClientCertificateHandlerTest {
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(clientConnection);
         channel.pipeline().addLast(new SslClientCertificateHandler(tls, mqttServerDisconnector));
         channel.pipeline().addLast(ChannelHandlerNames.SSL_HANDLER, sslHandler);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/security/ssl/SslExceptionHandlerTest.java
+++ b/src/test/java/com/hivemq/security/ssl/SslExceptionHandlerTest.java
@@ -26,6 +26,7 @@ import com.hivemq.mqtt.handler.disconnect.MqttServerDisconnectorImpl;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.ssl.NotSslRecordException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -61,9 +62,11 @@ public class SslExceptionHandlerTest {
 
     SslExceptionHandler sslExceptionHandler;
 
+    private AutoCloseable closeable;
+
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(ctx.channel()).thenReturn(channel);
 
         final Listener listener = mock(TcpListener.class);
@@ -77,6 +80,11 @@ public class SslExceptionHandlerTest {
         final MqttServerDisconnector mqttServerDisconnector = new MqttServerDisconnectorImpl(eventLog);
 
         sslExceptionHandler = new SslExceptionHandler(mqttServerDisconnector);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/security/ssl/SslParameterHandlerTest.java
+++ b/src/test/java/com/hivemq/security/ssl/SslParameterHandlerTest.java
@@ -21,6 +21,7 @@ import com.hivemq.bootstrap.netty.ChannelHandlerNames;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.when;
 public class SslParameterHandlerTest {
 
     private EmbeddedChannel channel;
+    private AutoCloseable closeable;
 
     @Mock
     private SslHandler sslHandler;
@@ -54,12 +56,17 @@ public class SslParameterHandlerTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         channel = new EmbeddedChannel();
         channel.attr(ClientConnectionContext.CHANNEL_ATTRIBUTE_NAME).set(new DummyClientConnection(channel, null));
         channel.pipeline().addLast(new SslParameterHandler());
         channel.pipeline().addLast(ChannelHandlerNames.SSL_HANDLER, sslHandler);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/statistics/HivemqIdTest.java
+++ b/src/test/java/com/hivemq/statistics/HivemqIdTest.java
@@ -17,6 +17,7 @@ package com.hivemq.statistics;
 
 import com.hivemq.configuration.info.SystemInformation;
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,16 +43,21 @@ public class HivemqIdTest {
     private SystemInformation systemInformation;
 
     private HivemqId hivemqId;
+    private AutoCloseable closeable;
 
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         when(systemInformation.getDataFolder()).thenReturn(temporaryFolder.getRoot());
 
         hivemqId = new HivemqId(systemInformation);
     }
 
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
+    }
 
     @Test
     public void test_no_id_present() {

--- a/src/test/java/com/hivemq/util/EnvVarUtilTest.java
+++ b/src/test/java/com/hivemq/util/EnvVarUtilTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.util;
 
 import com.hivemq.exceptions.UnrecoverableException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -39,10 +40,17 @@ public class EnvVarUtilTest {
     @Mock
     EnvVarUtil envVarUtil;
 
+    private AutoCloseable closeable;
+
     @Before
     public void before() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         when(envVarUtil.replaceEnvironmentVariablePlaceholders(anyString())).thenCallRealMethod();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test

--- a/src/test/java/com/hivemq/websocket/WebSocketInitializerTest.java
+++ b/src/test/java/com/hivemq/websocket/WebSocketInitializerTest.java
@@ -18,6 +18,7 @@ package com.hivemq.websocket;
 import com.google.common.collect.Lists;
 import com.hivemq.configuration.service.entity.WebsocketListener;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -38,17 +39,22 @@ import static org.junit.Assert.assertTrue;
 public class WebSocketInitializerTest {
 
     private EmbeddedChannel channel;
-
     private WebsocketListener websocketListener;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         channel = new EmbeddedChannel();
 
         channel.pipeline().addLast("dummy", new DummyHandler());
 
         websocketListener = new WebsocketListener.Builder().port(8000).bindAddress("0.0.0.0").build();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable. close();
     }
 
     @Test


### PR DESCRIPTION
Replace the deprecated MockitoAnnotations.initMocks() method with the recommended Mockito.Annotations.openMocks() method

**Motivation**

- initMocks was used to initialize mocks annotated with @Mock, @Spy, etc., in your test class
- openMocks is the recommended replacement since Mockito 3. It provides the same functionality but with better resource management
- openMocks returns an AutoCloseable object, which ensures that resources are properly closed after the test execution

**Changes**

Old:
```
import org.mockito.MockitoAnnotations;

@Before
public void setUp() {
    MockitoAnnotations.initMocks(this);
}
```

New:
```
import org.mockito.MockitoAnnotations;

public class <TEST-CLASS-NAME> {

private AutoCloseable closeable;

@Before
public void setUp() {
    closeable = MockitoAnnotations.openMocks(this)) {
        ...
    }
}

@After
public void releaseMocks() throws Exception {
        closeable. close();
    }
...
```
