### PR TITLE
Dont return packet ids twice

### DIFF
--- a/src/main/java/com/hivemq/mqtt/callback/PublishStatusFutureCallback.java
+++ b/src/main/java/com/hivemq/mqtt/callback/PublishStatusFutureCallback.java
@@ -93,14 +93,15 @@ public class PublishStatusFutureCallback implements FutureCallback<PublishStatus
             log.error("Exceptions in publish status callback handling, queue ID = {}", queueId, e);
         }
 
+        if (packetIdentifier != 0) {
+            messageIDPool.returnId(packetIdentifier);
+        }
+
         if (status != PublishStatus.NOT_CONNECTED) {
             final AtomicInteger inFlightMessages = ClientConnection.of(channel).getInFlightMessageCount();
             if (inFlightMessages == null || inFlightMessages.decrementAndGet() <= 0) {
                 publishPollService.pollMessages(client, channel);
             }
-        }
-        if (packetIdentifier != 0) {
-            messageIDPool.returnId(packetIdentifier);
         }
     }
 

--- a/src/main/java/com/hivemq/mqtt/handler/publish/PublishFlowHandler.java
+++ b/src/main/java/com/hivemq/mqtt/handler/publish/PublishFlowHandler.java
@@ -231,7 +231,6 @@ public class PublishFlowHandler extends ChannelDuplexHandler {
         log.trace("Client {}: Received PUBACK", clientId);
         final int messageId = msg.getPacketIdentifier();
         orderedTopicService.messageFlowComplete(ctx, messageId);
-        returnMessageId(ctx.channel(), msg, clientId);
 
         if (log.isTraceEnabled()) {
             log.trace("Client {}: Received PUBACK remove message id:[{}] ", clientId, messageId);
@@ -276,29 +275,9 @@ public class PublishFlowHandler extends ChannelDuplexHandler {
         log.trace("Client {}: Received PUBCOMP", clientId);
 
         orderedTopicService.messageFlowComplete(ctx, msg.getPacketIdentifier());
-        returnMessageId(ctx.channel(), msg, clientId);
 
         if (log.isTraceEnabled()) {
             log.trace("Client {}: Received PUBCOMP remove message id:[{}]", clientId, msg.getPacketIdentifier());
-        }
-
-    }
-
-    private void returnMessageId(
-            final @NotNull Channel channel, final @NotNull MessageWithID msg, final @NotNull String clientId) {
-
-        final int messageId = msg.getPacketIdentifier();
-
-        //Such a message ID must never be zero, but better be safe than sorry
-        if (messageId > 0) {
-            final FreePacketIdRanges freePacketIdRanges = ClientConnection.of(channel).getFreePacketIdRanges();
-            freePacketIdRanges.returnId(messageId);
-            if (log.isTraceEnabled()) {
-                log.trace("Returning Message ID {} for client {} because of a {} message was received",
-                        messageId,
-                        clientId,
-                        msg.getClass().getSimpleName());
-            }
         }
 
     }

--- a/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -20,6 +20,7 @@ import com.google.common.primitives.ImmutableIntArray;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.hivemq.configuration.service.MqttConfigurationService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -193,7 +194,7 @@ public class PublishDistributorImpl implements PublishDistributor {
 
         final SettableFuture<PublishStatus> statusFuture = SettableFuture.create();
 
-        Futures.addCallback(future, new FutureCallback<Void>() {
+        Futures.addCallback(future, new FutureCallback<>() {
             @Override
             public void onSuccess(final Void result) {
                 statusFuture.set(DELIVERED);
@@ -203,7 +204,7 @@ public class PublishDistributorImpl implements PublishDistributor {
             public void onFailure(final Throwable t) {
                 statusFuture.set(FAILED);
             }
-        }, singleWriterService.callbackExecutor(client));
+        }, MoreExecutors.directExecutor());
         return statusFuture;
     }
 

--- a/src/main/java/com/hivemq/mqtt/services/PublishPollServiceImpl.java
+++ b/src/main/java/com/hivemq/mqtt/services/PublishPollServiceImpl.java
@@ -195,7 +195,7 @@ public class PublishPollServiceImpl implements PublishPollService {
                 Exceptions.rethrowError("Exception in new messages handling", t);
                 channel.disconnect();
             }
-        }, singleWriterService.callbackExecutor(client));
+        }, MoreExecutors.directExecutor());
     }
 
     @Override
@@ -262,7 +262,7 @@ public class PublishPollServiceImpl implements PublishPollService {
             public void onFailure(final Throwable t) {
                 Exceptions.rethrowError("Exception in inflight messages handling", t);
             }
-        }, singleWriterService.callbackExecutor(client));
+        }, MoreExecutors.directExecutor());
     }
 
     private @NotNull AtomicInteger inFlightMessageCount(final @NotNull Channel channel) {
@@ -391,7 +391,7 @@ public class PublishPollServiceImpl implements PublishPollService {
                         "for shared subscription " +
                         sharedSubscription, t);
             }
-        }, singleWriterService.callbackExecutor(client));
+        }, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/src/main/java/com/hivemq/persistence/ProducerQueues.java
+++ b/src/main/java/com/hivemq/persistence/ProducerQueues.java
@@ -26,25 +26,18 @@ import java.util.List;
  */
 public interface ProducerQueues {
 
+    <R> @NotNull ListenableFuture<R> submit(@NotNull String key, @NotNull SingleWriterServiceImpl.Task<R> task);
 
-    <R> @NotNull ListenableFuture<R> submit(
-            @NotNull final String key, @NotNull final SingleWriterServiceImpl.Task<R> task);
+    <R> @NotNull ListenableFuture<R> submit(int bucketIndex, @NotNull SingleWriterServiceImpl.Task<R> task);
 
-    <R> @NotNull ListenableFuture<R> submit(final int bucketIndex, @NotNull final SingleWriterServiceImpl.Task<R> task);
+    @NotNull
+    <R> List<ListenableFuture<R>> submitToAllBucketsParallel(@NotNull SingleWriterService.Task<R> task);
 
+    @NotNull
+    <R> List<ListenableFuture<R>> submitToAllBucketsSequential(@NotNull SingleWriterService.Task<R> task);
 
-    <R> @Nullable ListenableFuture<R> submit(
-            final int bucketIndex,
-            @NotNull final SingleWriterServiceImpl.Task<R> task,
-            @Nullable final SingleWriterServiceImpl.SuccessCallback<R> successCallback,
-            @Nullable final SingleWriterServiceImpl.FailedCallback failedCallback);
+    int getBucket(@NotNull String key);
 
-    @NotNull <R> List<ListenableFuture<R>> submitToAllBucketsParallel(final @NotNull SingleWriterService.Task<R> task);
-
-    @NotNull <R> List<ListenableFuture<R>> submitToAllBucketsSequential(final @NotNull SingleWriterService.Task<R> task);
-
-    int getBucket(@NotNull final String key);
-
-    @NotNull ListenableFuture<Void> shutdown(final @Nullable SingleWriterServiceImpl.Task<Void> finalTask);
-
+    @NotNull
+    ListenableFuture<Void> shutdown(@Nullable SingleWriterServiceImpl.Task<Void> finalTask);
 }

--- a/src/main/java/com/hivemq/persistence/SingleWriterService.java
+++ b/src/main/java/com/hivemq/persistence/SingleWriterService.java
@@ -31,21 +31,11 @@ public interface SingleWriterService {
 
     @NotNull ProducerQueues getAttributeStoreQueue();
 
-    @NotNull Executor callbackExecutor(@NotNull final String key);
-
     int getPersistenceBucketCount();
 
     void stop();
 
     interface Task<R> {
         @NotNull R doTask(int bucketIndex);
-    }
-
-    interface SuccessCallback<R> {
-        void afterTask(@NotNull R result);
-    }
-
-    interface FailedCallback {
-        void afterTask(@NotNull Throwable exception);
     }
 }

--- a/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlowHandlerTest.java
+++ b/src/test/java/com/hivemq/mqtt/handler/publish/PublishFlowHandlerTest.java
@@ -111,25 +111,6 @@ public class PublishFlowHandlerTest {
     }
 
     @Test
-    public void test_return_qos_1_message_id() throws Exception {
-
-        final PUBACK puback = new PUBACK(freePacketIdRanges.takeNextId());
-        channel.writeInbound(puback);
-
-        verify(freePacketIdRanges).returnId(eq(100));
-
-    }
-
-    @Test
-    public void test_return_qos_2_message_id() throws Exception {
-
-        final PUBCOMP pubcomp = new PUBCOMP(freePacketIdRanges.takeNextId());
-        channel.writeInbound(pubcomp);
-
-        verify(freePacketIdRanges).returnId(eq(100));
-    }
-
-    @Test
     public void test_dont_return_message_id() throws Exception {
 
         final PUBREL pubrel = new PUBREL(freePacketIdRanges.takeNextId());

--- a/src/test/java/com/hivemq/persistence/InMemorySingleWriterServiceTest.java
+++ b/src/test/java/com/hivemq/persistence/InMemorySingleWriterServiceTest.java
@@ -22,8 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -55,42 +53,6 @@ public class InMemorySingleWriterServiceTest {
         assertEquals(8, singleWriterServiceImpl.validAmountOfQueues(5, 64));
         assertEquals(8, singleWriterServiceImpl.validAmountOfQueues(8, 64));
         assertEquals(64, singleWriterServiceImpl.validAmountOfQueues(64, 64));
-    }
-
-
-    @Test
-    public void test_callbackExecutor_whenManyThreadsSubmitConcurrently_thenOnlyOneThreadWorksConcurrently()
-            throws InterruptedException {
-        final LinkedList<Integer> list = new LinkedList<>();
-        list.add(0);
-
-        final List<Thread> threads = new ArrayList<>();
-        final int numberOfConcurrentThreads = 4;
-
-        // this is highly un-thread-safe, when this is concurrently executed
-        // there are many sources for exceptions
-        final Runnable runnable = () -> {
-            final Integer poll = list.pollFirst();
-            list.add(poll + 1);
-        };
-
-        for (int j = 0; j < 4; j++) {
-            final Thread thread = new Thread(() -> {
-                for (int i = 0; i < 10_000; i++) {
-                    singleWriterServiceImpl.callbackExecutor("sameKey").execute(runnable);
-                }
-            });
-            threads.add(thread);
-            thread.start();
-        }
-
-        //wait for all threads to finish their submissions
-        for (final Thread thread : threads) {
-            thread.join();
-        }
-
-        // 4 threads with 10_000 adds = 40_000
-        assertEquals(40_000, (int) list.pollFirst());
     }
 
     @Test

--- a/src/test/java/com/hivemq/persistence/SingleWriterServiceImplTest.java
+++ b/src/test/java/com/hivemq/persistence/SingleWriterServiceImplTest.java
@@ -101,10 +101,6 @@ public class SingleWriterServiceImplTest {
         singleWriterServiceImpl.stop();
         assertTrue(singleWriterServiceImpl.checkScheduler.isShutdown());
         assertTrue(singleWriterServiceImpl.singleWriterExecutor.isShutdown());
-
-        for (final ExecutorService callbackExecutor : singleWriterServiceImpl.callbackExecutors) {
-            assertTrue(callbackExecutor.isShutdown());
-        }
     }
 
     private static class NoOpExecutor implements ExecutorService {

--- a/src/test/java/util/TestSingleWriterFactory.java
+++ b/src/test/java/util/TestSingleWriterFactory.java
@@ -15,7 +15,6 @@
  */
 package util;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.SingleWriterServiceImpl;
@@ -34,9 +33,6 @@ public class TestSingleWriterFactory {
         InternalConfigurations.SINGLE_WRITER_INTERVAL_TO_CHECK_PENDING_TASKS_AND_SCHEDULE_MSEC.set(100);
 
         final SingleWriterServiceImpl singleWriterServiceImpl = new SingleWriterServiceImpl();
-        for (int i = 0; i < singleWriterServiceImpl.callbackExecutors.length; i++) {
-            singleWriterServiceImpl.callbackExecutors[i] = MoreExecutors.newDirectExecutorService();
-        }
 
         singleWriterServiceImpl.postConstruct();
 


### PR DESCRIPTION
**Motivation**
When a client subscribes to multiple shared subscriptions, it eventually stops receiving messages.

Resolves #<issue>
https://hivemq.kanbanize.com/ctrl_board/42/cards/31396/details/ 

**Changes**
The broker returns every packet ID twice when the publish flow is complete. Therefore, the same packet ID can be assigned to two publishes. The OrderedTopicService maps the packet ID to a future, which is complete when the publish flow is complete. When two publishes have the same packet ID, the map entry will be replaced, and one of the futures will never be complete.
The PublishFlowHandler is no longer returning packet IDs.
