### PR TITLE
Update build src toolchain & Wiremock Dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,7 +151,7 @@ dependencies {
     testImplementation(libs.shrinkwrap.api)
     testRuntimeOnly(libs.shrinkwrap.impl)
     testImplementation(libs.byteBuddy)
-    testImplementation(libs.wiremock.jre8.standalone)
+    testImplementation(libs.wiremock.standalone)
     testImplementation(libs.javassist)
     testImplementation(libs.awaitility)
     testImplementation(libs.stefanBirkner.systemRules) {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ group = "com.hivemq"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ rocksdb = "8.3.3"
 shrinkwrap = "1.2.6"
 slf4j = "2.0.16"
 stefanBirkner-systemRules = "1.19.0"
-wiremock = "3.0.1"
+wiremock = "3.9.2"
 xodus = "1.2.3"
 zeroAllocationHashing = "0.16"
 
@@ -73,7 +73,7 @@ shrinkwrap-api = { module = "org.jboss.shrinkwrap:shrinkwrap-api", version.ref =
 shrinkwrap-impl = { module = "org.jboss.shrinkwrap:shrinkwrap-impl-base", version.ref = "shrinkwrap" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 stefanBirkner-systemRules = { module = "com.github.stefanbirkner:system-rules", version.ref = "stefanBirkner-systemRules" }
-wiremock-jre8-standalone = { module = "com.github.tomakehurst:wiremock-jre8-standalone", version.ref = "wiremock" }
+wiremock-standalone = { module = "org.wiremock:wiremock-standalone", version.ref = "wiremock" }
 xodus-environment = { module = "org.jetbrains.xodus:xodus-environment", version.ref = "xodus" }
 xodus-openApi = { module = "org.jetbrains.xodus:xodus-openAPI", version.ref = "xodus" }
 zeroAllocationHashing = { module = "net.openhft:zero-allocation-hashing", version.ref = "zeroAllocationHashing" }


### PR DESCRIPTION
**Motivation**

HiveMQ Documentation should utilize the Java 11 Toolchain as per documentation. Wiremock version 3.0.1 has CVE's. The latest version of Wiremock resolves these vulnerabilities. 

Wiremock project team are no longer updating jre8 version of Wiremock as per their Github project page documentation.

Maven Central artifact relocation:

![image](https://github.com/user-attachments/assets/f04aaf4c-95dc-4ac6-8d85-45b150409d3e)

Wiremock Version 3.0.1 CVE's:
![image](https://github.com/user-attachments/assets/0b99e35b-bbad-4a09-b5d6-204fe5e2fc78)



Resolves #506 

**Changes**

buildSrc updated to Java 11 Toolchain.

Wiremock updated to version 3.9.2 resolving vulnerabilities and removing the requirement for JRE-8. Wiremock implentation updates not required with latest version (3.9.2) under the new Maven Central package org.wiremock.

All tests are passing locally.

![image](https://github.com/user-attachments/assets/6b4ed4bd-4588-4cfa-832e-a563e8e26d97)

