### PR TITLE
Disable setup-gradle Enhanced Caching and delegate to setup-java

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,18 +13,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Checkout Extension SDK
         run: |
           git clone https://github.com/hivemq/hivemq-extension-sdk.git ../hivemq-extension-sdk
           cd ../hivemq-extension-sdk
           git checkout ${GITHUB_REF#refs/heads/} || true
           cd ../hivemq-community-edition
+
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11
             21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
+
       - name: Check
         run: ./gradlew test javadoc hivemqZip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,13 +11,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11
             21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
+
       - name: Publish to Maven Central
         run: ./gradlew publishEmbeddedPublicationToMavenCentral
         env:
@@ -25,11 +33,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+
       - name: Push To Docker Hub
         run: ./gradlew pushOciImage --registry dockerHub --tag . --tag latest # . is a placeholder for the default tag
         env:
           ORG_GRADLE_PROJECT_dockerHubUsername: ${{ secrets.DOCKER_USERNAME }}
           ORG_GRADLE_PROJECT_dockerHubPassword: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Attach HiveMQ Zip to GitHub Release
         run: ./gradlew githubRelease
         env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,19 +11,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Checkout Extension SDK
         run: |
           git clone https://github.com/hivemq/hivemq-extension-sdk.git ../hivemq-extension-sdk
           cd ../hivemq-extension-sdk
           git checkout ${GITHUB_REF##*/} || true
           cd ../hivemq-community-edition
+
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11
             21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
+
       - name: Push Snapshot To Docker Hub
         run: ./gradlew pushOciImage --registry dockerHub --tag snapshot
         env:

--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -21,16 +21,14 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
+          cache-disabled: true
 
       - name: Check approved licenses
         run: ./gradlew checkApprovedLicenses


### PR DESCRIPTION
## Summary

- Disable `setup-gradle` proprietary Enhanced Caching (`cache-disabled: true`) across all workflows
- Delegate caching to `setup-java` with `cache: gradle` (MIT-licensed, writes on all branches)
- Remove `gradle-home-cache-includes` blocks (Enhanced-only, no longer needed)
- Add `cache: gradle` to all workflows using `setup-java` (check, publish, snapshot, snyk-pr, snyk-push, snyk-release)
- Add `setup-gradle` with `cache-disabled: true` to workflows running `./gradlew` (check, publish, snapshot)

Tracked by [INT-247](https://linear.app/hivemq/issue/INT-247)