### PR TITLE
PLT-758: Add jitpack smoke CI gate and agent instructions

### DIFF
--- a/.github/workflows/jitpack-smoke.yml
+++ b/.github/workflows/jitpack-smoke.yml
@@ -1,0 +1,50 @@
+name: JitPack smoke test
+
+# Replicates the JitPack build environment so a broken build is caught
+# in CI rather than at release time. JitPack runs `./gradlew publishToMavenLocal
+# -PsigningDisabled=true` on JDK 21 — we do the same.
+#
+# Background: 2026.5 shipped with a stale jitpack.yml and a Shadow 9.x
+# publication wiring bug that this job would have caught on the PR.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle/**'
+      - 'jitpack.yml'
+      - '.github/workflows/jitpack-smoke.yml'
+
+concurrency:
+  group: jitpack-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jitpack-smoke:
+    name: publishToMavenLocal (JDK 21, no signing)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          cache: gradle
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
+
+      - name: publishToMavenLocal (mirrors jitpack.yml)
+        run: ./gradlew publishToMavenLocal -PsigningDisabled=true

--- a/.github/workflows/jitpack-smoke.yml
+++ b/.github/workflows/jitpack-smoke.yml
@@ -4,8 +4,9 @@ name: JitPack smoke test
 # in CI rather than at release time. JitPack runs `./gradlew publishToMavenLocal
 # -PsigningDisabled=true` on JDK 21 — we do the same.
 #
-# Background: 2026.5 shipped with a stale jitpack.yml and a Shadow 9.x
-# publication wiring bug that this job would have caught on the PR.
+# `jitpack.yml` has its own jdk/install config that lives outside the
+# regular GitHub Actions workflows, so it can silently drift when the
+# build setup changes. This job is the gate.
 
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# Agent Instructions
+
+Notes for AI coding agents (and humans) contributing to **hivemq-community-edition**.
+
+## Build / publish surface — keep these in sync
+
+This repo publishes through **three different paths**, each with its own configuration. A change to one often requires a matching change in the others.
+
+| Path | Config | Java version | Build command |
+|---|---|---|---|
+| GitHub Actions CI (`push`) | [`.github/workflows/check.yml`](.github/workflows/check.yml) | 11 + 21 | `./gradlew test javadoc hivemqZip` |
+| GitHub Actions Publish (`release:published`) | [`.github/workflows/publish.yml`](.github/workflows/publish.yml) | 11 + 21 | `./gradlew publishEmbeddedPublicationToMavenCentral` |
+| JitPack (consumer-on-demand) | [`jitpack.yml`](jitpack.yml) | 21 | `./gradlew publishToMavenLocal -PsigningDisabled=true` |
+
+**Rule of thumb:** if you change any of the following, re-verify the *publish path* still works on a clean checkout with JDK 21 only (the jitpack environment is the strictest):
+
+- `build.gradle.kts` (especially anything touching `publishing`, `signing`, `shadow`, `components["java"]`)
+- `gradle/libs.versions.toml` (plugin or SDK version bumps)
+- `settings.gradle.kts` (included builds)
+- `gradle/wrapper/gradle-wrapper.properties` (Gradle version)
+- Java toolchain version anywhere
+
+### The pre-tag smoke test
+
+Run this locally before cutting a release tag:
+
+```bash
+./gradlew publishToMavenLocal -PsigningDisabled=true
+```
+
+That command is what jitpack runs. If it fails locally, jitpack will fail too — and so will Maven Central publishing on release. The `jitpack-smoke` CI job runs the same command on every PR that touches build files.
+
+## Common foot-guns (real bugs we have hit)
+
+1. **`jitpack.yml` drift.** When `hivemq-extension-sdk` was removed as an included build (#632) and the toolchain rose to JDK 21 (#635), `jitpack.yml` kept its `openjdk11` + included-build `before_install`. JitPack 2026.5 failed silently and the cached failure had to be deleted by hand in the JitPack UI. Touch `settings.gradle.kts` or change the Java toolchain → update `jitpack.yml` in the same PR.
+2. **Shadow plugin 9.x publication variants.** Shadow 9.x adds `shadowRuntimeElements` to the `java` component lazily. The old top-level idiom
+   ```kotlin
+   javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements.get()) { skip() }
+   ```
+   throws `Variant for configuration 'shadowRuntimeElements' does not exist in component 'java'`. Use the plugin-level toggle (Shadow 9.1.0+, PR [GradleUp/shadow#1662](https://github.com/GradleUp/shadow/pull/1662)):
+   ```kotlin
+   shadow {
+       addShadowVariantIntoJavaComponent = false
+   }
+   ```
+3. **Branch protection on `master`.** The release flow requires temporarily disabling "Do not allow bypassing the above settings" on rule [5047065](https://github.com/hivemq/hivemq-community-edition/settings/branch_protection_rules/5047065) to push the version-bump commit. **Always re-enable it** after pushing.
+
+## Releasing
+
+The full CE release runbook lives in the dev handbook:
+https://github.com/hivemq/hivemq-dev-handbook/blob/master/_kanban/documentation/templates/ce-release.md
+
+Key steps that span multiple repos:
+
+- This repo: version bump in `gradle.properties`, `gradle/libs.versions.toml` (`hivemq-extensionSdk`), `README.adoc`; run `./gradlew updateThirdPartyLicenses`; commit `Version to YYYY.i`; tag `YYYY.i`; create GitHub release; approve publish workflow.
+- `hivemq-website-cms`: add blogpost under `src/lib/cms/releases/hivemq-ce/`, then promote `develop` → `staging` → `production`.
+- After tagging, **verify** the JitPack build at `https://jitpack.io/#hivemq/hivemq-community-edition/<version>` actually succeeded — a stale `jitpack.yml` will not be caught by the GitHub Actions publish workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,28 +30,6 @@ Run this locally before cutting a release tag:
 
 That command is what jitpack runs. If it fails locally, jitpack will fail too — and so will Maven Central publishing on release. The `jitpack-smoke` CI job runs the same command on every PR that touches build files.
 
-## Common foot-guns (real bugs we have hit)
+## Common foot-guns
 
-1. **`jitpack.yml` drift.** When `hivemq-extension-sdk` was removed as an included build (#632) and the toolchain rose to JDK 21 (#635), `jitpack.yml` kept its `openjdk11` + included-build `before_install`. JitPack 2026.5 failed silently and the cached failure had to be deleted by hand in the JitPack UI. Touch `settings.gradle.kts` or change the Java toolchain → update `jitpack.yml` in the same PR.
-2. **Shadow plugin 9.x publication variants.** Shadow 9.x adds `shadowRuntimeElements` to the `java` component lazily. The old top-level idiom
-   ```kotlin
-   javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements.get()) { skip() }
-   ```
-   throws `Variant for configuration 'shadowRuntimeElements' does not exist in component 'java'`. Use the plugin-level toggle (Shadow 9.1.0+, PR [GradleUp/shadow#1662](https://github.com/GradleUp/shadow/pull/1662)):
-   ```kotlin
-   shadow {
-       addShadowVariantIntoJavaComponent = false
-   }
-   ```
-3. **Branch protection on `master`.** The release flow requires temporarily disabling "Do not allow bypassing the above settings" on rule [5047065](https://github.com/hivemq/hivemq-community-edition/settings/branch_protection_rules/5047065) to push the version-bump commit. **Always re-enable it** after pushing.
-
-## Releasing
-
-The full CE release runbook lives in the dev handbook:
-https://github.com/hivemq/hivemq-dev-handbook/blob/master/_kanban/documentation/templates/ce-release.md
-
-Key steps that span multiple repos:
-
-- This repo: version bump in `gradle.properties`, `gradle/libs.versions.toml` (`hivemq-extensionSdk`), `README.adoc`; run `./gradlew updateThirdPartyLicenses`; commit `Version to YYYY.i`; tag `YYYY.i`; create GitHub release; approve publish workflow.
-- `hivemq-website-cms`: add blogpost under `src/lib/cms/releases/hivemq-ce/`, then promote `develop` → `staging` → `production`.
-- After tagging, **verify** the JitPack build at `https://jitpack.io/#hivemq/hivemq-community-edition/<version>` actually succeeded — a stale `jitpack.yml` will not be caught by the GitHub Actions publish workflow.
+1. **`jitpack.yml` drift.** `jitpack.yml` has its own `jdk:` and `install:` directives that are independent of the GitHub Actions workflows. When `hivemq-extension-sdk` was removed as an included build and the toolchain rose to JDK 21, `jitpack.yml` had to be updated separately. Touch `settings.gradle.kts` or change the Java toolchain → update `jitpack.yml` in the same PR.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` at repo root with a single foot-gun reminder: `jitpack.yml` has its own jdk/install config that lives outside the GitHub Actions workflows and can silently drift when the build setup changes.
- Add `.github/workflows/jitpack-smoke.yml` that runs `./gradlew publishToMavenLocal -PsigningDisabled=true` on JDK 21 — the exact command JitPack runs — so a broken build is caught on PR rather than at release time.

## Test plan
- [ ] `jitpack-smoke` job runs on this PR and passes
- [ ] PR-path trigger fires for changes to `jitpack.yml`, `build.gradle.kts`, `gradle/**`, `settings.gradle.kts`
- [ ] Run does not fire on unrelated docs/source-only changes