### PR TITLE
fix: reject CONNECT with unexpected trailing data ([MQTT-3.1.2-16] [MQTT-3.1.2-18])

### DIFF
--- a/src/main/java/com/hivemq/codec/decoder/mqtt5/Mqtt5ConnectDecoder.java
+++ b/src/main/java/com/hivemq/codec/decoder/mqtt5/Mqtt5ConnectDecoder.java
@@ -181,6 +181,15 @@ public class Mqtt5ConnectDecoder extends AbstractMqttConnectDecoder {
         if (!decodeAndValidatePassword(clientConnectionContext, buf, connectBuilder, passwordRequired)) {
             return null;
         }
+        // [MQTT-3.1.2-16],[MQTT-3.1.2-18]: Reject CONNECT with unexpected trailing data
+        if (buf.isReadable()) {
+            mqttConnacker.connackError(clientConnectionContext.getChannel(),
+                    "A client (IP: {}) sent a CONNECT with unexpected trailing data.",
+                    "Sent CONNECT with unexpected trailing data",
+                    Mqtt5ConnAckReasonCode.MALFORMED_PACKET,
+                    ReasonStrings.CONNACK_MALFORMED_PACKET_FIXED_HEADER);
+            return null;
+        }
         clientConnectionContext.setCleanStart(cleanStart);
         return connectBuilder.withClientIdentifier(clientId)
                 .withCleanStart(cleanStart)

--- a/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5ConnectDecoderTest.java
+++ b/src/test/java/com/hivemq/codec/decoder/mqtt5/Mqtt5ConnectDecoderTest.java
@@ -3012,4 +3012,90 @@ public class Mqtt5ConnectDecoderTest extends AbstractMqtt5DecoderTest {
         assertNotNull(publishInternal);
         return publishInternal;
     }
+
+    // --- [MQTT-3.1.2-16],[MQTT-3.1.2-18]: CONNECT with trailing data after payload must be rejected ---
+
+    @Test
+    public void decode_connect_with_trailing_data_after_payload() {
+        final byte[] encoded = {
+                // fixed header
+                0b0001_0000,
+                // remaining length: 17 (normal) + 2 (trailing) = 19
+                19,
+                // variable header
+                // protocol name
+                0, 4, 'M', 'Q', 'T', 'T',
+                // protocol version 5
+                5,
+                // connect flags (clean start)
+                0b0000_0010,
+                // keep alive
+                0, 30,
+                // properties length
+                0,
+                // payload: client identifier
+                0, 4, 't', 'e', 's', 't',
+                // trailing data (should not be here)
+                0x01, 0x02,
+        };
+        decodeNullExpected(encoded);
+    }
+
+    @Test
+    public void decode_connect_with_single_trailing_byte() {
+        final byte[] encoded = {
+                // fixed header
+                0b0001_0000,
+                // remaining length: 17 (normal) + 1 (trailing) = 18
+                18,
+                // variable header
+                // protocol name
+                0, 4, 'M', 'Q', 'T', 'T',
+                // protocol version 5
+                5,
+                // connect flags (clean start)
+                0b0000_0010,
+                // keep alive
+                0, 30,
+                // properties length
+                0,
+                // payload: client identifier
+                0, 4, 't', 'e', 's', 't',
+                // trailing byte
+                0x00,
+        };
+        decodeNullExpected(encoded);
+    }
+
+    @Test
+    public void decode_connect_with_trailing_data_and_will() {
+        final byte[] encoded = {
+                // fixed header
+                0b0001_0000,
+                // remaining length: 30 (with will) + 2 (trailing) = 32
+                32,
+                // variable header
+                // protocol name
+                0, 4, 'M', 'Q', 'T', 'T',
+                // protocol version 5
+                5,
+                // connect flags: Will Flag + Will QoS 1 + Clean Start
+                0b0000_1110,
+                // keep alive
+                0, 30,
+                // properties length
+                0,
+                // payload: client identifier
+                0, 4, 't', 'e', 's', 't',
+                // will properties length
+                0,
+                // will topic
+                0, 5, 'w', 'i', 'l', 'l', '/',
+                // will payload
+                0, 3, 'm', 's', 'g',
+                // trailing data
+                (byte) 0xFF, (byte) 0xFE,
+        };
+        decodeNullExpected(encoded);
+    }
 }


### PR DESCRIPTION
## Summary

Per **[MQTT-3.1.2-16]** and **[MQTT-3.1.2-18]**, if User Name/Password Flags are set to 0, the corresponding fields MUST NOT be present. More broadly, per **[MQTT-3.2.2-1]**, the Server MUST validate CONNECT packets and reject malformed ones.

Currently, `Mqtt5ConnectDecoder` does not check for trailing data after parsing all CONNECT fields. Extra bytes after the payload are silently ignored instead of being rejected.

Closes #750

## Changes Made

- **`Mqtt5ConnectDecoder.decodeConnect()`**: Added trailing data check (L185-189) after parsing all CONNECT fields — if `buf.isReadable()`, responds with CONNACK Reason Code `0x90` (Malformed Packet) and closes the connection
- **Unit Tests**: Added 3 tests covering 2 trailing bytes, 1 trailing byte (boundary), and trailing data after Will message

## How to Test

```bash
./gradlew test --tests "com.hivemq.codec.decoder.mqtt5.Mqtt5ConnectDecoderTest"
```