### PR TITLE
feature: support try_private flag in MQTT connect decoder

### DIFF
--- a/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
@@ -90,7 +90,8 @@ public class MqttConnectDecoder {
                     return null;
                 }
                 final ByteBuf protocolVersionBuf = buf.slice(buf.readerIndex() + 6, 1);
-                final byte versionByte = protocolVersionBuf.readByte();
+                final byte rawVersionByte = protocolVersionBuf.readByte();
+                final int versionByte = normalizeProtocolVersionByte(rawVersionByte);
                 if (versionByte == 5) {
                     protocolVersion = ProtocolVersion.MQTTv5;
                 } else if (versionByte == 4) {
@@ -135,5 +136,24 @@ public class MqttConnectDecoder {
                 "Sent CONNECT with an invalid protocol version",
                 Mqtt5ConnAckReasonCode.UNSUPPORTED_PROTOCOL_VERSION,
                 ReasonStrings.CONNACK_UNSUPPORTED_PROTOCOL_VERSION);
+    }
+
+    /**
+     * Normalizes the raw MQTT protocol version byte.
+     * <p>
+     * When Mosquitto connects as a bridge with try_private enabled, it sets the MSB (0x80)
+     * of the protocol level byte (e.g. 0x04 becomes 0x84 / -124 in signed byte arithmetic).
+     *
+     * @param rawByte the raw protocol version byte from the payload
+     * @return normalized integer representation of the protocol version
+     */
+    private static int normalizeProtocolVersionByte(final byte rawByte) {
+        // Early return if MSB / first bit (0x80) is not set
+        if ((rawByte & 0x80) == 0) {
+            return rawByte;
+        }
+
+        // Mask out the Mosquitto try_private bit
+        return rawByte & 0x7F;
     }
 }

--- a/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
@@ -141,11 +141,11 @@ public class MqttConnectDecoder {
     /**
      * Normalizes the raw MQTT protocol version byte.
      * <p>
-     * When Mosquitto connects as a bridge with try_private enabled, it sets the Most Significant Bit (MSB) (0x80)
-     * of the protocol level byte (e.g. 0x04 becomes 0x84 / -124 in signed byte arithmetic).
+     * When Mosquitto connects as a bridge with try_private enabled, it sets the Most Significant Bit (MSB) (0x80) of
+     * the protocol level byte (e.g. 0x04 becomes 0x84 / -124 in signed byte arithmetic).
      *
-     * @param rawByte the raw protocol version byte from the payload
-     * @return normalized integer representation of the protocol version
+     * @param  rawByte the raw protocol version byte from the payload
+     * @return         normalized integer representation of the protocol version
      */
     private static int normalizeProtocolVersionByte(final byte rawByte) {
         // Early return if MSB / first bit (0x80) is not set

--- a/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/MqttConnectDecoder.java
@@ -141,7 +141,7 @@ public class MqttConnectDecoder {
     /**
      * Normalizes the raw MQTT protocol version byte.
      * <p>
-     * When Mosquitto connects as a bridge with try_private enabled, it sets the MSB (0x80)
+     * When Mosquitto connects as a bridge with try_private enabled, it sets the Most Significant Bit (MSB) (0x80)
      * of the protocol level byte (e.g. 0x04 becomes 0x84 / -124 in signed byte arithmetic).
      *
      * @param rawByte the raw protocol version byte from the payload

--- a/src/test/java/com/hivemq/codec/decoder/MqttConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/MqttConnectDecoderTest.java
@@ -21,6 +21,7 @@ import com.hivemq.configuration.HivemqId;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.mqtt.handler.connack.MqttConnacker;
 import com.hivemq.mqtt.message.ProtocolVersion;
+import com.hivemq.mqtt.message.connect.CONNECT;
 import com.hivemq.mqtt.message.reason.Mqtt5ConnAckReasonCode;
 import com.hivemq.util.ClientIds;
 import io.netty.buffer.ByteBuf;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class MqttConnectDecoderTest {
 
@@ -135,6 +137,41 @@ public class MqttConnectDecoderTest {
     public void decode_whenInvalidLength_thenConnectionIsClosedAndCONNACKIsReceived() {
         final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{0, 5, 'M', 'Q', 'T', 'T', 7});
         decoder.decode(clientConnection, buf, FIXED_HEADER);
+        verify(mqttConnacker).connackError(eq(channel),
+                anyString(),
+                anyString(),
+                eq(Mqtt5ConnAckReasonCode.UNSUPPORTED_PROTOCOL_VERSION),
+                anyString());
+    }
+
+   @Test
+    public void decode_whenMosquittoTryPrivateProtocolVersion_thenSuccessfullyDecodedAsMqtt311() {
+        final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{
+                0, 4, 'M', 'Q', 'T', 'T',
+                (byte) 0x84, // Mosquitto try_private protocol level (0x84)
+                2,          // Clean session
+                0, 60,      // Keep alive (60s)
+                0, 6, 'b', 'r', 'i', 'd', 'g', 'e' // Client ID
+        });
+
+        final CONNECT connect = decoder.decode(clientConnection, buf, FIXED_HEADER);
+        assertNotNull(connect);
+        assertSame(ProtocolVersion.MQTTv3_1_1, connect.getProtocolVersion());
+        verifyNoMoreInteractions(mqttConnacker);
+    }
+
+    @Test
+    public void decode_whenInvalidProtocolVersion_thenConnectionIsClosedAndCONNACKIsReceived() {
+        final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{
+                0, 4, 'M', 'Q', 'T', 'T',
+                2,          // Invalid protocol version
+                2,          // Clean session
+                0, 60,      // Keep alive (60s)
+                0, 6, 'b', 'r', 'i', 'd', 'g', 'e' // Client ID
+        });
+
+        decoder.decode(clientConnection, buf, FIXED_HEADER);
+
         verify(mqttConnacker).connackError(eq(channel),
                 anyString(),
                 anyString(),

--- a/src/test/java/com/hivemq/codec/decoder/MqttConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/MqttConnectDecoderTest.java
@@ -144,13 +144,11 @@ public class MqttConnectDecoderTest {
                 anyString());
     }
 
-   @Test
+    @Test
     public void decode_whenMosquittoTryPrivateProtocolVersion_thenSuccessfullyDecodedAsMqtt311() {
-        final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{
-                0, 4, 'M', 'Q', 'T', 'T',
-                (byte) 0x84, // Mosquitto try_private protocol level (0x84) (try_private = true)
-                2,          // Clean session
-                0, 60,      // Keep alive (60s)
+        final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{0, 4, 'M', 'Q', 'T', 'T', (byte) 0x84, // Mosquitto try_private protocol level (0x84) (try_private = true)
+                2, // Clean session
+                0, 60, // Keep alive (60s)
                 0, 6, 'b', 'r', 'i', 'd', 'g', 'e' // Client ID
         });
 
@@ -162,18 +160,16 @@ public class MqttConnectDecoderTest {
 
     @Test
     public void decode_whenStandardProtocolVersion_thenSuccessfullyDecodedAsMqtt311() {
-    final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{
-            0, 4, 'M', 'Q', 'T', 'T',
-            (byte) 0x04, // Standard MQTT 3.1.1 protocol level (try_private = false)
-            2,          // Clean session
-            0, 60,      // Keep alive (60s)
-            0, 6, 'b', 'r', 'i', 'd', 'g', 'e' // Client ID
-    });
+        final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{0, 4, 'M', 'Q', 'T', 'T', (byte) 0x04, // Standard MQTT 3.1.1 protocol level (try_private = false)
+                2, // Clean session
+                0, 60, // Keep alive (60s)
+                0, 6, 'b', 'r', 'i', 'd', 'g', 'e' // Client ID
+        });
 
-    final CONNECT connect = decoder.decode(clientConnection, buf, FIXED_HEADER);
-    assertNotNull(connect);
-    assertSame(ProtocolVersion.MQTTv3_1_1, connect.getProtocolVersion());
-    verifyNoMoreInteractions(mqttConnacker);
-}
+        final CONNECT connect = decoder.decode(clientConnection, buf, FIXED_HEADER);
+        assertNotNull(connect);
+        assertSame(ProtocolVersion.MQTTv3_1_1, connect.getProtocolVersion());
+        verifyNoMoreInteractions(mqttConnacker);
+    }
 
 }

--- a/src/test/java/com/hivemq/codec/decoder/MqttConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/MqttConnectDecoderTest.java
@@ -148,7 +148,7 @@ public class MqttConnectDecoderTest {
     public void decode_whenMosquittoTryPrivateProtocolVersion_thenSuccessfullyDecodedAsMqtt311() {
         final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{
                 0, 4, 'M', 'Q', 'T', 'T',
-                (byte) 0x84, // Mosquitto try_private protocol level (0x84)
+                (byte) 0x84, // Mosquitto try_private protocol level (0x84) (try_private = true)
                 2,          // Clean session
                 0, 60,      // Keep alive (60s)
                 0, 6, 'b', 'r', 'i', 'd', 'g', 'e' // Client ID
@@ -161,21 +161,19 @@ public class MqttConnectDecoderTest {
     }
 
     @Test
-    public void decode_whenInvalidProtocolVersion_thenConnectionIsClosedAndCONNACKIsReceived() {
-        final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{
-                0, 4, 'M', 'Q', 'T', 'T',
-                2,          // Invalid protocol version
-                2,          // Clean session
-                0, 60,      // Keep alive (60s)
-                0, 6, 'b', 'r', 'i', 'd', 'g', 'e' // Client ID
-        });
+    public void decode_whenStandardProtocolVersion_thenSuccessfullyDecodedAsMqtt311() {
+    final ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{
+            0, 4, 'M', 'Q', 'T', 'T',
+            (byte) 0x04, // Standard MQTT 3.1.1 protocol level (try_private = false)
+            2,          // Clean session
+            0, 60,      // Keep alive (60s)
+            0, 6, 'b', 'r', 'i', 'd', 'g', 'e' // Client ID
+    });
 
-        decoder.decode(clientConnection, buf, FIXED_HEADER);
+    final CONNECT connect = decoder.decode(clientConnection, buf, FIXED_HEADER);
+    assertNotNull(connect);
+    assertSame(ProtocolVersion.MQTTv3_1_1, connect.getProtocolVersion());
+    verifyNoMoreInteractions(mqttConnacker);
+}
 
-        verify(mqttConnacker).connackError(eq(channel),
-                anyString(),
-                anyString(),
-                eq(Mqtt5ConnAckReasonCode.UNSUPPORTED_PROTOCOL_VERSION),
-                anyString());
-    }
 }


### PR DESCRIPTION
## Summary
This PR adds support for accepting Mosquitto bridge `CONNECT` packets that set the `try_private` protocol version flag (`0x84`). When Mosquitto acts as a bridge, it sets the high bit on the protocol level byte (`0x84` instead of `0x04`). This in turn causes HiveMQ to break issuing the log `connected with an invalid protocol version`.

This change normalises the protocol version byte during connection decoding so that standard MQTT 3.1.1 handling applies seamlessly.

## Changes Made
- **Protocol Normalisation**: Updated `MqttConnectDecoder.normalizeProtocolVersionByte(...)` to clear the Mosquitto `try_private` flag (`0x80`), mapping raw protocol level `0x84` to standard MQTT 3.1.1 (`4`).
- **Unit Tests**: Added unit tests in `MqttConnectDecoderTest` asserting that packets containing `0x84` decode as `ProtocolVersion.MQTTv3_1_1` without triggering connection rejection errors via `mqttConnacker`.

---

## How to Test

### 1. Run Unit Tests
Run the `MqttConnectDecoderTest` suite to verify protocol version decoding logic:
```bash
./gradlew test --tests "com.hivemq.bootstrap.decoder.MqttConnectDecoderTest"

### 2. Build `hivemq-ce:local` locally

```bash
#!/usr/bin/env bash
set -e

IMAGE_NAME="hivemq-ce:local"
DOCKERFILE="Dockerfile.local"

echo "=========================================="
echo " 1. Building HiveMQ CE Zip via Gradle..."
echo "=========================================="
./gradlew hivemqZip -x test

echo "=========================================="
echo " 2. Updating $DOCKERFILE..."
echo "=========================================="
cat << 'EOF' > "$DOCKERFILE"
FROM eclipse-temurin:21-jre

ENV HIVEMQ_HOME=/opt/hivemq
WORKDIR $HIVEMQ_HOME

# Install unzip
RUN apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*

COPY build/distributions/*.zip /tmp/hivemq.zip

# Extract archive, strip CRLF line endings, and set executable permissions
RUN mkdir -p /tmp/unzipped \
    && unzip /tmp/hivemq.zip -d /tmp/unzipped \
    && cp -R /tmp/unzipped/*/* $HIVEMQ_HOME/ \
    && rm -rf /tmp/* \
    && sed -i 's/\r$//' $HIVEMQ_HOME/bin/*.sh \
    && chmod +x $HIVEMQ_HOME/bin/*.sh \
    && groupadd -r hivemq && useradd -r -g hivemq hivemq \
    && chown -R hivemq:hivemq $HIVEMQ_HOME

USER hivemq
EXPOSE 1883 8080

ENTRYPOINT ["/opt/hivemq/bin/run.sh"]
EOF

echo "=========================================="
echo " 3. Building Local Docker Image ($IMAGE_NAME)..."
echo "=========================================="
docker build -f "$DOCKERFILE" -t "$IMAGE_NAME" .

echo "=========================================="
echo " SUCCESS!"
echo " Image built: $IMAGE_NAME"
echo " Run with: docker compose up -d"
echo "=========================================="
```

### 3. Set up docker-compose with mosquitto.conf

`docker-compose.yml`:

```yml
services:
  hivemq:
    image: hivemq-ce:local
    pull_policy: never
    container_name: hivemq-ce
    ports:
      - "1883:1883"   # Central MQTT Broker Port
    environment:
      - HIVEMQ_LOG_LEVEL=DEBUG

  mosquitto:
    image: eclipse-mosquitto:latest
    container_name: mosquitto-bridge
    ports:
      - "1884:1883"   # Local Edge Broker Port
    volumes:
      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
    depends_on:
      - hivemq
```

`mosquitto.conf`:

```conf
listener 1883
allow_anonymous true

# HiveMQ Bridge Definition
connection hivemq_bridge
address hivemq:1883
topic test/# both 0

# Prevent 0x84 bit-flip protocol version error in HiveMQ's MqttConnectDecoder
try_private true

# Prevent HiveMQ from disconnecting Mosquitto due to $SYS topic publishes
notifications false
```

### 4. Test to check if no unsupported versions are in place

```sh
docker-compose down && docker-compose up
# check no "unsupported versions" log
# checking BAU on separate terminal windows (optional)
mqttx sub -h 127.0.0.1 -p 1883 -t "test/demo"
mqttx pub -h 127.0.0.1 -p 1883 -t "test/demo" -m "Hello Bridge"
```